### PR TITLE
fix(install-wrappers): the Windows installer writes a profile PowerShell can't parse

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -622,3 +622,118 @@ jobs:
       - name: install-wrappers regression under bash 3.2
         # The installer writes to a *stock* Mac's shell rc, which is exactly where 3.2 lives.
         run: /bin/bash tests/install-wrappers.test.sh
+
+  windows_installer:
+    # The Windows installer had NO execution lane. `install-wrappers.ps1` shipped
+    # twice on regex-inspection alone ("regex-verified against the same case matrix
+    # but not execution-verified -- no PowerShell on the authoring machine"), and the
+    # second time it shipped a file that Windows PowerShell 5.1 could not parse at all,
+    # from an installer whose own verification reported four green checks. A content
+    # check cannot catch that; only running it can.
+    name: Windows wrapper installer (Windows PowerShell 5.1)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Confirm the lane really is Windows PowerShell 5.1
+        # Load-bearing: pwsh 7 assumes UTF-8 for BOM-less scripts and would decode
+        # every file here correctly, making this lane prove nothing. 5.1 is the
+        # edition a stock Windows 11 ships, and the only one that reproduces the bug.
+        shell: powershell
+        run: |
+          $PSVersionTable.PSVersion
+          if ($PSVersionTable.PSEdition -ne 'Desktop') {
+            Write-Host "::error::Expected Windows PowerShell (Desktop edition) for this lane."
+            exit 1
+          }
+
+      - name: The hazard is real (negative control)
+        # Proves the invariant this lane guards is not theoretical: a BOM-less .ps1
+        # carrying one em dash inside a string does not parse under 5.1, because the
+        # ANSI decode turns its third byte into U+201D and PowerShell treats curly
+        # quotes as string delimiters. If this control ever stops failing, the
+        # ASCII-only rule below has become vacuous and should be revisited.
+        shell: powershell
+        run: |
+          $f = Join-Path $env:RUNNER_TEMP 'hazard.ps1'
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes("Write-Host `"a `u{2014} b`"`r`n")
+          [System.IO.File]::WriteAllBytes($f, $bytes)   # UTF-8, deliberately no BOM
+          $errs = $null
+          [System.Management.Automation.Language.Parser]::ParseFile($f, [ref]$null, [ref]$errs) | Out-Null
+          if (-not $errs) {
+            Write-Host "::error::A BOM-less em dash parsed cleanly -- the encoding hazard no longer reproduces."
+            exit 1
+          }
+          Write-Host "ok: BOM-less non-ASCII fails to parse, as expected ($($errs.Count) error(s))"
+
+      - name: Every .ps1 is ASCII-only or carries a UTF-8 BOM
+        # The rule install-wrappers.ps1 states in its own header and then stopped
+        # obeying -- 11 em dashes crept in, because nothing enforced it.
+        shell: powershell
+        run: |
+          $bad = @()
+          Get-ChildItem -Recurse -Filter *.ps1 -File | ForEach-Object {
+            $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
+            $hasBom = $bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
+            $nonAscii = ($bytes | Where-Object { $_ -gt 0x7F }).Count
+            if ($nonAscii -gt 0 -and -not $hasBom) {
+              $bad += "$($_.FullName.Replace($PWD.Path + '\','')) ($nonAscii non-ASCII byte(s), no BOM)"
+            }
+          }
+          if ($bad.Count -gt 0) {
+            Write-Host "::error::BOM-less .ps1 files contain non-ASCII -- Windows PowerShell 5.1 will corrupt them at parse time:"
+            $bad | ForEach-Object { Write-Host "  $_" }
+            exit 1
+          }
+          Write-Host "ok: no BOM-less .ps1 carries non-ASCII"
+
+      - name: install-wrappers.ps1 produces a profile that PARSES
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & .\hooks\claude-identity\install-wrappers.ps1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Installer exited $LASTEXITCODE"
+            exit 1
+          }
+          $errs = $null
+          [System.Management.Automation.Language.Parser]::ParseFile($PROFILE, [ref]$null, [ref]$errs) | Out-Null
+          if ($errs) {
+            Write-Host "::error::Installer reported success but the profile does not parse:"
+            $errs | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" }
+            exit 1
+          }
+          Write-Host "ok: profile parses cleanly after install"
+
+      - name: A real shell loads the profile and gets the functions
+        # The parse check above reads the file; this one proves a NEW shell -- the
+        # thing the operator actually opens -- ends up with the wrappers defined.
+        shell: powershell
+        run: |
+          # Single quotes inside the probe on purpose: double quotes are stripped
+          # by the command-line parser on the way into `powershell -Command`, which
+          # turns the string list into bare tokens and fails with MissingArgument.
+          $probe = "foreach (`$f in 'Invoke-ClaudeWithRespawn','spawn','spawn-kill') { if (-not (Get-Command `$f -ErrorAction SilentlyContinue)) { Write-Host ('MISSING ' + `$f); exit 1 } }; Write-Host 'ALL PRESENT'"
+          $out = & powershell -NoLogo -Command $probe 2>&1 | Out-String
+          Write-Host $out.Trim()
+          if ($out -notmatch 'ALL PRESENT') {
+            Write-Host "::error::A fresh Windows PowerShell did not get the wrapper functions from the profile."
+            exit 1
+          }
+
+      - name: Re-running the installer is idempotent and still parses
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & .\hooks\claude-identity\install-wrappers.ps1
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::Second run exited $LASTEXITCODE"; exit 1 }
+          $errs = $null
+          [System.Management.Automation.Language.Parser]::ParseFile($PROFILE, [ref]$null, [ref]$errs) | Out-Null
+          if ($errs) {
+            Write-Host "::error::Profile stopped parsing on the second install -- damage compounds across runs:"
+            $errs | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" }
+            exit 1
+          }
+          $n = (Select-String -Path $PROFILE -Pattern '^function spawn \{').Count
+          if ($n -ne 1) { Write-Host "::error::Expected exactly 1 spawn definition after re-run, found $n"; exit 1 }
+          Write-Host "ok: idempotent, still parses, exactly one spawn definition"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -649,19 +649,19 @@ jobs:
 
       - name: The hazard is real (negative control)
         # Proves the ASCII-only rule below guards something real, so the check is not
