### PR TITLE
fix(spawn): escape backticks in AppleScript heredoc comments

### DIFF
--- a/hooks/claude-identity/install-wrappers.sh
+++ b/hooks/claude-identity/install-wrappers.sh
@@ -409,9 +409,9 @@ $activate_clause
 delay 1.2
 tell application "System Events"
   $tell_process_clause
-    -- Robustness: force the IDE frontmost before any keystroke. `activate` alone can
+    -- Robustness: force the IDE frontmost before any keystroke. \`activate\` alone can
     -- lose the race when another window/app holds focus at spawn time (e.g. operator
-    -- typing in a separate terminal) — keystrokes then leak. `set frontmost to true`
+    -- typing in a separate terminal) — keystrokes then leak. \`set frontmost to true\`
     -- is the forceful guarantee; the extra settle lets the focus change land.
     set frontmost to true
     delay 0.5


### PR DESCRIPTION
## Problem class

Any operator who runs `spawn <name>` while an IDE (Antigravity / VS Code / Cursor) is running hits this. The spawn wrapper takes its IDE path and builds an AppleScript via an **unquoted** heredoc (`cat > "$applescript_file" <<APPLESCRIPT`) — unquoted by necessity, so `$activate_clause`, `$tell_process_clause`, and `$name` expand.

Two comment lines inside that heredoc contain backtick-quoted words:

```
-- ... force the IDE frontmost before any keystroke. `activate` alone can
-- ... keystrokes then leak. `set frontmost to true`
```

Because the heredoc is unquoted, zsh evaluates those backticks as **command substitution** at spawn time:

- `` `activate` `` → runs `activate` → `spawn: command not found: activate` printed to stderr
- `` `set frontmost to true` `` → runs `set frontmost to true`
- both words are stripped from the generated AppleScript comments

Cosmetic — the session still launches — but every IDE-path spawn prints an error and produces mangled AppleScript comments.

## Repro

With Antigravity / VS Code / Cursor running:

```
$ spawn worker
spawn:108: command not found: activate
```

Confirmed via `setopt xtrace`: the heredoc body lines `activate` and `set frontmost to true` execute as commands instead of being written to the file.

## Fix

Escape the two backtick pairs (`` \` ``) so they're literal, keeping the heredoc unquoted so the variables still expand. Two-line change in `hooks/claude-identity/install-wrappers.sh` (the canonical source that writes the wrapper into the operator's shell rc via the `<< 'WRAPPER'` block).

## Testing

- `setopt xtrace` trace **before**: heredoc body lines `activate` / `set frontmost to true` executed as commands.
- **After** the fix: sourced the regenerated wrapper and ran spawn (with `osascript` stubbed so no window opens) — no `command not found`, and the generated AppleScript keeps the backticks literal in the comments.
- Platform: macOS, zsh 5.9.

## Suggested CHANGELOG entry

Left for the maintainer to place with the canonical merge hash (since `hash:` must resolve in canonical git):

- **State:** `spawn` prints `command not found: activate` on every IDE-path spawn (IDE running).
- **Ask:** none — mechanical.
- **Act:** re-run `bash hooks/claude-identity/install-wrappers.sh` to regenerate the wrapper, then `source` your shell rc / open a new terminal. _(restart step — last)_

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHC1m1Hqmj2PAzfiNjiGWc
