### PR TITLE
fix: cross-platform portability — vault anchoring, ritual parity, agent probe, Chrome resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ If `USER.md` exists, read it. It contains:
 
 1. Your session name is your role (e.g. `accountant`, `lawyer`, `code-review`, `writing`).
 2. **Agent matching** (in order):
-   - **Exact:** glob `agents/**/{name}.md` — first match wins. `agents/custom/{name}.md` always overrides bundled. Wrapper warns on collisions across bundles.
+   - **Exact:** glob `agents/**/{name}.md` — first match wins. `agents/custom/{name}.md` always overrides bundled. Wrapper warns on collisions across bundles. **Probe with a command that exits 0 on no-match** — `find agents -ipath "*/{name}.md" -print -quit 2>/dev/null` (a bare `ls agents/**/{name}.md` exits 2 when nothing matches, surfacing a harmless-but-noisy red error every spawn). A no-match is expected and normal — especially for primary sessions in USER.md, which aren't agents; don't treat the empty result as a failure.
    - **Fuzzy:** no exact file → read `agents/_index.md` (canonical registry) + `agents/custom/_index.md` if present; match session name against agent names/purposes/keywords; pick closest; tell user which matched and why.
    - **No match:** No close agent found → general-purpose worker with session name as role context.
 3. **Greet by name with a contextual message that fits the role** — natural prose, not a fixed line. E.g. `lawyer` → *"Counsel is in, [name]. What do you need me to look at?"* (`[name]` from `about_me.md`; never hardcode). Adapt for any role.

--- a/hooks/claude-identity/install-wrappers.sh
+++ b/hooks/claude-identity/install-wrappers.sh
@@ -146,6 +146,15 @@ _claude_with_respawn() {
   local name="${1:?Usage: _claude_with_respawn <name> [bootstrap] [initial-session-id]}"
   local bootstrap="${2:-}"
   local initial_sid="${3:-}"
+
+  # Anchor every spawned session in the vault so Claude Code auto-loads ~/aios/CLAUDE.md
+  # and runs the Session Start Ritual. The launcher's `cd ~/aios` only covers the
+  # macOS AppleScript path; the in-shell spawn path (and any plain-terminal spawn on
+  # Linux) calls this function directly from whatever cwd the terminal happened to be
+  # in — landing sessions in $HOME with no CLAUDE.md, so nothing loaded. cd'ing here
+  # makes vault-loading independent of OS, IDE automation, and the caller's cwd.
+  cd ~/aios 2>/dev/null
+
   # Use ARRAY for resume args (portable bash + zsh). Unquoted string $resume_flag
   # would word-split in bash but NOT in zsh (default) — zsh would pass the whole
   # "--resume <uuid>" as ONE option-name, and claude would error with
@@ -635,11 +644,23 @@ cat >> "$RC" <<EOF
 # Primary-session shorthand — runs \`$PRIMARY_NAME\` as a named, respawn-capable
 # session. Re-run install-wrappers.sh after editing USER.md → ## Identity to
 # rename this function to your actual session name.
+#
+# A FRESH session is launched with a bootstrap prompt. Without one, \`claude\` opens
+# idle and waits: CLAUDE.md is loaded (the cwd is the vault) but nothing has taken a
+# turn, so the Session Start Ritual never runs — no declared/observed context, no
+# greeting. \`spawn\` never had this problem, but only by accident: it ALWAYS passes
+# a bootstrap ("Read <task-file> …"), and that turn is what triggers the ritual. The
+# primary shorthand passing none looks like an oversight rather than a decision, so
+# the two paths are made to behave the same.
+#
+# -c/--continue and -r/--resume deliberately pass NO bootstrap: the context is
+# already in the session being resumed, and re-running the ritual would spend a turn
+# re-reading what is already loaded.
 $PRIMARY_NAME() {
   case "\$1" in
     -c|--continue) _claude_with_respawn $PRIMARY_NAME "" --continue ;;
     -r|--resume)   _claude_with_respawn $PRIMARY_NAME "" "\${2:-}" ;;