-        # decoration. The hazard is a CHAIN of two links, and only one of them is
-        # universal -- so each is asserted on its own terms:
-        #   1. DECODE (codepage-dependent): UTF-8 bytes read under a legacy ANSI
-        #      codepage yield mojibake whose third character is U+201D. Asserted
-        #      against CP1252 EXPLICITLY, because a runner whose ACP is already
-        #      UTF-8 (65001) decodes correctly and does NOT reproduce it -- the
-        #      operator machine that surfaced this bug is es-MX; the runner is not.
-        #   2. PARSE (universal): PowerShell treats a curly quote as a string
-        #      delimiter, so a script carrying one inside a string fails to parse.
-        # Asserting the links separately makes this control deterministic on any
-        # runner, instead of silently depending on the runner sharing the operator's
-        # codepage. If either link stops holding, the ASCII-only rule has gone
-        # vacuous and should be revisited.
+        # decoration. The hazard is a CHAIN of two links, asserted separately so this
+        # control never depends on the runner's environment matching the operator's:
+        #   1. DECODE: UTF-8 bytes read under a legacy ANSI codepage yield mojibake
+        #      whose third character is U+201D. Asserted against CP1252 EXPLICITLY
+        #      rather than through whatever the runner's own ACP happens to be.
+        #      windows-latest is ACP 1252 today, so the end-to-end path DOES
+        #      reproduce here (see the note this step prints) -- but a runner moved
+        #      to UTF-8 (65001) would decode correctly and silently stop exercising
+        #      this link at all, with the lane still green.
+        #   2. PARSE: PowerShell treats a curly quote as a string delimiter, so a
+        #      script carrying one inside a string fails to parse.
+        # If either link stops holding, the ASCII-only rule has gone vacuous and
+        # should be revisited.
         shell: powershell
         run: |
           # Diagnostic, not an assertion: record what this runner actually decodes with.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -648,23 +648,64 @@ jobs:
           }
 
       - name: The hazard is real (negative control)
-        # Proves the invariant this lane guards is not theoretical: a BOM-less .ps1
-        # carrying one em dash inside a string does not parse under 5.1, because the
-        # ANSI decode turns its third byte into U+201D and PowerShell treats curly
-        # quotes as string delimiters. If this control ever stops failing, the
-        # ASCII-only rule below has become vacuous and should be revisited.
+        # Proves the ASCII-only rule below guards something real, so the check is not
+        # decoration. The hazard is a CHAIN of two links, and only one of them is
+        # universal -- so each is asserted on its own terms:
+        #   1. DECODE (codepage-dependent): UTF-8 bytes read under a legacy ANSI
+        #      codepage yield mojibake whose third character is U+201D. Asserted
+        #      against CP1252 EXPLICITLY, because a runner whose ACP is already
+        #      UTF-8 (65001) decodes correctly and does NOT reproduce it -- the
+        #      operator machine that surfaced this bug is es-MX; the runner is not.
+        #   2. PARSE (universal): PowerShell treats a curly quote as a string
+        #      delimiter, so a script carrying one inside a string fails to parse.
+        # Asserting the links separately makes this control deterministic on any
+        # runner, instead of silently depending on the runner sharing the operator's
+        # codepage. If either link stops holding, the ASCII-only rule has gone
+        # vacuous and should be revisited.
         shell: powershell
         run: |
