### PR TITLE
fix(hooks): empty-array expansion aborts under bash 3.2 (macOS system bash)

### DIFF
--- a/hooks/aios-commit
+++ b/hooks/aios-commit
@@ -118,7 +118,10 @@ if [ "${#PARENTS[@]}" -gt 0 ] && GIT_INDEX_FILE="$TMPIDX" git diff-index --quiet
 fi
 
 TREE=$(GIT_INDEX_FILE="$TMPIDX" git write-tree) || die "write-tree failed"
-COMMIT=$(git commit-tree "$TREE" "${PARENTS[@]}" -m "$MSG") || die "commit-tree failed"
+# ${PARENTS[@]+"${PARENTS[@]}"} — PARENTS is EMPTY on a root commit (no HEAD yet), and bash 3.2
+# (the macOS system bash) treats "${arr[@]}" on an empty array as unbound under `set -u` → the
+# very first commit in a fresh repo aborts. The +alternate form is empty-safe on 3.2 and 4+.
+COMMIT=$(git commit-tree "$TREE" ${PARENTS[@]+"${PARENTS[@]}"} -m "$MSG") || die "commit-tree failed"
 git update-ref HEAD "$COMMIT" || die "update-ref failed"
 
 # sync the REAL index for the committed paths only → `git status` shows them clean;

--- a/hooks/aios-note-append
+++ b/hooks/aios-note-append
@@ -55,6 +55,10 @@ else
 fi
 
 # ── commit the note via aios-commit (its own repo-mutex; lock order note→repo, no deadlock) ──
-"$AC" -m "$MSG" "${NOPUSH[@]}" -- "$NOTE" || die "aios-commit failed"
+# ${arr[@]+"${arr[@]}"} — bash 3.2 (the macOS system bash) treats "${arr[@]}" on an EMPTY
+# array as an unbound variable under `set -u`, so a plain expansion aborts HERE: after the
+# note was already written, before it was committed. The +alternate form is the portable
+# empty-safe expansion (no-op on bash 4+).
+"$AC" -m "$MSG" ${NOPUSH[@]+"${NOPUSH[@]}"} -- "$NOTE" || die "aios-commit failed"
 release; trap - EXIT
 exit 0


### PR DESCRIPTION
## The problem-class

Two canonical hooks expand a possibly-empty array as `"${arr[@]}"` while running under `set -u`. On **bash 3.2 — the bash that ships with macOS**, and what `#!/usr/bin/env bash` resolves to on a stock Mac — that is treated as an *unbound variable*, so the script aborts.

Both failures are **mid-operation**, which is what makes them costly rather than merely noisy:

| # | Hook | Empty when | Consequence |
|---|---|---|---|
| 1 | `aios-note-append:58` — `"${NOPUSH[@]}"` | `--no-push` not passed (the normal path) | Aborts **on** the `aios-commit` line — *after* the block was written into the note, *before* it was committed. `/close-session` never commits its own capture block on any Mac using the system bash. Worse: the natural reaction — re-run the command — **duplicates the block**, because the write already happened. |
| 2 | `aios-commit:121` — `"${PARENTS[@]}"` | Root commit (no `HEAD` yet) | The very **first commit in a fresh repo** fails: `PARENTS[@]: unbound variable` → `commit-tree failed`. |

Found #1 in a real `/close-session` (the block landed in the daily note, uncommitted, with a bare `NOPUSH[@]: unbound variable`); found #2 by grepping the same pattern across `hooks/` and reproducing it.

## The fix

The portable empty-safe form `${arr[@]+"${arr[@]}"}` in both places — no-op on bash 4+, correct on 3.2. Two lines of code; nothing else changes.

**Deliberately NOT touched.** These look like the same pattern but are already guarded by a length check, so widening the diff would be speculative:

- `aios-commit:94,108,126` (`"${PATHS[@]}"`) — guarded by `[ ${#PATHS[@]} -gt 0 ] || die` at `:47` and the `-eq 0` exit at `:88`.
- `git/secret-scan.sh:29` (`"${files[@]}"`) — guarded by `[ ${#files[@]} -eq 0 ] && exit 0` immediately above.

## Testing

Live on **bash 3.2.57 (macOS, arm64)**, reproducing each failure against the *unpatched* script first, then confirming the patched path, in throwaway repos:

- [x] root commit in a fresh repo → succeeds (was: aborted)
- [x] second commit → still succeeds (no regression)
- [x] no-op guard with unchanged paths → still reports nothing to commit
- [x] `note-append` without `--no-push` → block inserted **and** committed (was: inserted, not committed)
- [x] `note-append` with `--no-push` → unchanged behavior
- [x] concurrent-append ordering preserved (blocks land in turn, before the `## Close of Day` marker); no orphaned `.aios-lock` or `.aiostmp` left behind

Carries zero operator data — authored in a clean clone of this repo, not in a vault.

## The upstream question

The fix itself seems uncontroversial. The open call is whether the framework wants a **guard against the whole class** rather than two point-fixes: either a `shellcheck` run in CI (SC2068-adjacent; it would have caught both), or a smoke test that executes the hooks under `/bin/bash` 3.2 explicitly, since bash 4+ silently hides this entire family of bugs. Happy to add either — didn't want to bundle a CI decision into a two-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)