-    *)             _claude_with_respawn $PRIMARY_NAME ;;
+    *)             _claude_with_respawn $PRIMARY_NAME "Session start — follow the Session Start Ritual in CLAUDE.md: load declared + observed context, then greet me." ;;
   esac
 }
 # ==== END claude-primary-session ====

--- a/mcps/pdf-generator-mcp/server.py
+++ b/mcps/pdf-generator-mcp/server.py
@@ -1,6 +1,12 @@
-"""PDF Generator MCP — pandoc (md → HTML) → Chrome headless (HTML → PDF)."""
+"""PDF Generator MCP — pandoc (md → HTML) → Chrome headless (HTML → PDF).
+
+Cross-platform (macOS / Windows / Linux). Chrome is resolved per-OS at call time;
+override with the CHROME_PATH env var if your browser lives somewhere unusual.
+"""
 import os
+import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from datetime import datetime
@@ -19,17 +25,64 @@ from mcp.server.fastmcp import FastMCP
 # root from this file's location removes the dependency on the symlink entirely.
 AIOS_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT_DIR = AIOS_ROOT / "vault" / "03 - export" / "generated"
-CHROME_PATH = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
 mcp = FastMCP("pdf-generator")
 
 
-def _ensure_tools():
-    """Verify pandoc and Chrome are available."""
-    if subprocess.run(["which", "pandoc"], capture_output=True).returncode != 0:
-        raise RuntimeError("pandoc not found. Install: brew install pandoc")
-    if not os.path.exists(CHROME_PATH):
-        raise RuntimeError(f"Chrome not found at {CHROME_PATH}. Install Google Chrome.")
+def _find_chrome() -> str | None:
+    """Locate a Chrome/Chromium/Edge binary across macOS, Windows and Linux."""
+    # 1) explicit override
+    env = os.environ.get("CHROME_PATH")
+    if env and os.path.exists(env):
+        return env
+
+    # 2) per-OS well-known locations
+    if sys.platform == "darwin":
+        candidates = [
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        ]
+    elif sys.platform == "win32":
+        candidates = [
+            os.path.expandvars(r"%ProgramFiles%\Google\Chrome\Application\chrome.exe"),
+            os.path.expandvars(r"%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe"),
+            os.path.expandvars(r"%LocalAppData%\Google\Chrome\Application\chrome.exe"),
+            os.path.expandvars(r"%ProgramFiles%\Microsoft\Edge\Application\msedge.exe"),
+            os.path.expandvars(r"%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe"),
+        ]
+    else:  # linux / other unix
+        candidates = [
+            "/usr/bin/google-chrome",
+            "/usr/bin/google-chrome-stable",
+            "/usr/bin/chromium",
+            "/usr/bin/chromium-browser",
+            "/snap/bin/chromium",
+        ]
+    for c in candidates:
+        if c and os.path.exists(c):
+            return c
+
+    # 3) anything on PATH
+    for name in ("google-chrome", "google-chrome-stable", "chromium",
+                 "chromium-browser", "chrome", "msedge"):
+        found = shutil.which(name)
+        if found:
+            return found
+    return None
+
+
+def _ensure_tools() -> str:
+    """Verify pandoc and a Chrome-family browser are available. Returns the browser path."""
+    if shutil.which("pandoc") is None:
+        raise RuntimeError("pandoc not found. Install pandoc and make sure it's on PATH.")
+    chrome = _find_chrome()
+    if not chrome:
+        raise RuntimeError(
+            "Chrome/Chromium/Edge not found. Install Google Chrome, "
+            "or set the CHROME_PATH env var to your browser binary."
+        )
+    return chrome
 
 
 def _default_output(ext: str = "pdf") -> str:
@@ -38,8 +91,9 @@ def _default_output(ext: str = "pdf") -> str:
 
 
 def _html_to_pdf(html_path: str, pdf_path: str) -> None:
+    chrome = _ensure_tools()
     subprocess.run(
-        [CHROME_PATH, "--headless", "--no-pdf-header-footer", f"--print-to-pdf={pdf_path}", html_path],
+        [chrome, "--headless", "--no-pdf-header-footer", f"--print-to-pdf={pdf_path}", html_path],
         check=True,
         capture_output=True,
     )


### PR DESCRIPTION
## Problem class

Three places where the framework assumes macOS or assumes a happy path, and **all three fail silently** — no error, no visible symptom, just a session that quietly isn't what the operator thinks it is. Found while running AIOS daily on Linux Mint; each one is environment-shaped, not vault-shaped, so any operator outside macOS hits them.

---

### 1. Spawned sessions can start outside the vault, so `CLAUDE.md` never loads

`_claude_with_respawn` is called directly from whatever cwd the terminal happens to be in. The `cd` into the vault only exists inside the launcher's macOS AppleScript path, so on Linux (and any plain-terminal spawn) the session starts in `$HOME`, Claude Code finds no `CLAUDE.md`, and **the Session Start Ritual never runs** — no declared context, no observed context, no identity.

The failure mode is what makes this worth fixing: the session opens perfectly normally. The operator believes they're talking to their AIOS and they're talking to a bare Claude.

**Fix:** `cd` into the vault inside the function, so vault-loading is independent of OS, IDE automation, and the caller's cwd.

### 2. The primary-session shorthand never triggers the Session Start Ritual

A fresh `claude` with no bootstrap prompt opens idle and waits. `CLAUDE.md` is loaded, but nothing has taken a turn — so the ritual never runs. `spawn` never had this problem, but only by accident: it *always* passes a bootstrap (`Read <task-file> …`), and that turn is what triggers the ritual. The primary shorthand passing none reads as an oversight rather than a decision, so this makes the two paths behave the same.

`-c/--continue` and `-r/--resume` deliberately keep passing **no** bootstrap: the context is already in the session being resumed, and re-running the ritual would spend a turn re-reading what's already loaded.

### 3. Agent-name probe returns a nonzero exit on the normal case

`CLAUDE.md` instructs a glob probe to find a matching agent file. A bare glob with no match exits 2, which surfaces a red error on **every** spawn whose name doesn't match an agent — and that's the *expected* case for primary sessions, which aren't agents. The practical cost isn't the failed probe; it's that it trains operators to ignore red errors.

**Fix:** `find agents -ipath "*/{name}.md" -print -quit`, which exits 0 on no-match.

### 4. PDF Generator MCP only resolves Chrome on macOS

`server.py` hardcoded the macOS Chrome path, so the MCP fails on Linux and Windows. Now resolves Chrome/Chromium/Edge per-OS at call time, with a `CHROME_PATH` env override for unusual installs.

---

## Testing

Run live in a real vault on Linux Mint 22.3 / bash, Claude Code 2.1.223:

- **(1)** verified against the consumer, not the file: `spawn` from `/tmp`, then asked the new session for its cwd and whether it loaded `CLAUDE.md`. Before: `$HOME`, no ritual. After: vault, ritual runs.
- **(2)** primary shorthand opens and immediately runs the ritual; `-c` / `-r` confirmed still bootstrap-free.
- **(3)** `find agents -ipath "*/does-not-exist.md" -print -quit; echo $?` → `0`, no output.
- **(4)** PDF generated end-to-end on Linux.
- `bash -n` on the wrapper installer, `py_compile` on `server.py`.
- No new arrays introduced, so no bash 3.2 `set -u` empty-array exposure.

## Scope

Deliberately excluded from this PR: the model-default value in `install-wrappers.sh` is a personalization, not a portability bug — upstream should bump its own default on its own schedule, so this branch leaves it untouched.

## The upstream question

(1) and (2) both change *when* the Session Start Ritual runs. I've treated that as a bug — the ritual is documented as the contract for every session and these two paths were skipping it — but if either path skipping the ritual was intentional, say so and I'll narrow the PR to (3) and (4), which are unambiguous.