-          $f = Join-Path $env:RUNNER_TEMP 'hazard.ps1'
-          $bytes = [System.Text.Encoding]::UTF8.GetBytes("Write-Host `"a `u{2014} b`"`r`n")
-          [System.IO.File]::WriteAllBytes($f, $bytes)   # UTF-8, deliberately no BOM
+          # Diagnostic, not an assertion: record what this runner actually decodes with.
+          $acp = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage' -Name ACP).ACP
+          Write-Host "runner ANSI codepage (ACP): $acp   PSVersion: $($PSVersionTable.PSVersion)"
+
+          # --- Link 1: UTF-8 em dash bytes, decoded as CP1252, yield U+201D ---
+          # The bytes are written out literally. Do NOT use "`u{2014}" here: that
+          # escape is PowerShell 6+ only, and under 5.1 it degrades to the literal
+          # text "u{2014}", leaving the file pure ASCII. This control did exactly
+          # that and so asserted nothing -- vacuous in the way it exists to prevent.
+          $emdashUtf8 = [byte[]]@(0xE2, 0x80, 0x94)
+          $mojibake = [System.Text.Encoding]::GetEncoding(1252).GetString($emdashUtf8)
+          if ($mojibake.IndexOf([char]0x201D) -lt 0) {
+            Write-Host "::error::UTF-8 em dash decoded as CP1252 no longer yields U+201D (got '$mojibake') -- the mojibake mechanism changed."
+            exit 1
+          }
+          Write-Host "ok: UTF-8 em dash decoded as CP1252 -> '$mojibake' (contains U+201D)"
+
+          # --- Link 2: a curly quote inside a string breaks the parser ---
+          # Written WITH a BOM on purpose: this asserts the PARSER's treatment of the
+          # character, not the decode, so the read must be faithful on any ACP.
+          $f = Join-Path $env:RUNNER_TEMP 'curly.ps1'
+          $utf8Bom = New-Object System.Text.UTF8Encoding($true)
+          [System.IO.File]::WriteAllText($f, "Write-Host `"a $([char]0x201D) b`"`r`n", $utf8Bom)
           $errs = $null
           [System.Management.Automation.Language.Parser]::ParseFile($f, [ref]$null, [ref]$errs) | Out-Null
           if (-not $errs) {
-            Write-Host "::error::A BOM-less em dash parsed cleanly -- the encoding hazard no longer reproduces."
+            Write-Host "::error::A curly quote inside a string parsed cleanly -- PowerShell no longer treats it as a delimiter."
             exit 1
           }
-          Write-Host "ok: BOM-less non-ASCII fails to parse, as expected ($($errs.Count) error(s))"
+          Write-Host "ok: curly quote inside a string fails to parse ($($errs.Count) error(s))"
+
+          # --- Informational: does the end-to-end path reproduce on THIS runner? ---
+          # Deliberately NOT asserted. On a UTF-8-ACP runner it will not, and that is
+          # fine: links 1 and 2 already carry the proof for operators on a legacy ACP.
+          $g = Join-Path $env:RUNNER_TEMP 'hazard.ps1'
+          $pre = [System.Text.Encoding]::UTF8.GetBytes('Write-Host "a ')
+          $post = [System.Text.Encoding]::UTF8.GetBytes(" b`"`r`n")
+          [System.IO.File]::WriteAllBytes($g, ($pre + $emdashUtf8 + $post))
+          $e2 = $null
+          [System.Management.Automation.Language.Parser]::ParseFile($g, [ref]$null, [ref]$e2) | Out-Null
+          if ($e2) { Write-Host "note: BOM-less em dash also fails end-to-end on this runner (ACP $acp)" }
+          else     { Write-Host "note: BOM-less em dash parses on this runner (ACP $acp) -- expected when ACP is UTF-8; links 1+2 carry the proof" }
 
       - name: Every .ps1 is ASCII-only or carries a UTF-8 BOM
         # The rule install-wrappers.ps1 states in its own header and then stopped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,29 @@
 
 ---
 
