### PR TITLE
docs(update): prescribe shell-safe iteration — `for f in $LIST` silently creates newline-named dirs under zsh

### DIFF
--- a/plugins/aios/commands/update.md
+++ b/plugins/aios/commands/update.md
@@ -254,6 +254,25 @@ Report to operator at the end: *"`/aios:update` self-updated and re-ran automati
 
 ### 3. Apply ALL Tier 1 changes (auto-apply)
 
+> **Iterate the file list SAFELY — the session's shell may be zsh, and `for f in $LIST` does not word-split there.** The changed-file list comes from `git diff --name-only` (Step 2), i.e. **newline-separated paths**. On macOS the session's shell is **zsh**, which — unlike bash — performs **no word splitting on unquoted parameter expansion**. So the intuitive `for f in $FILES` hands the *entire list* to the body as ONE string, and the `mkdir -p "$(dirname "$f")"` below then creates a single directory whose name contains literal newlines:
+>
+> ```
+> 'CHANGELOG.md\nCLAUDE.md\nhooks'      # ← one directory, in the vault root
+> ```
+>
+> The failure is **silent and cumulative**: the stray directories are empty, break nothing, sit in the vault root, and are invisible to Step 6.5 — the reconcile drops every vault-side `Only in` line by design, so its own backstop cannot see them. Two such directories were found in a real vault, their names spelling out the changed-file lists of *earlier* syncs.
+>
+> **Use this loop (portable across bash and zsh):**
+>
+> ```bash
+> printf '%s\n' "${FILES[@]}" | while IFS= read -r f; do
+>   [ -z "$f" ] && continue
+>   # … per-file logic below …
+> done
+> ```
+>
+> Never `for f in $(git diff --name-only …)` and never `for f in $UNQUOTED_LIST`. The same rule applies anywhere this command turns a path list into a loop.
+
 For each changed Tier 1 file:
 
 1. **Diff local vs upstream HEAD.** If byte-identical, skip (no work needed — operator already has this version somehow).
@@ -371,6 +390,14 @@ VAULT="$HOME/aios"; CLONE="/tmp/aios-update-check"
 # appear as vault-side extras, never as Files-differ).
 # Whatever remains = genuine framework drift: differing framework files +
 # framework files/dirs present in the clone but missing from the vault.
+#
+# COROLLARY (why Step 3 has a shell-safety note): dropping every vault-side
+# "Only in" line is CORRECT — operator extras are never framework-drift-to-pull
+# — but it also means this reconcile can NEVER see junk the sync itself created
+# in the vault (e.g. a stray newline-named directory from a non-word-splitting
+# `for f in $LIST`). Malformed output of this command is structurally invisible
+# to its own backstop, so that class must be PREVENTED at the write site, not
+# detected here. See the iteration note at the top of Step 3.
 ```
 
 For each genuine framework drift surfaced (a Tier-1 file that **differs**, or a bundled file/dir present in the clone but **missing** from the vault — i.e. a `Files … differ` line or a clone-side `Only in /tmp/aios-update-check/…` line):


### PR DESCRIPTION
## The bug

Step 3 says *"For each changed Tier 1 file:"* and leaves the **how** to the session. The list it iterates comes from `git diff --name-only` (Step 2) — **newline-separated paths** — and on macOS the session's shell is **zsh**, which performs **no word splitting on unquoted parameter expansion**.

So the intuitive `for f in $FILES` hands the entire list to the body as ONE string, and Step 3's `mkdir -p "$(dirname "$f")"` then creates a single directory whose name contains literal newlines, **in the vault root**:

```
'CHANGELOG.md\nCLAUDE.md\nhooks'
```

## Verified repro

Same script, two shells:

```bash
FILES=$(printf 'CHANGELOG.md\nCLAUDE.md\nhooks/aios-commit\n')
for f in $FILES; do mkdir -p "$(dirname "$f")"; done
```

| Shell | Result |
|---|---|
| bash | creates `hooks` — correct |
| **zsh** | creates `CHANGELOG.md\nCLAUDE.md\nhooks` — junk |

**Not hypothetical.** Two such directories were found sitting in a real vault's root, and their names spell out the changed-file lists of **earlier** syncs — so this has been recurring silently across updates, on at least one operator, for as long as that vault has been syncing under zsh. (Found because a sync hit it again live; the older two were still there, empty, from previous runs.)

## Why prescribe it rather than leave it to the reader

1. **It's silent.** The directories are empty, break nothing, and sit in the vault root where they read as noise rather than damage. Nobody goes looking.
2. **Step 6.5 structurally cannot catch it.** The reconcile drops every vault-side `Only in` line — *correctly*, since operator extras are never framework-drift-to-pull — which means **malformed output of this command is invisible to this command's own backstop**. Prevention at the write site is the only place this can be fixed.

That second point is the interesting one: the backstop and the bug share a blind spot by construction, so no amount of reconcile-hardening would surface it.

## The change

Documentation-only, matching how this command **already** prescribes exact snippets for its other delicate operations (the `.gitignore` merge, the reconcile pipeline): a portable loop, the reason it's needed, and an explicit *never `for f in $(git diff --name-only …)`*.

```bash
printf '%s\n' "${FILES[@]}" | while IFS= read -r f; do
  [ -z "$f" ] && continue
  # … per-file logic …
done
```

Plus a corollary comment at the end of Step 6.5 pointing back to the Step 3 note, so a future reader who asks *"why doesn't the reconcile catch this?"* finds the answer where they'd look for it.

No behavior change to any script; no vault file behaves differently. Carries zero operator data — authored in a clean clone.

## The upstream question

This fixes the instance. The broader question is whether the framework wants a **general shell-assumption note** for command authors — `update.md` is unlikely to be the only command whose snippets assume bash word splitting while the session's actual shell on macOS is zsh. A short "authoring shell-safe snippets" section in `CONTRIBUTING.md` (alongside the *Shell portability* section that the bash-3.2 fix added) would cover the class. Happy to write it; didn't want to bundle a docs-structure decision into a scoped fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)