### PR TITLE
fix(mcps): pin mcp for the three servers that import mcp.server.fastmcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,27 @@
 
 ---
 
+## 2026-07-29 — Three bundled MCPs stopped installing, and setup.sh reported success anyway
+
+`hash: TBD`
+
+> **What this delivers.** `mcps/setup.sh` installed `spotify-dj`, `pdf-generator` and `nano-banana` with an **unpinned** `pip install … mcp`. All three import `from mcp.server.fastmcp import FastMCP`, and **`mcp` 2.0 removed that module**. Where that unpinned install resolves to 2.x, it produces a venv that builds cleanly, prints `✓ installed`, and then dies at import — surfacing much later, somewhere else, as `Failed to connect` in `claude mcp list`. Existing vaults are unaffected: a venv created before 2.0 keeps its old resolution and keeps working. **The operators exposed are the ones onboarding, rebuilding a machine, or setting up a second box** — exactly the people with the least context to diagnose it.
+>
+> **Scope of verification, stated plainly:** reproduced on macOS with Python 3.12, where a bare `pip install mcp` today resolves to 2.0.0 and all three servers fail to import. Whether every platform and interpreter resolves the same way has **not** been tested here, so read the blast radius as *"wherever pip resolves `mcp` to 2.x"* rather than as a claim about every machine. The fix is correct either way — pinning a dependency the servers demonstrably require is right independent of how many environments currently break without it.
+
+**What you can now do:**
+- **Set up a new machine and have the MCPs actually run.** Each of the three now ships a `requirements.txt` pinning `mcp==1.28.1` (plus `spotipy==2.26.0` and `google-genai==2.8.0` where they apply), and `setup.sh` installs from it. Verified by deleting each venv, re-running `setup.sh`, and importing each `server.py`.
+- **Diagnose this if you already hit it.** Symptom: `claude mcp list` shows `✘ Failed to connect` for one of the three while its folder and `.venv` clearly exist. Confirm with `mcps/<name>-mcp/.venv/bin/python -c "import server"` — a `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` is this bug. Fix: `rm -rf mcps/<name>-mcp/.venv && bash mcps/setup.sh <name>-mcp`.
+- **Know what was deliberately left alone.** `notebooklm-mcp` and `playwright-mcp` also install unpinned, but neither imports the removed module, so neither is broken today. Widening the diff to them would be speculative rather than tested — they are named here so the next person sees them, not silently fixed.
+
+**For the record — what changed:** three new `requirements.txt` files (`pdf-generator-mcp`, `spotify-dj-mcp`, `nano-banana-mcp`) and three lines in `mcps/setup.sh` changed from a literal package list to `-r requirements.txt`. No server code changed. `telegram`-style pinned requirements were already the pattern elsewhere in the tree; this brings the three stragglers in line with the pinning policy `mcps/_index.md` already states — *"Floating `@latest`/unpinned is forbidden: these servers run with live credentials."* The policy was written; these three were simply never brought under it.
+
+**The general lesson, which is not about `mcp`.** A pinning policy that lives only in prose protects nothing — it has to be executable. The failure here was invisible in the worst way: the installer's own `✓` was printed by an `echo` that ran unconditionally after `pip`, so success was asserted by position in the script rather than by anything about the artifact. **An installer that cannot fail cannot be trusted when it passes.** The narrow fix is the pins; the durable one is that a setup step should verify the thing it just built does the one thing it exists to do — here, import.
+
+**Action required — only if you are installing fresh.** Existing venvs are untouched and keep working; there is no need to rebuild a machine that is currently fine. On a new install, `bash mcps/setup.sh` now does the right thing with no extra steps.
+
+---
+
 ## 2026-07-28 — Paths and runtimes the framework asserted but never checked
 
 `hash: 86a7a10 · fd5fb5b · 19b1fe2`

--- a/mcps/nano-banana-mcp/requirements.txt
+++ b/mcps/nano-banana-mcp/requirements.txt
@@ -1,0 +1,7 @@
+# Pinned per the MCP pinning policy (mcps/_index.md). Bump deliberately; vet before bumping.
+#
+# The mcp pin is load-bearing, not hygiene: mcp 2.0 removed `mcp.server.fastmcp`,
+# which server.py imports. An unpinned install therefore builds a venv that
+# reports success and then fails at import.
+mcp==1.28.1
+google-genai==2.8.0

--- a/mcps/pdf-generator-mcp/requirements.txt
+++ b/mcps/pdf-generator-mcp/requirements.txt
@@ -1,0 +1,6 @@
+# Pinned per the MCP pinning policy (mcps/_index.md). Bump deliberately; vet before bumping.
+#
+# The pin is load-bearing, not hygiene: mcp 2.0 removed `mcp.server.fastmcp`,
+# which server.py imports. An unpinned install therefore builds a venv that
+# reports success and then fails at import.
+mcp==1.28.1