+## 2026-07-27 — The Windows installer wrote a profile PowerShell can't parse, and called it a success
+
+`hash: (stamped on merge)`
+
+> **What this delivers.** On Windows, `install-wrappers.ps1` has been corrupting the profile it writes. The file is stored **UTF-8 without a BOM** and carries 11 non-ASCII characters — so Windows PowerShell 5.1, which assumes the system ANSI codepage for a BOM-less script, mangles every em dash *while parsing the installer itself*, before a single byte is written. One of those em dashes lives inside a `Write-Host` string; the ANSI decode turns its third byte into `”`, PowerShell treats curly quotes as string delimiters, and the profile stops parsing mid-string. The whole file is then dead at shell startup: `spawn`, `spawn-kill` and the operator's own session shorthand all vanish. The installer's four verification checks passed the entire time, because they `-match` for text rather than asking whether the result is valid PowerShell. The file's own header says *"ASCII-only on purpose"* and explains this exact hazard — nothing enforced it, so it drifted. Reported with a live reproduction in [#8](https://github.com/The-AIOS/aios/issues/8).
+
+**What you can now do:**
+- **Open a new terminal on Windows and actually have `spawn`.** If your profile is currently broken — a wall of `Token 'is' unexpected` / `Missing closing '}'` on startup — re-run `powershell -File ~/aios/hooks/claude-identity/install-wrappers.ps1` and it rewrites the block cleanly. Windows PowerShell 5.1 (the only edition a stock Windows 11 ships) is the affected one; pwsh 7 assumes UTF-8 and was always fine, which is why this survived so long.
+- **Trust "installed successfully" to mean the shell can run it.** The installer now parses the finished profile with `[Parser]::ParseFile` before declaring victory, prints the real parse errors with line numbers when they exist, and **rolls back to the timestamped backup it already writes**. It had everything it needed to catch this; it just never asked. A content check answers *"is the text there"*, never *"can PowerShell run this"* — and this failure class is silent precisely because those two answers diverge.
+- **Stop losing a manual repair to a routine sync.** Because `/aios:update` auto-runs this installer whenever it appears in the diff, a Windows operator who had hand-fixed their profile got it re-broken by the next sync, with no action of their own. That loop is closed.
+- **Get a Windows lane in CI at all.** `install-wrappers.ps1` shipped twice on regex inspection alone — the last entry admits it: *"regex-verified against the same case matrix but not execution-verified — no PowerShell on the authoring machine."* The second of those shipped a file 5.1 cannot parse. There is now a `windows-latest` job that runs the installer end-to-end under 5.1, parse-checks the profile it produced, opens a fresh shell to confirm the functions are really defined, and re-runs it to prove idempotency.
+
+**Component list:** `hooks/claude-identity/install-wrappers.ps1` → ASCII-only restored (11 characters: em dashes → `--`, one `→` → `->`); parse gate + rollback added to the verification block; `-Encoding UTF8` on all three `Get-Content` reads (the profile round-trip, the verification read, and the `USER.md` read in `detect_primary_session`, where an accented session name would otherwise be mangled) · `hooks/inject-datetime.ps1`, `hooks/install-git-hooks.ps1`, `skills/setup.ps1` → same ASCII-only restoration; their non-ASCII sits in comments so it never broke parsing, but the invariant should hold repo-wide rather than per-file · `.github/workflows/validate.yml` → new `windows_installer` job: edition guard (the lane is worthless under pwsh 7), a **negative control** proving a BOM-less em dash genuinely fails to parse under 5.1, the repo-wide ASCII-or-BOM check, the end-to-end install, a fresh-shell function probe, and an idempotency re-run.
+
+**Verification:** executed on Windows 11, Windows PowerShell 5.1.26100.8875, es-MX locale — the edition and codepage that reproduce it. **Before:** the installer prints four green checks and `[ok] Wrappers installed successfully` over a profile with 12 mojibake characters that does not parse. **After:** `profile parses cleanly: 1`, profile is ASCII-only, a fresh `powershell` gets all four functions, a second run leaves exactly one `spawn` definition. **Rollback path tested directly** by re-injecting a single em dash into the fixed installer and running it: the four content checks still pass, the parse gate reports `0`, the real parse errors print with line numbers, the backup is restored, and the profile hash is byte-identical to before the run — exit `1`.
+
+**Action required (CHECK-THEN-ACT, idempotent):**
+1. **Windows only, and only if your profile is broken.** Check first: `powershell -Command "$e=$null; [System.Management.Automation.Language.Parser]::ParseFile($PROFILE,[ref]$null,[ref]$e)|Out-Null; if($e){'BROKEN'}else{'OK'}"`. If it says `OK`, no-op — nothing to do. macOS/Linux → never affected; `install-wrappers.sh` moves bytes through `awk` and `cat >>` without ever decoding them.
+2. **Only if it said `BROKEN`:** `/aios:update` applies the fixed installer and auto-runs it, which repairs the profile in place. If you'd rather not sync yet, run it directly: `powershell -File ~/aios/hooks/claude-identity/install-wrappers.ps1`. Either way the parse gate now refuses to leave you with a broken file.
+3. **Reopen your terminal (last step).** Open shells keep the old profile until they're restarted.
+
+---
+
 ## 2026-07-26 — The fix for the last bug renamed an operator's shell function (uppercase session names)
 
 `hash: 2addb2e`

