### PR TITLE
fix(pipeline-executor): don't treat a documented non-use as an enabled source

### DIFF
--- a/hooks/pipeline-executor.py
+++ b/hooks/pipeline-executor.py
@@ -99,6 +99,39 @@ def log(msg):
             print(f"⚠️  pipeline log unwritable at {LOG_PATH} ({e}) — continuing", file=sys.stderr)
 
 
+# Phrases that mark a source as deliberately NOT in use. An operator who documents
+# *why* they skip a source (good practice — it stops future sessions re-asking) would
+# otherwise have that very documentation read as "enabled", because detection was a bare
+# substring match: `if "Slack" in content`. The better the note, the more certain the
+# parser became that the source was live — and the daily plan then reported a hard
+# failure every morning for something the operator had deliberately turned off.
+# Bilingual on purpose: USER.md is written in the operator's own language.
+_NEGATION_MARKERS = (
+    "no configurado", "no configurada", "sin configurar", "not configured",
+    "no se usa", "no usar", "not used", "do not use", "don't use",
+    "no conectada", "no conectado", "not connected",
+    "desactivado", "desactivada", "disabled", "deshabilitado",
+    "a propósito", "por decisión", "on purpose", "deliberately", "by choice",
+)
+
+
+def _mentions_enabled(content, keyword):
+    """True when `keyword` appears in USER.md on at least one line that does NOT negate it.
+
+    Scans line by line rather than testing the whole document, so a single "Slack — no
+    configurado" bullet no longer flips the source on. If every line mentioning the
+    keyword negates it, the source counts as off.
+    """
+    for line in content.split("\n"):
+        if keyword not in line:
+            continue
+        low = line.lower()
+        if not any(marker in low for marker in _NEGATION_MARKERS):
+            return True
+    # Never mentioned, or mentioned only on negated lines → off.
+    return False
+
+
 def parse_sources():
     """Parse USER.md Sources section for API IDs and configured sources."""
     config = {
@@ -122,13 +155,13 @@ def parse_sources():
 
     content = SOURCES_PATH.read_text()
 
-    if "Google Calendar" in content:
+    if _mentions_enabled(content, "Google Calendar"):
         config["configured"].add("calendar")
-        if "Google Calendar (Personal)" in content:
+        if _mentions_enabled(content, "Google Calendar (Personal)"):
             config["configured"].add("calendar-personal")
-    if "Slack" in content and "### Communication" in content:
+    if _mentions_enabled(content, "Slack") and "### Communication" in content:
         config["configured"].add("slack")
-    if "Google Tasks" in content:
+    if _mentions_enabled(content, "Google Tasks"):
         config["configured"].add("tasks")
     if "### Dev projects" in content:
         config["configured"].add("dev-projects")
@@ -513,7 +546,10 @@ def run_pipeline(command_name):
                 google_tasks_list, creds_primary,
                 sources["google_tasks_list"]
             )
-        if "slack" in sources["configured"]:
+        # Credential guard, matching calendar/tasks above. Without it Slack was the one
+        # source that attempted a fetch with no tokens on disk, turning a missing optional
+        # integration into a hard ❌ in every morning's plan instead of a quiet skip.
+        if "slack" in sources["configured"] and SLACK_TOKENS_PATH.exists():
             futures["slack"] = pool.submit(slack_unreads)
             # Slack daily recap — both today and close-day if enabled
             if sources["slack_recap_enabled"]:
@@ -536,9 +572,15 @@ def run_pipeline(command_name):
             status.append(f"✅ {key}")
         else:
             status.append(f"❌ {key}: {errors.get(key, 'unknown')}")
+    # Distinguish "operator never turned this on" from "turned on but unusable". Reporting
+    # both as "not configured" hid a real problem: a source the operator HAD configured but
+    # whose credentials were missing read as a deliberate choice, so nobody went looking.
     for source, mapped in [("calendar", "calendar_primary"), ("calendar-personal", "calendar_personal"), ("tasks", "tasks"), ("slack", "slack")]:
         if mapped not in futures:
-            status.append(f"⏭️ {source}: not configured")
+            if source in sources["configured"]:
+                status.append(f"⏭️ {source}: configured but credentials missing — run the setup for this source")
+            else:
+                status.append(f"⏭️ {source}: not configured")
 
     elapsed = (datetime.now() - start_time).total_seconds()
 


### PR DESCRIPTION
## The problem class

`pipeline-executor.py` decides which sources to fetch by testing whether a keyword appears **anywhere** in `USER.md`:

```python
if "Slack" in content and "### Communication" in content:
    config["configured"].add("slack")
```

That means a line written to record a *deliberate non-use* enables the source:

```markdown
### Communication
- Slack — not configured
- Google Tasks — not used, on purpose. Todos already live in project notes.
```

Both of those switch their source ON. The failure mode is inverted from what you'd expect: **the more carefully an operator documents why they don't use something, the more certain the parser becomes that they do.** And documenting it is the behaviour the framework wants — it's what stops future sessions re-asking.

This is not specific to one vault. Any operator who writes down a considered "no" hits it, and `USER.md` is exactly the file the framework tells them to write those decisions into.

## Why Slack is where it surfaces

Slack was also the only source without a credential guard. Calendar and Tasks check for credentials before scheduling a fetch:

```python
if "calendar" in sources["configured"] and creds_primary and creds_primary.exists():
if "tasks"    in sources["configured"] and sources["google_tasks_list"] and creds_primary and creds_primary.exists():
if "slack"    in sources["configured"]:            # ← no guard
```

So a falsely-enabled Slack attempted a fetch with no tokens on disk and produced a hard `❌ FAILED` plus a `⚠️ Partial load` banner in **every** morning's plan — for an integration the operator had explicitly turned off. Calendar and Tasks fail quietly in the same situation, which is why only Slack was loud.

## A third thing this surfaced

The skip message conflates two different states:

```python
status.append(f"⏭️ {source}: not configured")
```

A source the operator **had** configured but whose credentials are missing reports identically to one they never turned on. The first is a broken setup worth fixing; the second is a choice. Reporting them the same way means the broken one reads as intentional and nobody goes looking.

## What this PR changes

1. **`_mentions_enabled(content, keyword)`** — scans line by line and ignores lines carrying a negation marker. A source counts as on only if it's mentioned on at least one non-negated line. Markers are bilingual (EN/ES) because `USER.md` is written in the operator's own language; the cold-start flow already runs that way.
2. **Slack gains the credential guard** calendar and tasks already had — symmetry, not a new concept.
3. **Status distinguishes** `not configured` from `configured but credentials missing`.

Each is independently useful; (2) alone would silence the symptom, but (1) is the actual defect and (3) is what stops the next one hiding.

## Reproduction

Add to `USER.md`:

```markdown
### Communication
- Slack — not configured
```

Then `uv run hooks/pipeline-executor.py --command today`.

**Before:** `⚠️ Partial load — slack failed.` + `❌ slack: Slack tokens not found …`
**After:** `⏭️ slack: not configured`

Verified against a real vault: with the patch, a `USER.md` documenting Calendar as in-use and Slack / Tasks / personal-calendar as deliberately-off resolves to Calendar on, the other three off — and the run reports no errors.

## Held loosely

The negation-marker list is a heuristic. It handles the phrasings the templates and cold-start flow tend to produce, but it is pattern matching, and a sufficiently creative "no" will slip past it.

The structural fix would be an explicit per-source enable field rather than inferring intent from prose — but that changes the `USER.md` contract for every existing operator, so it's a maintainer call, not something to smuggle into a bug fix. Happy to follow up with that shape if you'd prefer it; happy for you to take just the credential guard if the heuristic feels like the wrong trade.