--- a/mcps/setup.sh
+++ b/mcps/setup.sh
@@ -145,7 +145,7 @@ if want nano-banana-mcp && [ -d "$SCRIPT_DIR/nano-banana-mcp" ] && [ ! -d "$SCRI
   echo "→ nano-banana-mcp..."
   cd "$SCRIPT_DIR/nano-banana-mcp"
   $PY -m venv .venv
-  "$(vbin)/pip" install google-genai mcp -q
+  "$(vbin)/pip" install -r requirements.txt -q
   echo "  ✓ installed (requires GEMINI_API_KEY — see README)"
 fi
 
@@ -154,7 +154,7 @@ if want pdf-generator-mcp && [ -d "$SCRIPT_DIR/pdf-generator-mcp" ] && [ ! -d "$
   echo "→ pdf-generator-mcp..."
   cd "$SCRIPT_DIR/pdf-generator-mcp"
   $PY -m venv .venv
-  "$(vbin)/pip" install mcp -q
+  "$(vbin)/pip" install -r requirements.txt -q
   command -v pandoc >/dev/null 2>&1 || echo "  ⚠ pandoc not found — brew install pandoc"
   [ -d "/Applications/Google Chrome.app" ] || echo "  ⚠ Google Chrome not found — install from https://google.com/chrome"
   echo "  ✓ installed (requires pandoc + Chrome)"
@@ -165,7 +165,7 @@ if want spotify-dj-mcp && [ -d "$SCRIPT_DIR/spotify-dj-mcp" ] && [ ! -d "$SCRIPT
   echo "→ spotify-dj-mcp..."
   cd "$SCRIPT_DIR/spotify-dj-mcp"
   $PY -m venv .venv
-  "$(vbin)/pip" install spotipy mcp -q
+  "$(vbin)/pip" install -r requirements.txt -q
   echo "  ✓ installed (requires Spotify Dev app + SPOTIFY_CLIENT_ID/SECRET — see README)"
 fi
 

--- a/mcps/spotify-dj-mcp/requirements.txt
+++ b/mcps/spotify-dj-mcp/requirements.txt
@@ -1,0 +1,7 @@
+# Pinned per the MCP pinning policy (mcps/_index.md). Bump deliberately; vet before bumping.
+#
+# The mcp pin is load-bearing, not hygiene: mcp 2.0 removed `mcp.server.fastmcp`,
+# which server.py imports. An unpinned install therefore builds a venv that
+# reports success and then fails at import.
+mcp==1.28.1
+spotipy==2.26.0


### PR DESCRIPTION
## The problem

`mcps/setup.sh` installs three bundled servers with an **unpinned** `pip install … mcp`:

| Server | setup.sh line |
|---|---|
| `nano-banana-mcp` | `pip install google-genai mcp -q` |
| `pdf-generator-mcp` | `pip install mcp -q` |
| `spotify-dj-mcp` | `pip install spotipy mcp -q` |

All three do `from mcp.server.fastmcp import FastMCP`. **`mcp` 2.0 removed that module.**

Where the unpinned install resolves to 2.x, the venv builds cleanly, `setup.sh` prints `✓ installed`, and the server then fails at import — surfacing later, elsewhere, as `✘ Failed to connect` in `claude mcp list`.

Existing vaults are unaffected: a venv created before 2.0 keeps its resolution and keeps working. The exposed operators are the ones onboarding, rebuilding a machine, or setting up a second one — the people with the least context to diagnose it.

## Reproduction

Running `setup.sh`'s own command against the repo's own `pdf-generator-mcp/server.py`:

| Command | Resolves to | Result |
|---|---|---|
| `pip install mcp -q` (current) | `2.0.0` | `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` |
| `pip install mcp==1.28.1` | `1.28.1` | imports OK |

Confirmed for all three servers in both directions.

**Scope of verification, stated plainly:** reproduced on macOS with Python 3.12. Whether every platform/interpreter resolves identically has not been tested, so the blast radius is *"wherever pip resolves `mcp` to 2.x"*, not a claim about every machine. The fix is correct either way — pinning a dependency the servers demonstrably require is right independent of how many environments currently break without it.

## The fix

- Three new `requirements.txt` pinning `mcp==1.28.1`, plus `spotipy==2.26.0` / `google-genai==2.8.0` where applicable.
- The three `setup.sh` lines now install `-r requirements.txt`.
- No server code changed.

This brings the three stragglers under the policy `mcps/_index.md` already states — *"Floating `@latest`/unpinned is forbidden: these servers run with live credentials."* The policy was written; these three were never brought under it.

Verified end-to-end: each `.venv` deleted, `setup.sh` re-run, each `server.py` imported.

## Deliberately not fixed

`notebooklm-mcp` and `playwright-mcp` also install unpinned, but neither imports the removed module, so neither is broken today. Widening the diff to them would be speculative rather than tested. They are named in the CHANGELOG entry so the next reader sees them.

## The upstream question — maintainer's call

Two forks I did not decide:

1. **Pin version.** `1.28.1` is the newest 1.x tested here. If you would rather track 2.x, the real fix is porting the three `server.py` files to the new API — a larger change, and yours to scope.
2. **Whether the installer should verify.** The narrow bug is the pins. The broader one is that `setup.sh`'s `✓ installed` is an unconditional `echo` after `pip` — success asserted by position in the script rather than by anything about the artifact, which is why this stayed invisible. A one-line `python -c "import server"` per block would make the class of failure impossible. Not built here because it changes the installer's contract, which is a design call rather than a bug fix.