--- a/hooks/claude-identity/install-wrappers.ps1
+++ b/hooks/claude-identity/install-wrappers.ps1
@@ -47,7 +47,7 @@ function Get-PrimarySessionName {
     if (-not (Test-Path $userMd)) { return 'aios' }
     $inSection = $false
     $parsed = ''
-    foreach ($line in Get-Content $userMd) {
+    foreach ($line in Get-Content $userMd -Encoding UTF8) {
         if ($line -match '^## Identity') { $inSection = $true; continue }
         if ($inSection -and $line -match '^## ') { break }
         # Backtick-OPTIONAL: matches both | `name` | (vault format) and | name |
@@ -113,7 +113,12 @@ Write-Host "[ok] Backup: $BACKUP"
 # ---- Strip old wrapper content ----
 # Two patterns covered: banner-wrapped block (from previous installer runs),
 # and inline function defs (from first-time manual install).
-$content = Get-Content $RC -Raw -ErrorAction SilentlyContinue
+# -Encoding UTF8 pairs with the Set-Content below: we write UTF-8, so we must
+# read UTF-8. Windows PowerShell 5.1 honors a BOM but otherwise assumes the
+# system ANSI codepage, and pwsh 7's -Encoding UTF8 writes NO BOM -- so an
+# install under pwsh followed by one under 5.1 would decode this file wrong
+# and rewrite the damage back to disk, compounding on every run.
+$content = Get-Content $RC -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
 if (-not $content) { $content = '' }
 
 # Strip banner block: # ==== claude-spawn-wrappers ... # ==== END claude-spawn-wrappers
@@ -182,20 +187,20 @@ function Invoke-ClaudeWithRespawn {
     $resumeArgs = @()
     if ($InitialSessionId -eq '--continue') { $resumeArgs = @('--continue') }
     elseif ($InitialSessionId) { $resumeArgs = @('--resume', $InitialSessionId) }
-    # Model selection — AIOS default is 1M-context Opus (see install-wrappers.sh
+    # Model selection -- AIOS default is 1M-context Opus (see install-wrappers.sh
     # comment for the why). Override via $env:CLAUDE_MODEL (Sonnet, 3P, etc.).
     $modelToUse = if ($env:CLAUDE_MODEL) { $env:CLAUDE_MODEL } else { 'claude-opus-4-8[1m]' }
     $modelArgs = @('--model', $modelToUse)
     # Resolve the claude EXECUTABLE explicitly (not via function lookup) to
-    # avoid recursion if the operator NAMES their session "claude" in USER.md —
+    # avoid recursion if the operator NAMES their session "claude" in USER.md --
     # then `function claude { Invoke-ClaudeWithRespawn ... }` is defined and a
     # bare `& claude` would re-resolve to the function. (The default fallback is
-    # now "aios", which never shadows the CLI — see Get-PrimarySessionName;
+    # now "aios", which never shadows the CLI -- see Get-PrimarySessionName;
     # this guard now covers only the explicit "claude" session-name edge case.)
     # Get-Command -CommandType Application forces PATH-binary resolution.
     # Mirrors the `command claude` guard in install-wrappers.sh.
     # CAUTION: npm on Windows installs BOTH claude.cmd AND an extensionless
-    # Unix shim 'claude' into %AppData%\Roaming\npm\ — Get-Command matches
+    # Unix shim 'claude' into %AppData%\Roaming\npm\ -- Get-Command matches
     # both, .Source becomes a 2-element array, and `& $claudeExe` collapses
     # it into one bogus path -> CommandNotFoundException (spawn/zai dead).
     # Resolve deterministically: prefer .cmd, then .exe, then .bat; fall
@@ -291,7 +296,7 @@ function spawn {
         return
     }
     if ($Task -in 'mechanical','judgment') {
-        Write-Host "[spawn] task is the bare word '$Task' — a stale shell likely dropped your real task ('$Task' is a -Tier value, not a task)." -ForegroundColor Yellow
+        Write-Host "[spawn] task is the bare word '$Task' -- a stale shell likely dropped your real task ('$Task' is a -Tier value, not a task)." -ForegroundColor Yellow
         Write-Host "[spawn] Run '. `$PROFILE' (or open a fresh shell), then re-spawn." -ForegroundColor Yellow
         return
     }
@@ -303,7 +308,7 @@ function spawn {
     # AIOS-Glass-made terminal ($env:AIOS_GLASS_TERM). Glass created the terminal natively
     # (e.g. fulfilling a spawn-inbox request), so boot the worker in-place rather than
     # opening a redundant Windows Terminal window. The $env:CLAUDECODE check alone isn't
-    # enough — a Glass terminal inherits it when the IDE was launched from a Claude session.
+    # enough -- a Glass terminal inherits it when the IDE was launched from a Claude session.
     if ((-not $env:CLAUDECODE) -or $env:AIOS_GLASS_TERM) {
         # In-process path: set CLAUDE_MODEL for the call only, then restore (no leak).
         if ($spawnModel) {
@@ -320,10 +325,10 @@ function spawn {
     # Build the script the new shell will run. Pass via -EncodedCommand because
     # wt.exe treats unescaped semicolons as tab separators -- a -Command string
     # with multiple statements would be split across phantom tabs.
-    # Open the SAME PowerShell edition the wrapper was installed under — not
+    # Open the SAME PowerShell edition the wrapper was installed under -- not
     # just "pwsh if it exists". The wrapper lives in this edition's $PROFILE;
     # opening the other edition would dot-source a different (wrapper-less)
-    # profile → Invoke-ClaudeWithRespawn: command not found. Match the running
+    # profile -> Invoke-ClaudeWithRespawn: command not found. Match the running
     # edition (Core = pwsh, Desktop = Windows PowerShell 5.1).
     $shell = if ($PSVersionTable.PSEdition -eq 'Core') { 'pwsh' } else { 'powershell' }
     # Inject the model into the new shell's env before it launches (mirrors the
@@ -376,9 +381,9 @@ function spawn-kill {
     # holds the _claude_with_respawn loop) to take down the respawn cycle, then
     # kill claude itself to mop up any orphan that didn't cascade.
     #
-    # Note: Windows Terminal doesn't expose a per-tab close API — the tab will
+    # Note: Windows Terminal doesn't expose a per-tab close API -- the tab will
     # remain visible after the agent process exits. The tab can be closed
-    # manually (Ctrl+Shift+W). The agent process itself is dead — that's the
+    # manually (Ctrl+Shift+W). The agent process itself is dead -- that's the
     # part that matters for stopping work.
     #
     # Needs Windows validation on PS 5.1 + PS 7+. Untested on Windows as of
@@ -386,7 +391,7 @@ function spawn-kill {
     [CmdletBinding()]
     param([Parameter(Mandatory, Position=0)] [string] $Name)
 
-    # PowerShell doesn't expose process command lines via Get-Process — use CIM.
+    # PowerShell doesn't expose process command lines via Get-Process -- use CIM.
     # claude.exe on Windows is the Claude Code binary; node.exe is a possible
     # fallback for some install paths.
     $claudeProc = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
@@ -451,11 +456,27 @@ Write-Host "[ok] Appended new wrapper block + $PRIMARY_NAME() shorthand to $RC"
 # false negative even when the wrapper was correctly written. Verifying file
 # content (mirroring install-wrappers.sh's content-check approach) avoids
 # this entire class of false-negative.
-$profileText = Get-Content $RC -Raw
+#
+# -Encoding UTF8 is load-bearing: without it, Windows PowerShell 5.1 falls back
+# to the system ANSI codepage for a BOM-less profile, so the text we verify is
+# not the text on disk.
+$profileText = Get-Content $RC -Raw -Encoding UTF8
 $RESPAWN_FN_OK  = if ($profileText -match 'function\s+Invoke-ClaudeWithRespawn') { 1 } else { 0 }
 $SPAWN_FN_OK    = if ($profileText -match 'function\s+spawn\s*\{') { 1 } else { 0 }
 $RESPAWN_LOOP_OK = if ($profileText -match 'CLAUDE_RESPAWN_CAPABLE') { 1 } else { 0 }
 $SPAWN_WT_OK    = if ($profileText -match 'WindowsTerminal') { 1 } else { 0 }
+
+# Content checks answer "is the text present" -- NOT "can PowerShell run this".
+# A profile can contain every marker above and still be syntactically invalid,
+# in which case the shell aborts the whole file at startup and the operator
+# loses every function it defines, from an installer that reported success.
+# That is not hypothetical: a BOM-less .ps1 carrying a non-ASCII glyph decoded
+# under the ANSI codepage produces a curly quote, PowerShell treats curly
+# quotes as string delimiters, and the profile stops parsing mid-string.
+# So the last word belongs to the parser, not to a regex.
+$parseErrors = $null
+[System.Management.Automation.Language.Parser]::ParseFile($RC, [ref]$null, [ref]$parseErrors) | Out-Null
+$PARSE_OK = if ($parseErrors -and $parseErrors.Count -gt 0) { 0 } else { 1 }
 
 Write-Host ""
 Write-Host "Verification (profile-content check):"
@@ -463,9 +484,19 @@ Write-Host "  Invoke-ClaudeWithRespawn defined: $RESPAWN_FN_OK (expect 1)"
 Write-Host "  spawn defined:                    $SPAWN_FN_OK (expect 1)"
 Write-Host "  CLAUDE_RESPAWN_CAPABLE present:   $RESPAWN_LOOP_OK (expect 1)"
 Write-Host "  WindowsTerminal foreground logic: $SPAWN_WT_OK (expect 1)"
+Write-Host "  profile parses cleanly:           $PARSE_OK (expect 1)"
 Write-Host ""
 
-if ($RESPAWN_FN_OK -eq 1 -and $SPAWN_FN_OK -eq 1 -and $RESPAWN_LOOP_OK -eq 1 -and $SPAWN_WT_OK -eq 1) {
+if ($PARSE_OK -eq 0) {
+    Write-Host "[fail] The profile does not parse. Reporting the errors, then rolling back." -ForegroundColor Red
+    foreach ($e in $parseErrors) {
+        Write-Host ("    line {0}: {1}" -f $e.Extent.StartLineNumber, $e.Message) -ForegroundColor Red
+    }
+    Write-Host ""
+    Write-Host "  This is a bug in the installer, not in your setup -- please report it." -ForegroundColor Red
+}
+
+if ($PARSE_OK -eq 1 -and $RESPAWN_FN_OK -eq 1 -and $SPAWN_FN_OK -eq 1 -and $RESPAWN_LOOP_OK -eq 1 -and $SPAWN_WT_OK -eq 1) {
     Write-Host "[ok] Wrappers installed successfully."
     Write-Host ""
     Write-Host "Next steps:"

--- a/hooks/inject-datetime.ps1
+++ b/hooks/inject-datetime.ps1
@@ -1,4 +1,4 @@
-# UserPromptSubmit hook (PowerShell port) — inject current system date/time into Claude's context.
+# UserPromptSubmit hook (PowerShell port) -- inject current system date/time into Claude's context.
 #
 # Hook event: UserPromptSubmit (runs after user submits prompt, before Claude reads it).
 # stdout from this hook is appended to Claude's view of the prompt as additional context.
@@ -6,7 +6,7 @@
 # Eliminates the failure mode: Claude infers time-of-day from conversational context
 # instead of checking the system clock. Ref: antifragile.md 2026-05-18.
 #
-# Cross-platform sibling of inject-datetime.sh — same output format.
+# Cross-platform sibling of inject-datetime.sh -- same output format.
 # Encoding: ASCII-only (avoid CP1252 reinterpretation on Windows PowerShell 5.1).
 
 $ErrorActionPreference = "Stop"

--- a/hooks/install-git-hooks.ps1
+++ b/hooks/install-git-hooks.ps1
@@ -1,7 +1,7 @@
-# install-git-hooks.ps1 — Windows sibling of install-git-hooks.sh.
+# install-git-hooks.ps1 -- Windows sibling of install-git-hooks.sh.
 # Wires a concurrently-written AIOS repo to the attribution guard (hooks/git/pre-commit).
 # The guard scripts themselves are bash + run under Git Bash (Git for Windows always ships
-# it; git runs hooks through sh on every platform) — so there is no PowerShell rewrite of the
+# it; git runs hooks through sh on every platform) -- so there is no PowerShell rewrite of the
 # LOGIC, only of the per-machine install (git config is not version-controlled).
 # Usage:  pwsh -File hooks/install-git-hooks.ps1 [repoPath]   (default: $HOME\aios)
 param([string]$Repo = (Join-Path $HOME 'aios'))

--- a/skills/setup.ps1
+++ b/skills/setup.ps1
@@ -1,11 +1,11 @@
-# Skill registration (Windows) — directory junctions into ~/.claude/skills so
+# Skill registration (Windows) -- directory junctions into ~/.claude/skills so
 # Claude Code auto-loads AIOS-origin skills. Junctions are used instead of
 # symlinks because they do NOT require admin / Developer Mode. Idempotent.
 # Usage:  pwsh skills/setup.ps1
 #
 # Mirrors skills/setup.sh: registers every source EXCEPT anthropic/ and
 # superpowers/ (marketplace-provided), and skips any name already present in
-# ~/.claude/skills. Skills register standalone — they do not touch the `aios`
+# ~/.claude/skills. Skills register standalone -- they do not touch the `aios`
 # commands plugin. Restart Claude Code to pick up new links.
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path


### PR DESCRIPTION
Closes #8.

## The bug

`hooks/claude-identity/install-wrappers.ps1` is stored **UTF-8 without a BOM** and carries 11 non-ASCII characters. Windows PowerShell 5.1 assumes the system ANSI codepage for a BOM-less script, so the em dashes are corrupted **while the installer itself is being parsed** — before a single byte is written. One of them lives inside a `Write-Host` string; the decode turns its third byte into `”` (U+201D), PowerShell treats curly quotes as string delimiters, and the generated profile stops parsing mid-string. The whole file dies at shell startup — `spawn`, `spawn-kill`, and the operator's session shorthand with it.

pwsh 7 assumes UTF-8 for BOM-less scripts and was always fine, which is why this survived: the affected edition is the one a stock Windows 11 actually ships, and `/aios:update` explicitly falls back to it.

**The file already knew.** Its own header, lines 27–32:

> `# ASCII-only on purpose. Windows PowerShell 5.1 reads .ps1 files in the`
> `# system ANSI codepage when no BOM is present, so a UTF-8 glyph ... gets`
> `# misread as a smart-quote and breaks string parsing on this and following lines.`

The rule was right and stated in the right place. Nothing enforced it, so eleven em dashes drifted in. That's the part this PR treats as the real defect.

## Why it was silent

The installer's verification `-match`es for four markers and reports success when it finds them. A content check answers *"is the text present"* — never *"can PowerShell run this"*. Those two answers diverged here, which is exactly what turned a corrupted file into a **green** install:

```
Verification (profile-content check):
  Invoke-ClaudeWithRespawn defined: 1 (expect 1)
  spawn defined:                    1 (expect 1)
  CLAUDE_RESPAWN_CAPABLE present:   1 (expect 1)
  WindowsTerminal foreground logic: 1 (expect 1)
[ok] Wrappers installed successfully.
```

That output is from a profile PowerShell cannot parse.

And because `/aios:update` auto-runs this installer whenever it lands in the sync diff, it doesn't just break new installs — it **re-breaks a profile the operator already repaired by hand**, from a routine sync they initiated for unrelated reasons. See the [live reproduction](https://github.com/The-AIOS/aios/issues/8#issuecomment-5092456952) in the issue.

## What's in here

**1. Restore the ASCII-only invariant** — all four `.ps1` files in the repo violate it (`install-wrappers.ps1` 11, the other three 2 each). Only `install-wrappers.ps1` breaks today, because only it has a non-ASCII character inside a string; the others sit in comments. Fixed repo-wide anyway, so the rule is uniform and CI-checkable rather than a per-file judgment call.

I chose **restoring ASCII over adding a BOM** because that's what the file's own policy says, and a BOM is silently removable by any editor while ASCII content can't regress unnoticed. Happy to switch if you'd rather keep the typography.

**2. Parse-gate the verification, and roll back.** The installer already writes a timestamped backup and already has a rollback branch — it had everything it needed to catch this and simply never asked whether the result was valid:

```powershell
$parseErrors = $null
[System.Management.Automation.Language.Parser]::ParseFile($RC, [ref]$null, [ref]$parseErrors) | Out-Null
$PARSE_OK = if ($parseErrors -and $parseErrors.Count -gt 0) { 0 } else { 1 }
```

On failure it prints the real parse errors with line numbers, says *"this is a bug in the installer, not in your setup — please report it"*, restores the backup, and exits 1. This catches the class regardless of cause, not just this instance.

**3. `-Encoding UTF8` on all three `Get-Content` reads.** Separate latent bug, same family — the profile round-trip (read without encoding → rewrite as UTF-8 is lossy on a BOM-less file, and compounds per run), the verification read, and the `USER.md` read in `detect_primary_session`, where an accented session name would be mangled.

**4. A Windows CI lane.** `install-wrappers.ps1` has shipped twice on regex inspection alone — the last entry says so plainly: *"regex-verified against the same case matrix but not execution-verified — no PowerShell on the authoring machine."* The second of those shipped a file 5.1 can't parse. `windows-latest` has both editions, so the gap is closable:

- **Edition guard** — asserts Desktop edition. Under pwsh 7 the whole lane would decode everything correctly and prove nothing.
- **Negative control** — writes a BOM-less `.ps1` with one em dash and asserts it *fails* to parse. If that ever stops failing, the ASCII rule has gone vacuous and should be revisited. Guards against the check quietly becoming decorative.
- **Repo-wide ASCII-or-BOM check** — the enforcement the header comment was missing.
- **End-to-end install** → parse-check the produced profile → **fresh-shell probe** (a new `powershell` really does get the functions) → **idempotency re-run** (still parses, exactly one `spawn` definition — damage would otherwise compound across runs).

## Verification

Executed on **Windows 11, Windows PowerShell 5.1.26100.8875, es-MX locale** — the edition and codepage that reproduce it.

| | Result |
|---|---|
| Pre-fix installer | 4 green checks, `[ok] installed successfully`, profile has 12 mojibake chars and **does not parse** |
| Post-fix installer | `profile parses cleanly: 1`, profile ASCII-only, fresh shell gets all functions, re-run leaves exactly 1 `spawn` |
| Negative control | BOM-less em dash → `Missing string terminator` under 5.1, as expected |
| Existing suites | `install-wrappers.test.sh` 20/20, `aios-commit.test.sh` 10/10 |

**The rollback path was tested directly**, by re-injecting a single em dash into the *fixed* installer and running it:

```
  Invoke-ClaudeWithRespawn defined: 1 (expect 1)
  spawn defined:                    1 (expect 1)
  CLAUDE_RESPAWN_CAPABLE present:   1 (expect 1)
  WindowsTerminal foreground logic: 1 (expect 1)
  profile parses cleanly:           0 (expect 1)

[fail] The profile does not parse. Reporting the errors, then rolling back.
    line 143: Token 'is' unexpected in expression or statement.
    line 142: Missing closing '}' in statement block or type definition.
    ...
[warn] Verification failed. Restoring backup and exiting.
```

Exit `1`, and the profile hash was byte-identical to before the run. The four content checks still pass in that output — which is the point.

## Notes for review

- **The CHANGELOG entry needs its hash stamped on merge** — I left `hash: (stamped on merge)` since I can't know it. Followed the *What you can now do* convention.
- The `.sh` installer is untouched and unaffected: `awk` and `cat >>` move bytes without ever decoding them. Worth noting that's a *structural* property, not luck — the PowerShell side is the one that needs enforcement, which is why the CI check targets `.ps1`.
- Unrelated nit spotted while syncing: the `2026-07-25` entry for `afe0832` gives `grep -c 'arr[@]+' hooks/aios-note-append hooks/aios-commit` as verification and says both should be non-zero. `hooks/aios-commit` returns `0` at HEAD — the file is correct, the check string just isn't in it. Left alone here to keep the diff focused.
