### PR TITLE
fix(claude-identity): Linux port of the rotation autopilot + 3 bugs in the macOS implementation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -645,6 +645,12 @@ jobs:
         # arm the cooldown, or the watcher goes blind exactly when it must not.
         run: bash tests/quota-rotation-target.test.sh
 
+      - name: watcher evaluation interval tightens near the cap
+        # A flat 30s tick was the real ceiling: the credential swap lands in
+        # milliseconds, but only if the threshold is EVALUATED in time. Parallel
+        # subagents cross the cap inside a 30s blind window.
+        run: bash tests/quota-tick-interval.test.sh
+
   primitives_bash32:
     # The same regression suite under bash 3.2 — the bash Apple ships at /bin/bash on every
     # macOS, and what `#!/usr/bin/env bash` resolves to on a stock Mac. The `primitives` job

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -651,6 +651,13 @@ jobs:
         # subagents cross the cap inside a 30s blind window.
         run: bash tests/quota-tick-interval.test.sh
 
+      - name: every component follows CLAUDE_CONFIG_DIR together
+        # The safe way to add an account is to log it into an isolated config dir
+        # and capture from there (`/login` revokes the previous refresh token).
+        # If one component lags the relocation, every path still resolves and the
+        # watcher reads one account's state while the operator works in another.
+        run: bash tests/quota-config-dir.test.sh
+
   primitives_bash32:
     # The same regression suite under bash 3.2 — the bash Apple ships at /bin/bash on every
     # macOS, and what `#!/usr/bin/env bash` resolves to on a stock Mac. The `primitives` job

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -665,6 +665,13 @@ jobs:
         # rename bumps mtime, which is the signal a live session rides to adopt.
         run: bash tests/credential-backend.test.sh
 
+      - name: a rotation the live session never adopted is detected
+        # The autopilot leans on Claude Code re-reading the credential store on
+        # its next API request. That was measured, not promised — if an update
+        # removed it the failure would be mute: swap succeeds, log says rotated,
+        # session keeps burning the capped account. This is the only sensor.
+        run: bash tests/adoption-detector.test.sh
+
   primitives_bash32:
     # The same regression suite under bash 3.2 — the bash Apple ships at /bin/bash on every
     # macOS, and what `#!/usr/bin/env bash` resolves to on a stock Mac. The `primitives` job

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -638,6 +638,13 @@ jobs:
         # live rotation (#15).
         run: bash tests/quota-threshold.test.sh
 
+      - name: rotation picks an account with actual capacity
+        # Bare `switch` wraps, so with two accounts exhausting B rotates back to
+        # a still-capped A — landing on a dead account and then burning the
+        # cooldown there. Includes the non-obvious one: a `declined` row must not
+        # arm the cooldown, or the watcher goes blind exactly when it must not.
+        run: bash tests/quota-rotation-target.test.sh
+
   primitives_bash32:
     # The same regression suite under bash 3.2 — the bash Apple ships at /bin/bash on every
     # macOS, and what `#!/usr/bin/env bash` resolves to on a stock Mac. The `primitives` job

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -630,6 +630,14 @@ jobs:
         # reported by operators, neither catchable here because nothing tested this file.
         run: bash tests/install-wrappers.test.sh
 
+      - name: rotation threshold reaches its enforcing process
+        # THRESHOLD_5H/7D lived in claude-identity.sh and nothing read them: never
+        # exported, no consumer in that file, and the hot path (statusLine ->
+        # _cache.py -> _watch.py) never sources the shell. Editing the value you
+        # could find changed nothing, silently. Reported from a Linux operator's
+        # live rotation (#15).
+        run: bash tests/quota-threshold.test.sh
+
   primitives_bash32:
     # The same regression suite under bash 3.2 — the bash Apple ships at /bin/bash on every
     # macOS, and what `#!/usr/bin/env bash` resolves to on a stock Mac. The `primitives` job
@@ -666,6 +674,11 @@ jobs:
       - name: install-wrappers regression under bash 3.2
         # The installer writes to a *stock* Mac's shell rc, which is exactly where 3.2 lives.
         run: /bin/bash tests/install-wrappers.test.sh
+
+      - name: rotation threshold under bash 3.2
+        # macOS is the platform the rotation autopilot already supports, so this
+        # lane is the one that matters most for it.
+        run: /bin/bash tests/quota-threshold.test.sh
 
   primitives_windows:
     # The same regression suite under GIT BASH — the shell Windows operators actually run

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -658,6 +658,13 @@ jobs:
         # watcher reads one account's state while the operator works in another.
         run: bash tests/quota-config-dir.test.sh
 
+      - name: credential backend round-trip and refusal
+        # The Linux/Windows store is a plaintext file that this tool REPLACES on
+        # every swap: a malformed blob would overwrite a working credential and
+        # surface as a logged-out session, not as an error. Also asserts the
+        # rename bumps mtime, which is the signal a live session rides to adopt.
+        run: bash tests/credential-backend.test.sh
+
   primitives_bash32:
     # The same regression suite under bash 3.2 — the bash Apple ships at /bin/bash on every
     # macOS, and what `#!/usr/bin/env bash` resolves to on a stock Mac. The `primitives` job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,25 @@
 
 ---
 
+## 2026-08-12 — The rotation autopilot runs on Linux, and three of its bugs were never about Linux
+
+`hash: TBD-ON-MERGE` <!-- date + hash set by the maintainer on merge; 08-12 is a placeholder because 08-11 is taken -->
+
+> **What this delivers.** `hooks/claude-identity/` was documented macOS-only, so every operator running two or more Anthropic accounts on Linux had **no rate-limit autopilot at all** — they hit the 5h cap mid-task with no fallback, which is the exact situation the feature exists to prevent. Porting it surfaced four things, and **three of them are bugs in the existing macOS implementation** that affect operators today. The fourth is a documented premise that measurement contradicts. The shape worth naming: *a port is an unusually good auditor, because it forces you to read every assumption out loud.*
+
+**What you can now do:**
+
+- **Run the quota autopilot on Linux.** The credential store is platform-detected — Keychain on macOS, and on Linux the plaintext `$CLAUDE_CONFIG_DIR/.credentials.json` (mode 600) that Claude Code itself writes. Not libsecret, not a keyring: anything else would be storing the credential somewhere the application never reads. The scheduler follows suit — a systemd **user** timer beside the launchd agent. The macOS path is byte-for-byte unchanged.
+- **Actually change the rotation threshold.** `claude-identity.sh` declared `THRESHOLD_5H`/`THRESHOLD_7D` and **nothing read them** — never exported, no consumer in that file, and the path that actually fires (statusLine → `_cache.py` → `_watch.py`) never sources the shell at all. So the copy that reads as configuration was inert, and `_watch.py`'s own default silently governed. Set 92, watch a 96% reading log `no swap`, get no error anywhere. `_watch.py` now owns the value; `claude-switch watch --threshold` answers from the enforcing process, so what is reported cannot drift from what is applied.
+- **Stop rotating onto an account that is still capped.** Rotation was a bare `switch`, which advances one position and wraps — so with two accounts, exhausting B rotated straight back to a still-capped A, landing the session on a dead account and then burning the cooldown there. The watcher now persists each account's `resets_at` as it sees it, and only rotates somewhere whose window has genuinely rolled. When nothing has capacity it **declines and tells you when capacity returns**, which is a better outcome than a swap to nowhere.
+- **Cross the cap without the rotation arriving late.** The threshold was only *evaluated* every 30 seconds. The credential swap lands in milliseconds, so that flat interval was the real ceiling: with parallel subagents burning fast, the cap gets crossed inside the blind window. The tick now tightens to 3s above 85% usage and stays at 30s below it.
+- **Find out if a rotation never reached your running session.** The autopilot leans on Claude Code re-reading its credential store on the next API request — measured, not promised. If that ever changes the failure is **mute**: the swap succeeds, the log says rotated, and the session keeps burning the capped account. A detector now watches for the usage that should have fallen and did not, and says so.
+- **Add a second account without killing the first.** `/login` performs a server-side revoke of the previous refresh token, so the documented "log in, then `--capture`" flow can destroy an identity you already captured, depending on ordering. Every component now honours `CLAUDE_CONFIG_DIR`, so you can log the new account into an isolated config dir and capture from there — nothing to log out of.
+
+**Action required:** none, unless you are on Linux and want the autopilot — see `hooks/claude-identity/README.md` § Setup. **If you are on macOS and had edited the threshold in `claude-identity.sh`, it was never in force.** Export `CLAUDE_QUOTA_5H` / `CLAUDE_QUOTA_7D` instead, and run `claude-switch watch --threshold` to see what is actually applied.
+
+**Not included:** Windows. The credential layout is the same as Linux, but no scheduler is wired and nothing has been tested there. `_resume.py` is also **not** deleted — its premise is false and its docstring now says so plainly, but it sits behind the documented `CLAUDE_AUTOSWAP_RESPAWN=1` opt-in, and removing an escape hatch operators may be using is a separate decision from a port.
+
 ## 2026-08-11 — Four backstops that could not see the thing they existed to catch
 
 `hash: f03c411 · 9f80efc · 19d674f · 05f7340`

--- a/SETUP.md
+++ b/SETUP.md
@@ -420,7 +420,7 @@ Merge `PreToolUse` alongside your existing `UserPromptSubmit` array — don't re
 
 If either hook silently failed: re-read the settings.json and confirm the `hooks.UserPromptSubmit` array + `statusLine.command` are exactly as above. Common gotcha: an existing settings.json with `hooks: {}` empty object — merge the array in, don't replace the empty value at the wrong nesting level.
 
-### 11. Quota autopilot — split: install now, capture later (macOS only, ≥ 2 accounts)
+### 11. Quota autopilot — split: install now, capture later (macOS + Linux, ≥ 2 accounts)
 
 **Why this is split.** The autopilot has two install phases. The first is file-system-only (drop the plist, load the launchd agent) — safe to do during setup. The second is the **account-capture dance** (login → capture identity → logout → switch → repeat) — that one cycles Claude's auth, and running it during setup would interrupt the very session that's setting things up. So we ALWAYS defer capture to the operator's first `/today`, where it's a deliberate task with no other in-flight work to disrupt.
 
@@ -457,7 +457,7 @@ If either hook silently failed: re-read the settings.json and confirm the `hooks
 **The full capture walkthrough** is at `hooks/claude-identity/README.md` → `## Setup` — 7 interactive steps: configure accounts in USER.md, capture identities, verify cache writes, run a swap dry-run. That walkthrough is what fires from `/today` when the marker is present.
 
 Hard preconditions:
-- **macOS only.** Uses Keychain Services and launchd. On Linux/Windows the autopilot stays dormant; the spawn wrapper + universal hooks still work on all platforms.
+- **macOS and Linux.** The credential store and the scheduler are both platform-detected: Keychain + launchd on macOS; on Linux, the plaintext credentials file Claude Code itself writes (mode 600) + a systemd **user** timer. **Windows stays dormant** — the credential path is right there but no scheduler is wired and it is untested. The spawn wrapper + universal hooks work on all three regardless.
 - **≥ 2 Anthropic accounts.** A single-account setup gets no value — skip this section entirely.
 
 ### 12. Advanced — two-machine architecture (optional, power users)
@@ -590,7 +590,7 @@ OS-specific debugging fixes documented as the team hit them. Cross-reference if 
 | Terminal in Obsidian doesn't work | polyipseity plugin incompatible | Use VS Code or Antigravity terminal instead. Uninstall the plugin. |
 | Atlassian auth doesn't open popup | VS Code OAuth popup blocked | Authenticate at claude.ai → Settings → Connectors → Atlassian. VS Code detects it after. *(Skip if you don't use Jira/Confluence.)* |
 
-**Skip on Windows:** Quota autopilot (above) is macOS-only — single-account use works fine on Windows without it.
+**Skip on Windows:** Quota autopilot (above) supports macOS and Linux — single-account use works fine on Windows without it.
 
 ### macOS
 

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -181,7 +181,7 @@ If you customize how a command behaves, put it in `USER.md` → `## Command pers
 
 ## (Optional) Quota autopilot — multi-account rotation
 
-If you run two or more Anthropic accounts to manage 5h/7d rate limits, the bundled `hooks/claude-identity/` autopilot rotates between them automatically and respawns active Claude sessions on the new account. macOS-only (uses Keychain + launchd). Single-account setup? Skip — the scripts stay dormant.
+If you run two or more Anthropic accounts to manage 5h/7d rate limits, the bundled `hooks/claude-identity/` autopilot rotates between them automatically and respawns active Claude sessions on the new account. macOS (Keychain + launchd) and Linux (Claude Code's own credentials file + a systemd user timer). Single-account setup? Skip — the scripts stay dormant.
 
 To set up: in any Claude session, say *"set up the quota autopilot"*. Claude reads `hooks/claude-identity/README.md` and walks you through 7 steps.
 

--- a/hooks/claude-identity/README.md
+++ b/hooks/claude-identity/README.md
@@ -345,14 +345,21 @@ Any command written as `~/path/to/thing` in `settings.json` (under `hooks` or `s
 
 The statusLine/hook command is `execve`d directly, not `bash -c`-wrapped. Bash-only features like process substitution (`>(...)`), `$(...)` command substitution, heredocs, and arrays DO NOT work unless you explicitly wrap the whole thing in `bash -c '...'`. If your statusline is coming out blank, this is probably why.
 
-### 4. The running session keeps its token in memory
+### 4. A running session adopts a swapped credential on its NEXT API request
 
-When `claude-switch` runs mid-session (auto or manual), it swaps the Keychain + `~/.claude.json` identity, but your RUNNING Claude Code session holds the OLD account's OAuth token in memory. It keeps hitting the API as the old account until the token refreshes naturally (~1h) — at which point the refresh uses the NEW Keychain credentials and may fail because the refresh token belongs to the old account. The session will prompt you to log in again or simply error.
+> **This entry said the opposite until 2026-08-12, and that is the lesson.** It read *"The running session keeps its token in memory"* and built three conclusions on it. The belief was corrected in the `2026-05-28` CHANGELOG entry — which explicitly records this README being fixed — but the fix never landed here. So the doc kept teaching the false version for two and a half months while the changelog claimed it had been corrected, and two code files went on citing it. **A correction that isn't propagated is not a correction**; it is a second source of truth that disagrees with the first.
 
-**Implications:**
-- Auto-swaps are best-effort — they ensure your NEXT spawn uses the new account, but the current session keeps burning the old account's quota.
-- To cleanly hand over: restart the session (new terminal + new `claude` spawn), or let the token refresh fail naturally.
-- The 15-min cooldown is not a bug — it's a thrashing guard. During cooldown, the running session's old-token reports will reflect against the NEW `oauthAccount` email in the cache. Without cooldown, we'd swap back immediately into a ping-pong loop.
+When `claude-switch` runs mid-session, the running session picks the new credential up on its **next API request** — no restart, no waiting for a ~1h token refresh.
+
+**Why**, measured on Claude Code 2.1.223: the client `stat()`s the credential store *on the request path* and purges its in-memory token caches when the mtime changes, before the not-expired early return. It is not a background watcher — bumping the credential file's mtime 40 times at 1s intervals produced re-reads **only at the 3 request boundaries**. So the check rides the request: swap the file, and the next turn is the new account. (Reported and measured in #15, on Linux; the mechanism is the client's, not the platform's.)
+
+**Implications** — each one inverts an earlier conclusion:
+- **Auto-swaps are not best-effort.** The current session moves too, so it stops burning the exhausted account's quota. That is the entire point of the autopilot, and it does work mid-task.
+- **You do not need to restart to hand over.** The old advice ("new terminal + new `claude` spawn") was doing nothing except costing you your session.
+- **`_resume.py` no longer has a token-related job.** It is kept, and still reachable via `CLAUDE_AUTOSWAP_RESPAWN=1`, but it is now a hard restart on rotation and nothing more. Its docstring says so at the top; do not reason from the paragraph beneath.
+- **The 15-min cooldown stays, on a different justification.** It was originally defended as a token-in-memory guard, which is void. It survives because the *cache* — not the token — lags: for a short window after a swap, `rate-limit-cache.json` can still report the previous account's percentages against the new `oauthAccount` email, and acting on that reading would ping-pong. The guard is against stale telemetry, not stale credentials. It is deliberately unchanged at `COOLDOWN_SECS = 900` rather than shortened on inference — shortening it wants its own measurement.
+
+**What the swap latency actually depends on** is therefore not adoption but *evaluation*: the threshold has to be checked before the cap is crossed. `_cache.py` ticks the watcher every `WATCH_TICK_SECS = 30` with headroom, tightening to `WATCH_TICK_SECS_HOT = 3` above `HOT_ZONE_PCT = 85`, because parallel subagents can cross a cap inside a 30-second blind window.
 
 ### 5. Tee-based statusLine piggyback is the cleanest pattern
 

--- a/hooks/claude-identity/README.md
+++ b/hooks/claude-identity/README.md
@@ -61,7 +61,7 @@ Multi-account Claude Code identity manager + quota autopilot. One tool that:
 >
 > **Hard preconditions — check both before any step runs:**
 >
-> 1. **macOS only.** The autopilot uses `security` (Keychain), `launchctl`, `~/Library/LaunchAgents/`, and `osascript` — all macOS-specific. If `uname -s` ≠ `Darwin`, tell the user: *"This autopilot is macOS-only — it relies on Keychain Services and launchd. The scripts are now in your repo but won't run on Linux/Windows. Skipping setup."* Then **skip the rest of setup entirely**.
+> 1. **macOS or Linux.** The credential store is platform-detected: Keychain on macOS, the plaintext `$CLAUDE_CONFIG_DIR/.credentials.json` (mode 600) that Claude Code itself writes on Linux/Windows. The scheduler follows the platform too — a launchd agent on macOS, a systemd **user** timer on Linux (`aios-claude-quota-watch.{service,timer}`). **Windows is not supported yet:** the credential path is right, but there is no scheduler equivalent wired and nothing has been tested there. If `uname -s` is neither `Darwin` nor `Linux`, tell the user: *"This autopilot supports macOS and Linux. The scripts are in your repo but the scheduler isn't wired for your platform. Skipping setup."* Then **skip the rest of setup entirely**.
 > 2. **≥ 2 Anthropic accounts.** This autopilot only brings value with multiple accounts in rotation. If step 1 (below) establishes the user has fewer than 2, **skip steps 2 through 7 entirely** — the scripts stay dormant in their repo until they configure ≥ 2 accounts in `USER.md`. Don't try to run capture, plist install, or statusLine wire on a single-account user.
 
 Paths below assume the vault is at `~/aios`. If you cloned elsewhere, either symlink `~/aios → /your/path` or substitute the full path.

--- a/hooks/claude-identity/_cache.py
+++ b/hooks/claude-identity/_cache.py
@@ -23,9 +23,21 @@ import subprocess
 import sys
 import time
 
-# Fire _watch.py at most once per WATCH_TICK_SECS to avoid spawning a
-# subprocess on every statusLine render (~4-6/turn).
-WATCH_TICK_SECS = 30
+# Fire _watch.py at most once per tick to avoid spawning a subprocess on every
+# statusLine render (~4-6/turn).
+#
+# The interval is adaptive, because a flat 30s was the real ceiling on the whole
+# autopilot. Claude Code adopts a swapped credential on its very next API request
+# — milliseconds — but that is moot if the threshold is only EVALUATED every 30
+# seconds: with parallel subagents burning fast, the cap gets crossed inside that
+# blind window and the rotation arrives after the wall it existed to avoid.
+#
+# So: poll lazily while there is headroom, tighten as the account approaches its
+# cap. The cost of the fast lane is one short-lived subprocess a few seconds
+# apart, and only in the minutes that actually matter.
+WATCH_TICK_SECS = 30        # headroom — stay cheap
+WATCH_TICK_SECS_HOT = 3     # near the cap — every second counts
+HOT_ZONE_PCT = 85           # above this, tick fast
 
 
 def main():
@@ -80,20 +92,33 @@ def main():
     # every statusLine render). Any failure here is non-fatal — the launchd
     # safety-net will still catch threshold crossings within 30 min.
     try:
-        kick_watcher(home)
+        kick_watcher(
+            home, max(out["five_hour_pct"] or 0, out["seven_day_pct"] or 0)
+        )
     except Exception as e:
         sys.stderr.write(f"claude-identity cache: watch kick skipped: {e}\n")
 
 
-def kick_watcher(home: str) -> None:
-    """Spawn _watch.py in the background if at least WATCH_TICK_SECS have
-    elapsed since the last kick. Touches a tick marker so subsequent
-    statusLine renders don't pile up subprocesses."""
+def tick_interval(worst_pct: float) -> int:
+    """Seconds to wait between watcher kicks, given the worst of the two usage
+    percentages. Fast only inside the hot zone — see the note on WATCH_TICK_SECS."""
+    try:
+        pct = float(worst_pct or 0)
+    except (TypeError, ValueError):
+        pct = 0.0
+    return WATCH_TICK_SECS_HOT if pct >= HOT_ZONE_PCT else WATCH_TICK_SECS
+
+
+def kick_watcher(home: str, worst_pct: float = 0) -> None:
+    """Spawn _watch.py in the background if enough time has elapsed since the
+    last kick. Touches a tick marker so subsequent statusLine renders don't pile
+    up subprocesses. The interval tightens as usage approaches the cap."""
     tick_path = os.path.join(home, ".claude", "watch-tick")
+    interval = tick_interval(worst_pct)
     now = time.time()
     if os.path.exists(tick_path):
         try:
-            if now - os.path.getmtime(tick_path) < WATCH_TICK_SECS:
+            if now - os.path.getmtime(tick_path) < interval:
                 return
         except OSError:
             pass

--- a/hooks/claude-identity/_cache.py
+++ b/hooks/claude-identity/_cache.py
@@ -40,10 +40,21 @@ WATCH_TICK_SECS_HOT = 3     # near the cap — every second counts
 HOT_ZONE_PCT = 85           # above this, tick fast
 
 
+def config_dir(home: str) -> str:
+    """Claude Code's config root. Honouring CLAUDE_CONFIG_DIR is what makes the
+    isolated-config account capture possible — see the note in _watch.py."""
+    return os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(home, ".claude")
+
+
 def main():
     home = os.path.expanduser("~")
-    cache_path = os.path.join(home, ".claude", "rate-limit-cache.json")
-    claude_json = os.path.join(home, ".claude.json")
+    cfg = config_dir(home)
+    cache_path = os.path.join(cfg, "rate-limit-cache.json")
+    # .claude.json sits BESIDE the config dir in the default layout but INSIDE
+    # it when relocated, so try the relocated position first and fall back.
+    claude_json = os.path.join(cfg, ".claude.json")
+    if not os.path.exists(claude_json):
+        claude_json = os.path.join(home, ".claude.json")
 
     try:
         payload = sys.stdin.read()
@@ -113,7 +124,7 @@ def kick_watcher(home: str, worst_pct: float = 0) -> None:
     """Spawn _watch.py in the background if enough time has elapsed since the
     last kick. Touches a tick marker so subsequent statusLine renders don't pile
     up subprocesses. The interval tightens as usage approaches the cap."""
-    tick_path = os.path.join(home, ".claude", "watch-tick")
+    tick_path = os.path.join(config_dir(home), "watch-tick")
     interval = tick_interval(worst_pct)
     now = time.time()
     if os.path.exists(tick_path):

--- a/hooks/claude-identity/_resume.py
+++ b/hooks/claude-identity/_resume.py
@@ -2,12 +2,34 @@
 """
 _resume.py — after an auto-swap, continue any active Claude Code sessions.
 
-The problem: `claude-switch` rewrites the Keychain + ~/.claude.json, but a
-running Claude Code session holds the OLD account's OAuth token in memory.
-It keeps working for ~1h until refresh, then fails (the refresh token
-belongs to the OLD account, Keychain now has the NEW). Session stalls.
+  ⚠️ THE PREMISE BELOW IS FALSE. Kept because the behaviour is still reachable
+  via CLAUDE_AUTOSWAP_RESPAWN=1, but do not reason from this paragraph.
 
-The fix: right after the swap, kill each active session and respawn with
+  This file was written to solve "a running session holds the OLD account's
+  token in memory and stalls". Measured on Claude Code 2.1.223 (Linux): a
+  running session adopts a swapped credential on its NEXT API request, with no
+  restart. Claude Code stat()s the credential store on the request path and
+  purges its token caches when mtime changes — the check rides the request,
+  there is no background watcher. An isolated process with its own
+  CLAUDE_CONFIG_DIR, running a 3-turn task with the credential file's mtime
+  bumped 40 times at 1s intervals, re-read ONLY at the 3 request boundaries.
+
+  The CHANGELOG entry for 2026-05-28 already corrected this ("auto-transitions
+  on its next API turn — empirically ~30 seconds") and made the respawn opt-in;
+  this docstring was never updated to match, so the file kept asserting a
+  problem that does not exist. See issue #15.
+
+  What the opt-in is still FOR, if anything: an unattended agent whose operator
+  wants a hard restart on rotation for reasons other than the token. Note the
+  hazard the same CHANGELOG documents — respawning into a broken transcript can
+  chain-burn every account in the pool.
+
+The original rationale, retained for context (and now known to be wrong):
+`claude-switch` rewrites the Keychain + ~/.claude.json, but a running Claude
+Code session was believed to hold the OLD account's OAuth token in memory,
+working for ~1h until refresh and then stalling.
+
+The mechanism: right after the swap, kill each active session and respawn with
 `--resume <session-id>` + an auto-resume prompt so Claude wakes up with
 the EXACT transcript that was in flight and immediately picks up work.
 No human input needed.

--- a/hooks/claude-identity/_watch.py
+++ b/hooks/claude-identity/_watch.py
@@ -34,10 +34,17 @@ import time
 
 
 HOME = os.path.expanduser("~")
-CACHE = os.path.join(HOME, ".claude", "rate-limit-cache.json")
-LOG = os.path.join(HOME, ".claude", "quota-watch.log")
-SWAP_LOG = os.path.join(HOME, ".claude", "swap-log.jsonl")
-IDENTITIES = os.path.join(HOME, ".claude", "identities")
+# Claude Code relocates its whole config tree when CLAUDE_CONFIG_DIR is set, and
+# the documented safe way to add a second account depends on that: log the new
+# account into an ISOLATED config dir and capture from there, so the live
+# credentials are never touched and no logout fires. Hard-coding ~/.claude here
+# would make the watcher read one account's state while the operator works in
+# another — silently, since every path would still resolve.
+CONFIG_DIR = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(HOME, ".claude")
+CACHE = os.path.join(CONFIG_DIR, "rate-limit-cache.json")
+LOG = os.path.join(CONFIG_DIR, "quota-watch.log")
+SWAP_LOG = os.path.join(CONFIG_DIR, "swap-log.jsonl")
+IDENTITIES = os.path.join(CONFIG_DIR, "identities")
 USER_MD = os.environ.get("USER_MD_PATH") or os.path.join(HOME, "aios", "USER.md")
 STALE_AFTER_SECS = 1800  # 30 min
 COOLDOWN_SECS = 900  # 15 min — prevent thrashing after a swap

--- a/hooks/claude-identity/_watch.py
+++ b/hooks/claude-identity/_watch.py
@@ -482,6 +482,13 @@ def main(self_path: str) -> None:
         # respawn behavior. Only meaningful for unattended overnight agents
         # that MUST keep working past the cap without a human present to
         # restart. For interactive use it's strictly noisier.
+        #
+        # NOTE (#15): the reason this path was originally built — "a running
+        # session keeps the old token in memory" — is false, measured. A live
+        # session adopts on its next API request. So the respawn no longer has a
+        # token-related job; it is a hard restart on rotation and nothing more.
+        # Left reachable because it is a documented opt-in and removing it is
+        # the maintainer's call, not a side effect of this port.
         if r.returncode != 0:
             # Swap failed — most commonly because there's only one account in
             # USER.md (rotation needs >= 2). Degrade quietly: no OS notification

--- a/hooks/claude-identity/_watch.py
+++ b/hooks/claude-identity/_watch.py
@@ -27,6 +27,7 @@ to force a specific account on a specific machine.
 """
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -36,6 +37,8 @@ HOME = os.path.expanduser("~")
 CACHE = os.path.join(HOME, ".claude", "rate-limit-cache.json")
 LOG = os.path.join(HOME, ".claude", "quota-watch.log")
 SWAP_LOG = os.path.join(HOME, ".claude", "swap-log.jsonl")
+IDENTITIES = os.path.join(HOME, ".claude", "identities")
+USER_MD = os.environ.get("USER_MD_PATH") or os.path.join(HOME, "aios", "USER.md")
 STALE_AFTER_SECS = 1800  # 30 min
 COOLDOWN_SECS = 900  # 15 min — prevent thrashing after a swap
 
@@ -74,29 +77,58 @@ def thresholds() -> tuple:
     return _threshold("CLAUDE_QUOTA_5H")[0], _threshold("CLAUDE_QUOTA_7D")[0]
 
 
+def _swap_log_tail(limit: int = 40) -> list:
+    """Most recent swap-log rows, newest first. Bounded read; malformed lines
+    are skipped rather than aborting the scan."""
+    if not os.path.exists(SWAP_LOG):
+        return []
+    rows = []
+    try:
+        with open(SWAP_LOG, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            if size == 0:
+                return []
+            block = min(65536, size)
+            f.seek(-block, os.SEEK_END)
+            lines = f.read().splitlines()
+        # A partial first line is likely when we seek into the middle of the
+        # file; json.loads rejects it and the skip below handles it.
+        for raw in reversed(lines[-limit:]):
+            try:
+                rows.append(json.loads(raw.decode()))
+            except Exception:
+                continue
+    except Exception:
+        return []
+    return rows
+
+
+def last_actual_swap() -> dict:
+    """The most recent row where the account genuinely changed.
+
+    `declined` rows are NOT swaps. They must be skipped here: a decline means we
+    looked and stayed put, so nothing about the session changed and there is
+    nothing to debounce. Counting one would arm the cooldown at the exact moment
+    the watcher most needs to keep looking — the other account's window may roll
+    over seconds later, and we would not notice for another COOLDOWN_SECS."""
+    for r in _swap_log_tail():
+        if r.get("action") == "rotate" and r.get("rc") == 0:
+            return r
+    return {}
+
+
 def recently_swapped() -> tuple[bool, int]:
     """Returns (True, seconds_since_last) if a swap happened within COOLDOWN_SECS.
     Thrashing guard: after a swap the running session keeps the old token in
     memory; its next turns report the OLD account's rate_limits against the NEW
     oauthAccount email in ~/.claude.json — without this cooldown we'd swap
     back immediately and ping-pong forever."""
-    if not os.path.exists(SWAP_LOG):
+    last = last_actual_swap()
+    if not last:
         return False, 0
-    try:
-        with open(SWAP_LOG, "rb") as f:
-            # read last line efficiently
-            f.seek(0, os.SEEK_END)
-            size = f.tell()
-            if size == 0:
-                return False, 0
-            block = min(4096, size)
-            f.seek(-block, os.SEEK_END)
-            last_line = f.read().splitlines()[-1]
-        last = json.loads(last_line.decode())
-        elapsed = int(time.time() - last.get("ts", 0))
-        return elapsed < COOLDOWN_SECS, elapsed
-    except Exception:
-        return False, 0
+    elapsed = int(time.time() - (last.get("ts") or 0))
+    return elapsed < COOLDOWN_SECS, elapsed
 
 
 def log(msg: str) -> None:
@@ -135,6 +167,124 @@ def _read_active_email() -> str:
         return ""
 
 
+# ── where to rotate ─────────────────────────────────────────────────────────
+# Rotation used to be a bare `switch`, which advances one position in the
+# USER.md list and wraps. With exactly two accounts — the common case — that
+# means exhausting B rotates straight back to A, whose 5h window has not rolled
+# yet. The session lands on a dead account and then sits out the cooldown there,
+# which is worse than not rotating at all.
+#
+# The data needed to avoid it is already in hand and was being thrown away:
+# `rate_limits` carries `resets_at` per window. Persisting the ACTIVE account's
+# limits on every tick is what lets the watcher reason about accounts it is not
+# currently on — otherwise it is blind to every account but one, and blind is
+# exactly what forces round-robin.
+
+
+def parse_accounts() -> list:
+    """Ordered account list from USER.md -> '## Anthropic accounts'.
+
+    Position is preference, not a cycle: #1 is home, the rest are overflow.
+    Same numbered-backtick format claude-identity.sh parses; kept in step with
+    it deliberately, because two parsers disagreeing about the account list is
+    the failure this file already fixed once for thresholds."""
+    out = []
+    try:
+        in_sec = False
+        with open(USER_MD, encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("## Anthropic accounts"):
+                    in_sec = True
+                    continue
+                if in_sec and line.startswith("## "):
+                    break
+                if in_sec:
+                    m = re.match(r"\s*\d+\.\s*`([^`]+)`", line)
+                    if m:
+                        out.append(m.group(1))
+    except FileNotFoundError:
+        log(f"USER.md not found at {USER_MD} — cannot determine the account list")
+    except Exception as e:
+        log(f"could not parse accounts from {USER_MD}: {type(e).__name__}: {e}")
+    return out
+
+
+def state_path(email: str) -> str:
+    return os.path.join(IDENTITIES, email, "last-limits.json")
+
+
+def record_state(email: str, cache: dict) -> None:
+    """Persist the active account's limits so that, once we have rotated away
+    from it, we can still reason about when its window frees up."""
+    if not email:
+        return
+    try:
+        os.makedirs(os.path.join(IDENTITIES, email), exist_ok=True)
+        dst = state_path(email)
+        tmp = dst + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump({
+                "email": email,
+                "recorded_at": int(time.time()),
+                "five_hour_pct": cache.get("five_hour_pct") or 0,
+                "five_hour_resets_at": cache.get("five_hour_resets_at"),
+                "seven_day_pct": cache.get("seven_day_pct") or 0,
+                "seven_day_resets_at": cache.get("seven_day_resets_at"),
+            }, f, indent=2)
+        os.replace(tmp, dst)
+        os.chmod(dst, 0o600)
+    except Exception as e:
+        log(f"record_state({email}) failed: {type(e).__name__}: {e}")
+
+
+def headroom(email: str, t5: int, t7: int) -> tuple:
+    """(available, why) for an account we are not currently on.
+
+    Available means: no evidence it is capped, or the window that capped it has
+    already rolled over. Absence of evidence is treated as available on purpose
+    — a never-seen account is the normal state right after setup, and refusing
+    to rotate to it would make the feature useless on day one."""
+    p = state_path(email)
+    if not os.path.exists(p):
+        return True, "no known state (assume fresh)"
+    try:
+        with open(p) as f:
+            s = json.load(f)
+    except Exception:
+        return True, "state unreadable (assume fresh)"
+    now = time.time()
+    for pct_key, reset_key, thr, label in (
+        ("five_hour_pct", "five_hour_resets_at", t5, "5h"),
+        ("seven_day_pct", "seven_day_resets_at", t7, "7d"),
+    ):
+        pct = s.get(pct_key) or 0
+        reset = s.get(reset_key)
+        if pct < thr:
+            continue
+        if reset and now > reset:
+            continue  # window rolled over — fresh again
+        when = time.strftime("%H:%M", time.localtime(reset)) if reset else "unknown"
+        return False, f"{label} at {round(pct)}% until {when}"
+    return True, "under thresholds"
+
+
+def pick_target(current: str, t5: int, t7: int) -> tuple:
+    """(email_or_None, reason). Preference is USER.md order, but an account is
+    only a candidate if its cap window has actually rolled."""
+    accts = parse_accounts()
+    if len(accts) < 2:
+        return None, f"need >= 2 accounts in USER.md (found {len(accts)})"
+    blocked = []
+    for email in accts:
+        if email == current:
+            continue
+        ok, why = headroom(email, t5, t7)
+        if ok:
+            return email, why
+        blocked.append(f"{email} ({why})")
+    return None, "all alternatives still capped: " + "; ".join(blocked)
+
+
 def main(self_path: str) -> None:
     try:
         t5, t7 = thresholds()
@@ -158,6 +308,12 @@ def main(self_path: str) -> None:
         pct7 = cache.get("seven_day_pct") or 0
         email = cache.get("email", "")
 
+        # Persist BEFORE deciding. This tick is the only moment we can observe
+        # the active account's numbers; once we rotate away it goes dark until
+        # we come back. The rotation decision below is only ever as good as this
+        # record, so it must not sit behind any of the early returns.
+        record_state(email, cache)
+
         # Thrashing guard — if we swapped recently, the session is still on
         # its old token and reporting misleading numbers against the new email.
         in_cooldown, elapsed = recently_swapped()
@@ -180,8 +336,27 @@ def main(self_path: str) -> None:
 
         log(f"TRIGGER ({action}): {reason}")
 
+        # Where to — not a blind advance. Declining to rotate is a legitimate
+        # outcome and a better one than landing on an account that is still
+        # capped, so it is logged as its own action rather than as a failure.
+        target, why = pick_target(email, t5, t7)
+        if not target:
+            log(f"NO ROTATION — {why}. Staying on {email}; its window rolls on its own.")
+            append_swap_log({
+                "ts": int(time.time()),
+                "from": email,
+                "action": "declined",
+                "reason": f"{reason} | {why}",
+                "five_hour_pct": pct5,
+                "seven_day_pct": pct7,
+                "rc": None,
+            })
+            notify(f"quota {round(pct5)}% — no account with capacity. {why}")
+            return
+
+        log(f"target: {target} ({why})")
         r = subprocess.run(
-            [self_path, "switch"], capture_output=True, text=True
+            [self_path, "switch", target], capture_output=True, text=True
         )
         log(
             f"swap result: rc={r.returncode} "

--- a/hooks/claude-identity/_watch.py
+++ b/hooks/claude-identity/_watch.py
@@ -39,6 +39,40 @@ SWAP_LOG = os.path.join(HOME, ".claude", "swap-log.jsonl")
 STALE_AFTER_SECS = 1800  # 30 min
 COOLDOWN_SECS = 900  # 15 min — prevent thrashing after a swap
 
+# ── rotation thresholds ─────────────────────────────────────────────────────
+# This module is the SINGLE owner of the default. claude-identity.sh used to
+# carry its own `THRESHOLD_5H="${CLAUDE_QUOTA_5H:-98}"`, which nothing read and
+# nothing exported — and the hot path (statusLine -> _cache.py -> _watch.py)
+# never touches the shell at all, so an operator editing that line changed
+# nothing and got no error. Two declarations of one value is one too many; the
+# one the consumer reads is the only one that exists now.
+DEFAULT_THRESHOLD_PCT = 98
+
+
+def _threshold(name: str) -> tuple:
+    """(value, source) for one threshold. `source` says where the value that is
+    ACTUALLY in force came from — a rejected override reports the default, not
+    'environment'. Mislabelling that is the same failure this fix exists for."""
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return DEFAULT_THRESHOLD_PCT, "built-in default"
+    try:
+        v = int(raw)
+    except ValueError:
+        log(f"{name}={raw!r} is not an integer — using {DEFAULT_THRESHOLD_PCT}")
+        return DEFAULT_THRESHOLD_PCT, f"built-in default ({name} rejected: not an integer)"
+    if not 1 <= v <= 100:
+        # A 0 would rotate on every tick; a 150 would never rotate. Both are
+        # almost certainly typos, and both fail silently if we honour them.
+        log(f"{name}={v} out of range 1-100 — using {DEFAULT_THRESHOLD_PCT}")
+        return DEFAULT_THRESHOLD_PCT, f"built-in default ({name}={v} out of range 1-100)"
+    return v, "environment"
+
+
+def thresholds() -> tuple:
+    """(5h, 7d) rotation thresholds actually in force."""
+    return _threshold("CLAUDE_QUOTA_5H")[0], _threshold("CLAUDE_QUOTA_7D")[0]
+
 
 def recently_swapped() -> tuple[bool, int]:
     """Returns (True, seconds_since_last) if a swap happened within COOLDOWN_SECS.
@@ -103,8 +137,7 @@ def _read_active_email() -> str:
 
 def main(self_path: str) -> None:
     try:
-        t5 = int(os.environ.get("CLAUDE_QUOTA_5H", "98"))
-        t7 = int(os.environ.get("CLAUDE_QUOTA_7D", "98"))
+        t5, t7 = thresholds()
 
         if not os.path.exists(CACHE):
             log("no cache yet — skip (is the Stop hook installed?)")
@@ -236,7 +269,15 @@ if __name__ == "__main__":
     # argv: self-path (claude-identity.sh)
     # Note: come-home removed 2026-04-23, so the second-arg "primary" from
     # claude-identity.sh `watch` is now accepted but ignored for back-compat.
+    if len(sys.argv) >= 2 and sys.argv[1] == "--threshold":
+        # Report the value THIS process would enforce. The point is that it is
+        # answered by the consumer, so it cannot drift from what actually runs.
+        t5, s5 = _threshold("CLAUDE_QUOTA_5H")
+        t7, s7 = _threshold("CLAUDE_QUOTA_7D")
+        print(f"5h: {t5}%  ({s5})")
+        print(f"7d: {t7}%  ({s7})")
+        sys.exit(0)
     if len(sys.argv) < 2:
-        sys.stderr.write("_watch.py: usage: _watch.py <self_path>\n")
+        sys.stderr.write("_watch.py: usage: _watch.py <self_path> | --threshold\n")
         sys.exit(2)
     main(sys.argv[1])

--- a/hooks/claude-identity/_watch.py
+++ b/hooks/claude-identity/_watch.py
@@ -151,13 +151,22 @@ def append_swap_log(row: dict) -> None:
 
 
 def notify(msg: str) -> None:
+    """Best-effort desktop notification. Never raises, never blocks the tick.
+
+    Platform-detected rather than macOS-only: `osascript` simply does not exist
+    off macOS, and the except below swallows that — so on Linux every
+    notification this module sends was silently dropped, including the two that
+    matter most (no account has capacity; a rotation was not adopted). A missing
+    notifier is still a no-op, but now it is the RIGHT notifier that is missing."""
+    if sys.platform == "darwin":
+        cmd = ["osascript", "-e",
+               f'display notification "{msg}" with title "Claude quota watch"']
+    else:
+        # libnotify is near-universal on desktop Linux; absent on headless
+        # boxes, where the log is the channel that matters anyway.
+        cmd = ["notify-send", "Claude quota watch", msg]
     try:
-        subprocess.run(
-            ["osascript", "-e",
-             f'display notification "{msg}" with title "Claude quota watch"'],
-            check=False,
-            timeout=5,
-        )
+        subprocess.run(cmd, check=False, timeout=5)
     except Exception:
         pass
 
@@ -167,11 +176,80 @@ def _read_active_email() -> str:
     Used to fill the swap-notification marker's `to` field — the cache still
     has the OLD email at this point (it was the trigger). Empty string on any
     error so the marker write doesn't crash the watch tick."""
+    # Same beside-or-inside rule as the other components: .claude.json sits next
+    # to the config dir normally and inside it when relocated.
+    for p in (os.path.join(CONFIG_DIR, ".claude.json"),
+              os.path.join(HOME, ".claude.json")):
+        try:
+            with open(p) as f:
+                return json.load(f).get("oauthAccount", {}).get("emailAddress", "")
+        except Exception:
+            continue
+    return ""
+
+
+# ── did the live session actually adopt the swap? ───────────────────────────
+# The one hole this design cannot close by itself. Rotating the credential is
+# our code; a RUNNING session picking it up is Claude Code's internal behaviour
+# (it stat()s the credential store on the API request path and purges its token
+# caches when mtime changes). That was measured, but it is not a contract we
+# control — an upstream change could remove it, and the failure would be MUTE:
+# the swap succeeds, the log says "rotated", and the session keeps burning the
+# capped account until it hits the wall the autopilot exists to avoid.
+#
+# The detector is cheap because we only ever rotate to an account with real
+# capacity (pick_target). So after a successful swap the reported percentage
+# MUST fall. If it is still high minutes later, the session never adopted.
+ADOPTION_GRACE_SECS = 120   # let the session make its next request
+ADOPTION_WINDOW_SECS = 900  # past this, stop looking
+ADOPTION_DROP_PTS = 3       # minimum fall that counts as adoption
+ALERT_FILE = os.path.join(CONFIG_DIR, "rotation-alert.json")
+
+
+def check_adoption(cache: dict) -> None:
+    """Warn if a completed rotation never reached the running session."""
+    last = last_actual_swap()
+    if not last:
+        return
+    now = time.time()
+    elapsed = now - (last.get("ts") or 0)
+    if elapsed < ADOPTION_GRACE_SECS or elapsed > ADOPTION_WINDOW_SECS:
+        return
+    # The cache must be NEWER than the swap, or we are reading the old photo and
+    # would report a failure that has not had a chance to happen yet.
+    if (cache.get("captured_at") or 0) <= (last.get("ts") or 0):
+        return
+    before = last.get("five_hour_pct") or 0
+    current = cache.get("five_hour_pct") or 0
+    if current < before - ADOPTION_DROP_PTS:
+        # It fell: adopted. Clear any previous alert so a recovered system does
+        # not keep showing a stale warning.
+        if os.path.exists(ALERT_FILE):
+            try:
+                os.remove(ALERT_FILE)
+            except OSError:
+                pass
+        return
+    msg = (
+        f"rotation to {_read_active_email()} happened {int(elapsed)}s ago but 5h usage "
+        f"is still {round(current)}% (was {round(before)}% before the swap). The live "
+        f"session did not adopt the new credential — most likely Claude Code stopped "
+        f"re-reading the credential store. Restart open sessions and check whether an "
+        f"update changed that behaviour."
+    )
+    log(f"ADOPTION FAILED: {msg}")
+    notify(msg)
     try:
-        with open(os.path.join(HOME, ".claude.json")) as f:
-            return json.load(f).get("oauthAccount", {}).get("emailAddress", "")
-    except Exception:
-        return ""
+        with open(ALERT_FILE, "w") as f:
+            json.dump({
+                "ts": int(now),
+                "kind": "adoption_failed",
+                "message": msg,
+                "pct_before": before,
+                "pct_now": current,
+            }, f)
+    except Exception as e:
+        log(f"alert write failed: {type(e).__name__}: {e}")
 
 
 # ── where to rotate ─────────────────────────────────────────────────────────
@@ -320,6 +398,12 @@ def main(self_path: str) -> None:
         # we come back. The rotation decision below is only ever as good as this
         # record, so it must not sit behind any of the early returns.
         record_state(email, cache)
+
+        # Deliberately BEFORE the cooldown check. The cooldown returns early,
+        # and the cooldown window is exactly when a failed adoption is visible —
+        # putting this after it would mean the one condition the detector exists
+        # for is the one it never runs in.
+        check_adoption(cache)
 
         # Thrashing guard — if we swapped recently, the session is still on
         # its old token and reporting misleading numbers against the new email.

--- a/hooks/claude-identity/aios-claude-quota-watch.service
+++ b/hooks/claude-identity/aios-claude-quota-watch.service
@@ -1,0 +1,42 @@
+; aios-claude-quota-watch.service — systemd user unit (Linux).
+;
+; The Linux equivalent of com.aios.claude-quota-watch.plist. Same role: a
+; SAFETY-NET watcher. Fast-path detection lives in _cache.py, which the
+; statusLine pipe drives several times per turn; this unit exists for sessions
+; where that pipe is broken or absent.
+;
+; Install (as your own user — NOT root, the credentials are per-user):
+;   mkdir -p ~/.config/systemd/user
+;   cp ~/aios/hooks/claude-identity/aios-claude-quota-watch.{service,timer} \
+;      ~/.config/systemd/user/
+;   systemctl --user daemon-reload
+;   systemctl --user enable --now aios-claude-quota-watch.timer
+;
+; Verify / debug:
+;   systemctl --user list-timers aios-claude-quota-watch.timer
+;   systemctl --user start aios-claude-quota-watch.service   # trigger once
+;   tail -f ~/.claude/quota-watch.log
+;
+; Remove:
+;   systemctl --user disable --now aios-claude-quota-watch.timer
+;
+; Note: if you are not logged into a graphical session, systemd may stop your
+; user manager on logout and the timer with it. `loginctl enable-linger $USER`
+; keeps it running. This is the closest Linux gets to launchd's RunAtLoad
+; behaviour for a headless box.
+
+[Unit]
+Description=AIOS Claude Code quota watcher (safety net)
+Documentation=file:%h/aios/hooks/claude-identity/README.md
+
+[Service]
+Type=oneshot
+# %h is the user's home. Path assumes the vault is at ~/aios, same assumption
+# the plist makes; symlink ~/aios or edit this line if yours lives elsewhere.
+ExecStart=/usr/bin/env bash -c '"$HOME/aios/hooks/claude-identity/claude-identity.sh" watch'
+
+# The watcher writes its own log; keeping the unit's stdout in the journal
+# separates "the timer fired" from "the watcher decided something", which is
+# the distinction you need when nothing appears to be happening.
+StandardOutput=journal
+StandardError=journal

--- a/hooks/claude-identity/aios-claude-quota-watch.timer
+++ b/hooks/claude-identity/aios-claude-quota-watch.timer
@@ -1,0 +1,29 @@
+; aios-claude-quota-watch.timer — systemd user timer (Linux).
+;
+; Mirrors the plist's StartInterval=1800 + RunAtLoad=true.
+;
+; Why 30 minutes and not 60 seconds: on macOS a 60s interval pinned the machine
+; awake (constant DarkWake cycles). The Linux failure mode is different but the
+; conclusion is the same — this is the SAFETY NET, not the detector. Real-time
+; detection comes from _cache.py, which now tightens to a 3s evaluation interval
+; as the account approaches its cap. A tight timer here would burn wakeups to
+; duplicate work the statusLine pipe already does better.
+
+[Unit]
+Description=Run the AIOS Claude Code quota watcher every 30 minutes
+Documentation=file:%h/aios/hooks/claude-identity/README.md
+
+[Timer]
+; launchd's RunAtLoad: fire shortly after the user session comes up. 1 minute of
+; delay rather than 0 so it does not compete with login.
+OnStartupSec=1min
+OnUnitActiveSec=30min
+; Let systemd batch this with other wakeups instead of demanding its own.
+AccuracySec=1min
+; If the machine was asleep or off when a run was due, run once on resume —
+; the launchd agent gets this for free, systemd needs it asked for.
+Persistent=true
+Unit=aios-claude-quota-watch.service
+
+[Install]
+WantedBy=timers.target

--- a/hooks/claude-identity/claude-identity.sh
+++ b/hooks/claude-identity/claude-identity.sh
@@ -141,6 +141,63 @@ fi
 
 die() { echo "${RED}error:${RESET} $*" >&2; exit 1; }
 
+# ---- credential backend ----------------------------------------------------
+# macOS stores the OAuth blob in Keychain. Linux and Windows store the SAME blob
+# as a plaintext JSON file at $CONFIG_DIR/.credentials.json, mode 600 — this is
+# Claude Code's own layout, not a choice made here, so libsecret/secret-tool or
+# any other keyring would be storing it somewhere the app never reads.
+#
+# Because the blob is identical either way, every caller above and below this
+# block stays platform-agnostic; only read and write differ.
+case "$(uname -s)" in
+  Darwin) CRED_BACKEND="keychain" ;;
+  *)      CRED_BACKEND="file" ;;
+esac
+CRED_FILE="$CONFIG_DIR/.credentials.json"
+
+cred_source() {
+  case "$CRED_BACKEND" in
+    keychain) printf "Keychain '%s'" "$KEYCHAIN_SERVICE" ;;
+    file)     printf '%s' "$CRED_FILE" ;;
+  esac
+}
+
+cred_read() {
+  case "$CRED_BACKEND" in
+    keychain)
+      security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null || return 1
+      ;;
+    file)
+      [ -f "$CRED_FILE" ] || return 1
+      cat "$CRED_FILE" || return 1
+      ;;
+  esac
+}
+
+cred_write() {
+  local blob="$1"
+  case "$CRED_BACKEND" in
+    keychain)
+      security add-generic-password -U -s "$KEYCHAIN_SERVICE" -a "$USER" -w "$blob" \
+        >/dev/null 2>&1 || return 1
+      ;;
+    file)
+      # Validate before the write. On this path a bad blob would REPLACE a
+      # working credential with garbage, and the operator would discover it as
+      # a logged-out session rather than as an error from this tool.
+      printf '%s' "$blob" | python3 -c "import json,sys; json.load(sys.stdin)" 2>/dev/null \
+        || die "refusing to write a malformed credential blob to $CRED_FILE"
+      local tmp="$CRED_FILE.tmp.$$"
+      ( umask 077; printf '%s' "$blob" > "$tmp" ) || return 1
+      chmod 600 "$tmp"
+      # Atomic, and the rename bumps mtime — which is the signal a live session
+      # rides to pick the new credential up. A truncate-and-write would both
+      # risk a torn read and, on some filesystems, leave mtime unchanged.
+      mv -f "$tmp" "$CRED_FILE" || return 1
+      ;;
+  esac
+}
+
 # ---- parse USER.md for the ordered account list ----
 parse_accounts() {
   [ -f "$USER_MD" ] || die "USER.md not found at $USER_MD (set USER_MD_PATH if elsewhere)"
@@ -174,8 +231,8 @@ capture_current() {
   chmod 700 "$IDENTITIES_DIR" "$dir"
 
   local blob
-  blob=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null) || \
-    die "could not read Keychain '$KEYCHAIN_SERVICE'. Is this account fully logged in to Claude Code?"
+  blob=$(cred_read) || \
+    die "could not read $(cred_source). Is this account fully logged in to Claude Code?"
   printf '%s' "$blob" > "$dir/keychain.json"
   chmod 600 "$dir/keychain.json"
 
@@ -204,8 +261,7 @@ restore_identity() {
 
   local blob
   blob=$(cat "$dir/keychain.json")
-  security add-generic-password -U -s "$KEYCHAIN_SERVICE" -a "$USER" -w "$blob" >/dev/null 2>&1 || \
-    die "security add-generic-password failed"
+  cred_write "$blob" || die "credential write failed ($CRED_BACKEND: $(cred_source))"
 
   python3 - <<PY
 import json, shutil
@@ -288,7 +344,7 @@ First-time setup per account:
   3. Repeat for each account in USER.md → ## Anthropic accounts
 
 Safety:
-  - Swaps Keychain '$KEYCHAIN_SERVICE' blob + .claude.json oauthAccount + userID
+  - Swaps the credential blob ($(cred_source)) + .claude.json oauthAccount + userID
   - Always captures outgoing identity before swap (refresh tokens rotate)
   - Never touches mcpServers, project configs, or history
   - Backup written to $CLAUDE_JSON.bak-claude-switch on every swap

--- a/hooks/claude-identity/claude-identity.sh
+++ b/hooks/claude-identity/claude-identity.sh
@@ -112,12 +112,23 @@
 set -euo pipefail
 
 USER_MD="${USER_MD_PATH:-$HOME/aios/USER.md}"
-CLAUDE_JSON="$HOME/.claude.json"
-IDENTITIES_DIR="$HOME/.claude/identities"
+# Claude Code relocates its whole config tree when CLAUDE_CONFIG_DIR is set, and
+# the safe way to add a second account leans on exactly that: log the new account
+# into an isolated config dir and `--capture` from there, so the live credentials
+# are never touched and no logout fires (see the /login revoke note below).
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+# .claude.json sits BESIDE the config dir in the default layout but INSIDE it
+# when relocated. Try the relocated position first, then fall back.
+if [ -f "$CONFIG_DIR/.claude.json" ]; then
+  CLAUDE_JSON="$CONFIG_DIR/.claude.json"
+else
+  CLAUDE_JSON="$HOME/.claude.json"
+fi
+IDENTITIES_DIR="$CONFIG_DIR/identities"
 KEYCHAIN_SERVICE="Claude Code-credentials"
-CACHE_FILE="$HOME/.claude/rate-limit-cache.json"
-WATCH_LOG="$HOME/.claude/quota-watch.log"
-SWAP_LOG="$HOME/.claude/swap-log.jsonl"
+CACHE_FILE="$CONFIG_DIR/rate-limit-cache.json"
+WATCH_LOG="$CONFIG_DIR/quota-watch.log"
+SWAP_LOG="$CONFIG_DIR/swap-log.jsonl"
 
 # NOTE: the rotation thresholds are intentionally NOT defined here — _watch.py
 # owns them. See the "Environment overrides" block above.

--- a/hooks/claude-identity/claude-identity.sh
+++ b/hooks/claude-identity/claude-identity.sh
@@ -94,6 +94,14 @@
 #   CLAUDE_QUOTA_5H=98      rotate when 5h pct >= this
 #   CLAUDE_QUOTA_7D=98      rotate when 7d pct >= this
 #
+# These are read by _watch.py, which OWNS the default — this script deliberately
+# does not define one. It used to (`THRESHOLD_5H="${CLAUDE_QUOTA_5H:-98}"`), and
+# that copy was never read by anything: nothing in this file consumed it, it was
+# never exported, and the hot path (statusLine -> _cache.py -> _watch.py) never
+# runs this script at all. An operator who edited it got silence, not an effect.
+# One value, one owner. Export the env vars to change it; `watch --threshold`
+# prints what is actually in force.
+#
 # Note (2026-04-23): come-home semantics removed for topology-independence.
 # The watcher now does pure rotate-only: when current account hits its cap,
 # advance to the next account in USER.md. Round-robin alternation across
@@ -111,8 +119,8 @@ CACHE_FILE="$HOME/.claude/rate-limit-cache.json"
 WATCH_LOG="$HOME/.claude/quota-watch.log"
 SWAP_LOG="$HOME/.claude/swap-log.jsonl"
 
-THRESHOLD_5H="${CLAUDE_QUOTA_5H:-98}"
-THRESHOLD_7D="${CLAUDE_QUOTA_7D:-98}"
+# NOTE: the rotation thresholds are intentionally NOT defined here — _watch.py
+# owns them. See the "Environment overrides" block above.
 
 if [ -t 1 ]; then
   BOLD=$'\033[1m'; DIM=$'\033[2m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; BLUE=$'\033[34m'; RED=$'\033[31m'; RESET=$'\033[0m'
@@ -333,6 +341,12 @@ cmd_cache() {
 cmd_watch() {
   # _watch.py used to take a `primary` arg for come-home logic; come-home
   # was removed 2026-04-23 for topology-independence. Only self-path now.
+  if [ "${1:-}" = "--threshold" ]; then
+    # Ask the process that actually enforces it. Reading a number out of this
+    # file would just recreate the second source of truth we deleted.
+    python3 "$SELF_DIR/_watch.py" --threshold
+    return
+  fi
   python3 "$SELF_DIR/_watch.py" "$0"
 }
 

--- a/hooks/claude-identity/claude-identity.sh
+++ b/hooks/claude-identity/claude-identity.sh
@@ -6,13 +6,17 @@
 # ============================================================================
 # One tool that handles three concerns for running Claude Code across multiple
 # Anthropic accounts (e.g., a primary + an overflow to dodge the 5h/7d rate
-# limits). All state is self-contained in your vault + ~/.claude/.
+# limits). All state is self-contained in your vault + your Claude config dir.
+#
+# Platforms: macOS and Linux. The credential store is detected, not assumed —
+# Keychain on macOS, and on Linux the plaintext $CONFIG_DIR/.credentials.json
+# (mode 600) that Claude Code itself writes. Windows uses the same file layout
+# as Linux but has no scheduler wired here and is untested.
 #
 # 1. Identity: save/restore/rotate between Anthropic accounts.
-#    Swaps the Keychain 'Claude Code-credentials' blob + the oauthAccount
-#    object + userID in ~/.claude.json atomically. Never touches mcpServers
-#    or project configs. Captures the outgoing identity before every swap
-#    (refresh tokens rotate).
+#    Swaps the credential blob + the oauthAccount object + userID in
+#    .claude.json atomically. Never touches mcpServers or project configs.
+#    Captures the outgoing identity before every swap (refresh tokens rotate).
 #
 # 2. Cache: read a Claude Code hook payload from stdin, extract the
 #    rate_limits object + current account email, write to
@@ -24,7 +28,7 @@
 #    to run under launchd every few minutes.
 #
 # ============================================================================
-# INSTALL ON A NEW MACHINE (macOS)
+# INSTALL ON A NEW MACHINE (macOS + Linux)
 # ============================================================================
 # All paths assume the vault is at ~/aios. Adjust if cloned elsewhere.
 #
@@ -38,10 +42,19 @@
 #   1. `primary@example.com` — optional label/context
 #   2. `overflow@example.com`
 #
-# Step 3 — capture each identity once. For each account, log into it via the
-# normal Claude Code flow, then:
+# Step 3 — capture each identity once.
 #
 #   claude-switch --capture
+#
+# SAFETY: do NOT just /login as the second account and capture. /login performs
+# a server-side revoke of the previous refresh token (POST {TOKEN_URL}/revoke,
+# token_type_hint: "refresh_token"), so depending on ordering it can kill an
+# identity you already captured. Log the additional account into an ISOLATED
+# config dir and capture from there — nothing to log out of, live credentials
+# untouched:
+#
+#   CLAUDE_CONFIG_DIR=~/.claude-acct-2 claude    # /login as account 2, then /exit
+#   CLAUDE_CONFIG_DIR=~/.claude-acct-2 claude-switch --capture
 #
 # Step 4 — wire the cache writer to the statusLine command. The statusline
 # is the ONLY Claude Code surface that receives rate_limits on stdin (Stop
@@ -65,14 +78,28 @@
 #   json.dump(d, open(p, "w"), indent=2)
 #   PY
 #
-# Step 5 — load the launchd agent (runs `watch` every 10 min, swaps when near cap):
+# Step 5 — install the safety-net scheduler.
 #
+# macOS (launchd):
 #   cp ~/aios/hooks/claude-identity/com.aios.claude-quota-watch.plist ~/Library/LaunchAgents/
 #   launchctl load ~/Library/LaunchAgents/com.aios.claude-quota-watch.plist
 #
+# Linux (systemd USER units — never system; the credentials are per-user):
+#   mkdir -p ~/.config/systemd/user
+#   cp ~/aios/hooks/claude-identity/aios-claude-quota-watch.service ~/.config/systemd/user/
+#   cp ~/aios/hooks/claude-identity/aios-claude-quota-watch.timer   ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now aios-claude-quota-watch.timer
+#   # headless box? `loginctl enable-linger $USER` so the timer survives logout
+#
+# Either way this is the SAFETY NET, not the detector. Real-time detection runs
+# from the statusLine pipe via _cache.py, which tightens to a 3s evaluation
+# interval as the account approaches its cap.
+#
 # Verify: `claude-whoami` works, `claude mcp list` unchanged, after a few
-# minutes `~/.claude/rate-limit-cache.json` appears and stays fresh as you use
-# Claude Code. The launchd log at ~/.claude/quota-watch.log records each check.
+# minutes `$CONFIG_DIR/rate-limit-cache.json` appears and stays fresh as you use
+# Claude Code. The watcher log at $CONFIG_DIR/quota-watch.log records each check.
+# `claude-switch watch --threshold` prints the threshold actually in force.
 #
 # ============================================================================
 # SUBCOMMANDS

--- a/tests/adoption-detector.test.sh
+++ b/tests/adoption-detector.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# adoption-detector.test.sh — catch a rotation the live session never picked up.
+#
+# This guards the one premise the autopilot cannot enforce. Rotating the
+# credential is our code; a RUNNING session adopting it is Claude Code's own
+# behaviour — it stat()s the credential store on the API request path and purges
+# its token caches when mtime changes. Measured, but not a contract we control.
+#
+# If an upstream change removed it, the failure would be MUTE: the swap succeeds,
+# the log says "rotated", and the session keeps burning the capped account until
+# it hits the exact wall the autopilot exists to prevent. Nothing would go red.
+#
+# The signal is cheap: we only rotate to an account with real capacity, so the
+# reported percentage MUST fall after a successful swap. Still high minutes
+# later means it never landed.
+#
+# Scenario 4 is the one that keeps this honest in the other direction — a cache
+# older than the swap must NOT raise, or the detector fires on every rotation
+# before the first post-swap reading even exists.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WATCH="$ROOT/hooks/claude-identity/_watch.py"
+PASS=0; FAIL=0
+ok(){ printf '  ok   %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/ad-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# swap_at <secs_ago> <pct_before>   — seed a successful rotation in the log
+swap_at(){
+  python3 - "$WORK/swap-log.jsonl" "$1" "$2" <<'PYEOF'
+import json, sys, time
+json_row = {"ts": int(time.time()) - int(sys.argv[2]), "action": "rotate", "rc": 0,
+            "from": "old@example.com", "five_hour_pct": float(sys.argv[3])}
+open(sys.argv[1], "w").write(json.dumps(json_row) + "\n")
+PYEOF
+}
+
+# run_check <cache_age_secs_ago> <pct_now>
+run_check(){
+  rm -f "$WORK/rotation-alert.json"
+  # PATH without notify-send/osascript so the probe cannot pop a real toast.
+  CLAUDE_CONFIG_DIR="$WORK" PATH="/nonexistent" /usr/bin/python3 - "$WATCH" "$1" "$2" <<'PYEOF'
+import importlib.util, sys, time
+spec = importlib.util.spec_from_file_location("w", sys.argv[1])
+w = importlib.util.module_from_spec(spec); spec.loader.exec_module(w)
+cache = {"captured_at": time.time() - float(sys.argv[2]),
+         "five_hour_pct": float(sys.argv[3]), "email": "new@example.com"}
+w.check_adoption(cache)
+PYEOF
+}
+
+alert_exists(){ [ -f "$WORK/rotation-alert.json" ]; }
+
+echo "adoption-detector: $WATCH"
+
+# 1. Inside the grace period: too early to judge, must stay quiet.
+swap_at 30 99
+run_check 5 99
+if ! alert_exists; then ok "silent inside the grace period"; else
+  no "silent inside the grace period" "alerted before the session could react"; fi
+
+# 2. Past grace, usage fell -> adopted, no alert.
+swap_at 300 99
+run_check 5 20
+if ! alert_exists; then ok "no alert when usage fell after the swap"; else
+  no "no alert when usage fell after the swap" "false positive on a healthy rotation"; fi
+
+# 3. Past grace, usage still high -> the session never adopted.
+swap_at 300 99
+run_check 5 99
+if alert_exists && grep -q "did not adopt" "$WORK/rotation-alert.json"; then
+  ok "alerts when usage did not fall after the swap"
+else
+  no "alerts when usage did not fall after the swap" \
+     "$( [ -f "$WORK/rotation-alert.json" ] && cat "$WORK/rotation-alert.json" || echo 'no alert file')"; fi
+
+# 4. A cache OLDER than the swap is the pre-swap photo — judging on it would
+#    fire on every single rotation before the first fresh reading exists.
+swap_at 300 99
+run_check 600 99
+if ! alert_exists; then ok "ignores a cache older than the swap"; else
+  no "ignores a cache older than the swap" "judged on the pre-swap reading"; fi
+
+# 5. Past the window entirely: stop looking rather than alert forever.
+swap_at 5000 99
+run_check 5 99
+if ! alert_exists; then ok "stops looking past the observation window"; else
+  no "stops looking past the observation window" "still alerting hours later"; fi
+
+# 6. A recovered rotation must CLEAR a previous alert, not leave a stale one
+#    that trains the operator to ignore the file.
+swap_at 300 99
+run_check 5 99
+alert_exists || no "setup for clear-on-recovery" "expected an alert first"
+swap_at 300 99
+run_check 5 10
+if ! alert_exists; then ok "clears a previous alert once a rotation lands"; else
+  no "clears a previous alert once a rotation lands" "stale alert survives recovery"; fi
+
+# 7. A `declined` row is not a rotation and must never be judged for adoption.
+python3 - "$WORK/swap-log.jsonl" <<'PYEOF'
+import json, sys, time
+open(sys.argv[1], "w").write(json.dumps(
+    {"ts": int(time.time()) - 300, "action": "declined", "rc": None,
+     "five_hour_pct": 99}) + "\n")
+PYEOF
+run_check 5 99
+if ! alert_exists; then ok "a declined rotation is never judged for adoption"; else
+  no "a declined rotation is never judged for adoption" "nothing was swapped"; fi
+
+# 8. The alert must survive a missing notifier — on Linux `osascript` does not
+#    exist, and the original code swallowed that, dropping every notification.
+if grep -q 'notify-send' "$WATCH" && grep -q 'sys.platform == "darwin"' "$WATCH"; then
+  ok "notify picks a notifier per platform instead of assuming osascript"
+else
+  no "notify picks a notifier per platform instead of assuming osascript" \
+     "off macOS every notification is silently dropped"; fi
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/credential-backend.test.sh
+++ b/tests/credential-backend.test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# credential-backend.test.sh — the platform-detected credential store.
+#
+# macOS keeps the OAuth blob in Keychain; Linux and Windows keep the SAME blob as
+# a plaintext JSON file at $CONFIG_DIR/.credentials.json, mode 600. That is
+# Claude Code's own layout, not a choice made here — which is why the Linux
+# equivalent is a plain file and not libsecret/secret-tool: a keyring would be
+# storing the credential somewhere the application never looks.
+#
+# Two properties below are load-bearing and neither is obvious from reading:
+#
+#   * The write must VALIDATE before replacing. On this path a bad blob
+#     overwrites a working credential, and the operator meets the failure as a
+#     logged-out session rather than as an error from this tool.
+#   * The write must be ATOMIC VIA RENAME. The mtime bump is the signal a live
+#     session rides to pick the new credential up on its next API request; a
+#     truncate-and-write risks a torn read and can leave mtime unchanged.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$ROOT/hooks/claude-identity/claude-identity.sh"
+PASS=0; FAIL=0
+ok(){ printf '  ok   %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/cb-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# Extract the backend block only. Sourcing the whole script would run its
+# dispatch; these are pure functions and are exercised as such.
+sed -n '/^# ---- credential backend/,/^# ---- parse USER.md/p' "$SRC" \
+  | sed '$d' > "$WORK/backend.sh"
+
+harness() {  # harness <body>
+  CONFIG_DIR="$WORK" bash -c '
+    set -uo pipefail
+    RED=""; RESET=""
+    die() { echo "error: $*" >&2; exit 1; }
+    KEYCHAIN_SERVICE="Claude Code-credentials"
+    CONFIG_DIR="'"$WORK"'"
+    . "'"$WORK"'/backend.sh"
+    '"$1"'
+  '
+}
+
+echo "credential-backend: $SRC"
+
+# 1. The block is extractable and self-contained — if this breaks, everything
+#    below is measuring the harness rather than the code.
+if [ -s "$WORK/backend.sh" ] && grep -q 'cred_write()' "$WORK/backend.sh"; then
+  ok "backend block extracts cleanly"
+else
+  no "backend block extracts cleanly" "got $(wc -l < "$WORK/backend.sh") lines"; fi
+
+# 2. Non-Darwin selects the file backend. (uname is the real one here; on a mac
+#    runner this asserts keychain instead, which is equally correct.)
+out="$(harness 'echo "$CRED_BACKEND"')"
+expected="file"; [ "$(uname -s)" = "Darwin" ] && expected="keychain"
+if [ "$out" = "$expected" ]; then
+  ok "platform detection selects '$expected' on $(uname -s)"
+else
+  no "platform detection selects '$expected' on $(uname -s)" "got: $out"; fi
+
+# The remaining cases exercise the file path. On macOS they would need a real
+# Keychain, so skip rather than assert something untrue.
+if [ "$expected" = "keychain" ]; then
+  echo "  skip remaining (file-backend cases) — this runner is macOS"
+  printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"; [ "$FAIL" -eq 0 ]; exit $?
+fi
+
+# 3. Round-trip: what goes in comes back out byte for byte.
+blob='{"claudeAiOauth":{"accessToken":"tok-abc","refreshToken":"ref-xyz"}}'
+harness 'cred_write '"'"''"$blob"''"'"'' >/dev/null 2>&1
+out="$(harness 'cred_read')"
+if [ "$out" = "$blob" ]; then ok "write then read round-trips exactly"; else
+  no "write then read round-trips exactly" "got: $out"; fi
+
+# 4. The stored file is 0600 — it is a bearer credential in plaintext.
+mode="$(stat -c '%a' "$WORK/.credentials.json" 2>/dev/null || stat -f '%Lp' "$WORK/.credentials.json")"
+if [ "$mode" = "600" ]; then ok "credential file is mode 600"; else
+  no "credential file is mode 600" "got: $mode"; fi
+
+# 5. THE ONE THAT MATTERS: malformed input must not replace a working credential.
+harness 'cred_write "not json at all"' >/dev/null 2>&1
+out="$(harness 'cred_read')"
+if [ "$out" = "$blob" ]; then
+  ok "a malformed blob is refused and the good credential survives"
+else
+  no "a malformed blob is refused and the good credential survives" \
+     "credential is now: $out"; fi
+
+# 6. ...and it fails loudly rather than returning success.
+if ! harness 'cred_write "not json at all"' >/dev/null 2>&1; then
+  ok "refusing a malformed blob is a non-zero exit"
+else
+  no "refusing a malformed blob is a non-zero exit" "it reported success"; fi
+
+# 7. No temp file is left behind on the rejected path.
+if [ -z "$(find "$WORK" -maxdepth 1 -name '.credentials.json.tmp.*' 2>/dev/null)" ]; then
+  ok "no temp file left behind after a refused write"
+else
+  no "no temp file left behind after a refused write" "$(ls -a "$WORK")"; fi
+
+# 8. mtime advances on write — this is what a live session watches for. Without
+#    it the rotation completes and the running session never notices.
+before="$(stat -c '%Y' "$WORK/.credentials.json" 2>/dev/null || stat -f '%m' "$WORK/.credentials.json")"
+sleep 1.1
+harness 'cred_write '"'"'{"claudeAiOauth":{"accessToken":"tok-second"}}'"'"'' >/dev/null 2>&1
+after="$(stat -c '%Y' "$WORK/.credentials.json" 2>/dev/null || stat -f '%m' "$WORK/.credentials.json")"
+if [ "$after" -gt "$before" ]; then
+  ok "a successful write advances mtime (the live-adoption signal)"
+else
+  no "a successful write advances mtime (the live-adoption signal)" \
+     "before=$before after=$after"; fi
+
+# 9. A missing store reads as failure, not as an empty credential.
+rm -f "$WORK/.credentials.json"
+if ! harness 'cred_read' >/dev/null 2>&1; then
+  ok "a missing credential store fails rather than returning empty"
+else
+  no "a missing credential store fails rather than returning empty" \
+     "an empty read would be captured as a valid identity"; fi
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/quota-config-dir.test.sh
+++ b/tests/quota-config-dir.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# quota-config-dir.test.sh — every component follows CLAUDE_CONFIG_DIR together.
+#
+# Why this matters beyond tidiness: the documented safe way to add a second
+# account is to log it into an ISOLATED config dir and capture from there, so the
+# live credentials are never touched and no logout fires. (`/login` performs a
+# server-side revoke of the previous refresh token, so the naive "log in, then
+# capture" flow can kill an identity you already captured.) That workflow only
+# holds if the tools actually follow the relocation.
+#
+# The failure mode if one component lags is the nastiest kind: every path still
+# resolves, nothing errors, and the watcher reads one account's state while the
+# operator works in another. So these assert the components AGREE — a partial
+# migration is worse than none, and is invisible without a test like this.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+D="$ROOT/hooks/claude-identity"
+PASS=0; FAIL=0
+ok(){ printf '  ok   %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/qcd-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+ALT="$WORK/alt-config"
+mkdir -p "$ALT"
+
+echo "quota-config-dir: $D"
+
+# 1. _watch.py resolves every one of its state paths inside the relocated dir.
+out="$(CLAUDE_CONFIG_DIR="$ALT" python3 - "$D/_watch.py" <<'PYEOF'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("w", sys.argv[1])
+w = importlib.util.module_from_spec(spec); spec.loader.exec_module(w)
+print("\n".join([w.CACHE, w.LOG, w.SWAP_LOG, w.IDENTITIES]))
+PYEOF
+)"
+if [ "$(printf '%s' "$out" | grep -cv "^$ALT/")" -eq 0 ] && [ -n "$out" ]; then
+  ok "_watch.py puts cache, log, swap-log and identities under CLAUDE_CONFIG_DIR"
+else
+  no "_watch.py puts cache, log, swap-log and identities under CLAUDE_CONFIG_DIR" \
+     "escaped: $(printf '%s' "$out" | grep -v "^$ALT/" | tr '\n' ' ')"; fi
+
+# 2. _cache.py agrees — including the tick marker, which is the one easy to miss
+#    because it is written from a helper that takes `home`, not the config dir.
+out="$(CLAUDE_CONFIG_DIR="$ALT" python3 - "$D/_cache.py" "$WORK" <<'PYEOF'
+import importlib.util, sys, os
+spec = importlib.util.spec_from_file_location("c", sys.argv[1])
+c = importlib.util.module_from_spec(spec); spec.loader.exec_module(c)
+home = sys.argv[2]
+print(c.config_dir(home))
+print(os.path.join(c.config_dir(home), "watch-tick"))
+PYEOF
+)"
+if [ "$(printf '%s' "$out" | grep -cv "^$ALT")" -eq 0 ] && [ -n "$out" ]; then
+  ok "_cache.py resolves its config dir and tick marker under CLAUDE_CONFIG_DIR"
+else
+  no "_cache.py resolves its config dir and tick marker under CLAUDE_CONFIG_DIR" "got: $out"; fi
+
+# 3. The shell agrees. Probed by sourcing the config block only — running a
+#    subcommand would need a real credential store.
+out="$(CLAUDE_CONFIG_DIR="$ALT" SRC="$D/claude-identity.sh" bash -c '
+  set -uo pipefail
+  eval "$(sed -n "/^CONFIG_DIR=/,/^SWAP_LOG=/p" "$SRC")"
+  printf "%s\n%s\n%s\n%s\n" "$IDENTITIES_DIR" "$CACHE_FILE" "$WATCH_LOG" "$SWAP_LOG"
+')"
+if [ "$(printf '%s' "$out" | grep -cv "^$ALT/")" -eq 0 ] && [ -n "$out" ]; then
+  ok "claude-identity.sh resolves its state paths under CLAUDE_CONFIG_DIR"
+else
+  no "claude-identity.sh resolves its state paths under CLAUDE_CONFIG_DIR" "got: $out"; fi
+
+# 4. Unset must reproduce the classic layout exactly — this is the back-compat
+#    guard for every existing macOS operator.
+out="$(env -u CLAUDE_CONFIG_DIR python3 - "$D/_watch.py" <<'PYEOF'
+import importlib.util, sys, os
+spec = importlib.util.spec_from_file_location("w", sys.argv[1])
+w = importlib.util.module_from_spec(spec); spec.loader.exec_module(w)
+print(w.CONFIG_DIR == os.path.join(os.path.expanduser("~"), ".claude"))
+PYEOF
+)"
+if [ "$out" = "True" ]; then
+  ok "unset CLAUDE_CONFIG_DIR keeps the classic ~/.claude layout"
+else
+  no "unset CLAUDE_CONFIG_DIR keeps the classic ~/.claude layout" "got: $out"; fi
+
+# 5. .claude.json is the odd one out — beside the config dir normally, inside it
+#    when relocated. Both branches must resolve to a real file.
+printf '{"oauthAccount":{"emailAddress":"relocated@example.com"}}' > "$ALT/.claude.json"
+out="$(CLAUDE_CONFIG_DIR="$ALT" SRC="$D/claude-identity.sh" bash -c '
+  set -uo pipefail
+  eval "$(sed -n "/^CONFIG_DIR=/,/^IDENTITIES_DIR=/p" "$SRC")"
+  echo "$CLAUDE_JSON"
+')"
+if [ "$out" = "$ALT/.claude.json" ]; then
+  ok "a relocated .claude.json is preferred when present"
+else
+  no "a relocated .claude.json is preferred when present" "got: $out"; fi
+
+rm -f "$ALT/.claude.json"
+out="$(CLAUDE_CONFIG_DIR="$ALT" SRC="$D/claude-identity.sh" bash -c '
+  set -uo pipefail
+  eval "$(sed -n "/^CONFIG_DIR=/,/^IDENTITIES_DIR=/p" "$SRC")"
+  echo "$CLAUDE_JSON"
+')"
+if [ "$out" = "$HOME/.claude.json" ]; then
+  ok "falls back to \$HOME/.claude.json when the relocated one is absent"
+else
+  no "falls back to \$HOME/.claude.json when the relocated one is absent" "got: $out"; fi
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/quota-rotation-target.test.sh
+++ b/tests/quota-rotation-target.test.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# quota-rotation-target.test.sh — rotate only to an account that actually has capacity.
+#
+# Regression origin: rotation was a bare `switch`, which advances one position in
+# the USER.md list and wraps. With exactly two accounts — the common case —
+# exhausting B rotates straight back to A, whose 5h window has not rolled yet.
+# The session lands on a dead account AND then sits out the cooldown there, which
+# is strictly worse than not rotating. The data to avoid it was already in hand
+# and discarded: rate_limits carries resets_at per window.
+#
+# Scenario 4 is the one that matters most and is the least obvious: a `declined`
+# row must NOT arm the cooldown. Declining means we looked and stayed put, so
+# nothing changed and there is nothing to debounce — counting it would blind the
+# watcher for COOLDOWN_SECS at precisely the moment it most needs to keep looking.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WATCH="$ROOT/hooks/claude-identity/_watch.py"
+PASS=0; FAIL=0
+ok(){ printf '  ok   %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/qrt-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/USER.md" <<'EOF'
+## Anthropic accounts
+
+1. `home@example.com` — preferred
+2. `overflow@example.com` — overflow
+
+## Something else
+3. `notanaccount@example.com`
+EOF
+
+# Drive the module directly: these are pure decision functions, so exercising
+# them beats trying to fake a whole live rotation.
+probe() {  # probe <python-body>
+  HOME="$WORK" USER_MD_PATH="$WORK/USER.md" python3 - "$WATCH" <<PYEOF
+import importlib.util, sys, json, os, time
+spec = importlib.util.spec_from_file_location("w", sys.argv[1])
+w = importlib.util.module_from_spec(spec); spec.loader.exec_module(w)
+$1
+PYEOF
+}
+
+seed_state() {  # seed_state <email> <pct5> <resets_at_offset_secs>
+  mkdir -p "$WORK/.claude/identities/$1"
+  python3 - "$WORK/.claude/identities/$1/last-limits.json" "$2" "$3" <<'PYEOF'
+import json, sys, time
+json.dump({"email":"x","recorded_at":int(time.time()),
+           "five_hour_pct":float(sys.argv[2]),
+           "five_hour_resets_at":time.time()+float(sys.argv[3]),
+           "seven_day_pct":0,"seven_day_resets_at":None},
+          open(sys.argv[1],"w"))
+PYEOF
+}
+
+echo "quota-rotation-target: $WATCH"
+
+# 1. Only the numbered list under the right heading counts as accounts.
+out="$(probe 'print(",".join(w.parse_accounts()))')"
+if [ "$out" = "home@example.com,overflow@example.com" ]; then
+  ok "parses the account list and stops at the next section"
+else
+  no "parses the account list and stops at the next section" "got: $out"; fi
+
+# 2. A capped alternative whose window has NOT rolled is refused.
+seed_state overflow@example.com 99 3600
+out="$(probe 'print(w.pick_target("home@example.com", 98, 98))')"
+if printf '%s' "$out" | grep -q "None" && printf '%s' "$out" | grep -q "still capped"; then
+  ok "declines when the only alternative is still capped"
+else
+  no "declines when the only alternative is still capped" "got: $out"; fi
+
+# 3. Same account, window already rolled -> it becomes a candidate again.
+seed_state overflow@example.com 99 -60
+out="$(probe 'print(w.pick_target("home@example.com", 98, 98))')"
+if printf '%s' "$out" | grep -q "overflow@example.com"; then
+  ok "accepts a capped account once its window has rolled over"
+else
+  no "accepts a capped account once its window has rolled over" "got: $out"; fi
+
+# 4. THE ONE THAT BITES: a `declined` row must not arm the cooldown.
+mkdir -p "$WORK/.claude"
+python3 - "$WORK/.claude/swap-log.jsonl" <<'PYEOF'
+import json, time, sys
+now = int(time.time())
+rows = [
+    {"ts": now - 5000, "action": "rotate",   "rc": 0},   # long ago, real swap
+    {"ts": now - 10,   "action": "declined", "rc": None},# just now, changed nothing
+]
+open(sys.argv[1], "w").write("\n".join(json.dumps(r) for r in rows) + "\n")
+PYEOF
+out="$(probe 'print(w.recently_swapped())')"
+if printf '%s' "$out" | grep -q "False"; then
+  ok "a 'declined' row does not arm the cooldown"
+else
+  no "a 'declined' row does not arm the cooldown" "got: $out (a decline changed nothing)"; fi
+
+# 5. A real recent swap still does arm it — the guard must not be gutted.
+python3 - "$WORK/.claude/swap-log.jsonl" <<'PYEOF'
+import json, time, sys
+now = int(time.time())
+open(sys.argv[1], "w").write(json.dumps({"ts": now - 10, "action": "rotate", "rc": 0}) + "\n")
+PYEOF
+out="$(probe 'print(w.recently_swapped())')"
+if printf '%s' "$out" | grep -q "True"; then
+  ok "a real recent swap still arms the cooldown"
+else
+  no "a real recent swap still arms the cooldown" "got: $out"; fi
+
+# 6. A FAILED swap (rc != 0) is not a swap either.
+python3 - "$WORK/.claude/swap-log.jsonl" <<'PYEOF'
+import json, time, sys
+now = int(time.time())
+open(sys.argv[1], "w").write(json.dumps({"ts": now - 10, "action": "rotate", "rc": 1}) + "\n")
+PYEOF
+out="$(probe 'print(w.recently_swapped())')"
+if printf '%s' "$out" | grep -q "False"; then
+  ok "a failed swap does not arm the cooldown"
+else
+  no "a failed swap does not arm the cooldown" "got: $out"; fi
+
+# 7. Corrupt lines must not abort the scan — the good row behind them still wins.
+python3 - "$WORK/.claude/swap-log.jsonl" <<'PYEOF'
+import json, time, sys
+now = int(time.time())
+lines = ["{not json at all", json.dumps({"ts": now - 10, "action": "rotate", "rc": 0}), "]["]
+open(sys.argv[1], "w").write("\n".join(lines) + "\n")
+PYEOF
+out="$(probe 'print(w.recently_swapped())')"
+if printf '%s' "$out" | grep -q "True"; then
+  ok "malformed swap-log lines are skipped, not fatal"
+else
+  no "malformed swap-log lines are skipped, not fatal" "got: $out"; fi
+
+# 8. Never-seen account is available — otherwise the feature is dead on day one.
+rm -rf "$WORK/.claude/identities"
+out="$(probe 'print(w.headroom("overflow@example.com", 98, 98))')"
+if printf '%s' "$out" | grep -q "True"; then
+  ok "an account with no recorded state is assumed fresh"
+else
+  no "an account with no recorded state is assumed fresh" "got: $out"; fi
+
+# 9. One account configured cannot rotate anywhere, and says so.
+cat > "$WORK/USER.md" <<'EOF'
+## Anthropic accounts
+
+1. `only@example.com`
+EOF
+out="$(probe 'print(w.pick_target("only@example.com", 98, 98))')"
+if printf '%s' "$out" | grep -q "None" && printf '%s' "$out" | grep -q ">= 2 accounts"; then
+  ok "a single-account setup declines with a legible reason"
+else
+  no "a single-account setup declines with a legible reason" "got: $out"; fi
+
+# 10. record_state -> headroom round-trips through what the cache actually gives us.
+cat > "$WORK/USER.md" <<'EOF'
+## Anthropic accounts
+
+1. `home@example.com`
+2. `overflow@example.com`
+EOF
+out="$(probe '
+cache = {"five_hour_pct": 99, "five_hour_resets_at": time.time()+3600,
+         "seven_day_pct": 10, "seven_day_resets_at": None}
+w.record_state("overflow@example.com", cache)
+print(w.headroom("overflow@example.com", 98, 98))
+print(oct(os.stat(w.state_path("overflow@example.com")).st_mode & 0o777))')"
+if printf '%s' "$out" | grep -q "False" && printf '%s' "$out" | grep -q "0o600"; then
+  ok "recorded limits are read back and the file is 0600"
+else
+  no "recorded limits are read back and the file is 0600" "got: $out"; fi
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/quota-threshold.test.sh
+++ b/tests/quota-threshold.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# quota-threshold.test.sh — the rotation threshold reaches the process that enforces it.
+#
+# Regression origin: `claude-identity.sh` defined THRESHOLD_5H/THRESHOLD_7D, and
+# nothing consumed them. They were never exported, no function in that file read
+# them, and the hot path (statusLine -> _cache.py -> _watch.py) never sources the
+# shell at all — so `_watch.py`'s own default was the value in force, always. An
+# operator who edited the shell got no effect AND no error: set 92, and a 96%
+# reading logged "no swap". Two declarations of one value, and the one you could
+# find was the one that did nothing.
+#
+# The fix makes _watch.py the single owner and adds `--threshold`, answered BY the
+# consumer so it cannot drift from what actually runs.
+#
+# Scenarios 1-2 MUST fail against the pre-fix implementation (no --threshold at
+# all, and a built-in default that ignored the shell). 4-7 guard the reporting
+# label: a rejected override must report the DEFAULT as the value in force, never
+# "environment" — mislabelling that is the same class of bug this fix exists for.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WATCH="$ROOT/hooks/claude-identity/_watch.py"
+SHELL_ENTRY="$ROOT/hooks/claude-identity/claude-identity.sh"
+PASS=0; FAIL=0
+ok(){ printf '  ok   %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+# Every case runs with a scratch CLAUDE_CONFIG_DIR so a developer's real
+# quota-watch.log is never touched by the suite.
+run_threshold(){
+  local dir; dir="$(mktemp -d "${TMPDIR:-/tmp}/qt-XXXXXX")"
+  env -u CLAUDE_QUOTA_5H -u CLAUDE_QUOTA_7D CLAUDE_CONFIG_DIR="$dir" "$@" \
+    python3 "$WATCH" --threshold 2>/dev/null
+  local rc=$?
+  rm -rf "$dir"
+  return $rc
+}
+
+echo "quota-threshold: $WATCH"
+
+# 1. The consumer can report what it enforces at all.
+out="$(run_threshold)"
+if [ -n "$out" ]; then ok "--threshold is answerable"; else
+  no "--threshold is answerable" "produced no output"; fi
+
+# 2. With no override, the documented default (98) is what is in force.
+if printf '%s' "$out" | grep -q '5h: 98%' && printf '%s' "$out" | grep -q '7d: 98%'; then
+  ok "no override -> documented default 98"
+else
+  no "no override -> documented default 98" "got: $out"; fi
+
+# 3. An override actually lands (the whole point of the bug).
+out="$(run_threshold env CLAUDE_QUOTA_5H=92 CLAUDE_QUOTA_7D=91)"
+if printf '%s' "$out" | grep -q '5h: 92%' && printf '%s' "$out" | grep -q '7d: 91%'; then
+  ok "env override reaches the enforcing process"
+else
+  no "env override reaches the enforcing process" "got: $out"; fi
+
+# 4-6. Junk must be REJECTED, and must not be reported as if it took effect.
+for bad in abc 0 150; do
+  out="$(run_threshold env CLAUDE_QUOTA_5H="$bad")"
+  if printf '%s' "$out" | grep -q '5h: 98%' \
+     && ! printf '%s' "$out" | grep -qE '5h: 98%.*\(environment\)'; then
+    ok "CLAUDE_QUOTA_5H=$bad -> falls back to 98 and says so"
+  else
+    no "CLAUDE_QUOTA_5H=$bad -> falls back to 98 and says so" "got: $out"; fi
+done
+
+# 7. The two windows are independent — a bad 5h must not drag 7d with it.
+out="$(run_threshold env CLAUDE_QUOTA_5H=abc CLAUDE_QUOTA_7D=90)"
+if printf '%s' "$out" | grep -q '7d: 90%'; then
+  ok "a rejected 5h does not clobber a valid 7d"
+else
+  no "a rejected 5h does not clobber a valid 7d" "got: $out"; fi
+
+# 8. The operator-facing path agrees with the process-facing one. This is the
+#    assertion that would have caught the original bug: the shell must not be
+#    able to report a number the watcher does not enforce.
+via_shell="$(CLAUDE_QUOTA_5H=92 bash "$SHELL_ENTRY" watch --threshold 2>/dev/null)"
+via_python="$(CLAUDE_QUOTA_5H=92 python3 "$WATCH" --threshold 2>/dev/null)"
+if [ -n "$via_shell" ] && [ "$via_shell" = "$via_python" ]; then
+  ok "shell and watcher report the same effective threshold"
+else
+  no "shell and watcher report the same effective threshold" \
+     "shell=[$via_shell] python=[$via_python]"; fi
+
+# 9. The dead second declaration must not come back.
+if ! grep -qE '^[[:space:]]*THRESHOLD_(5H|7D)=' "$SHELL_ENTRY"; then
+  ok "no second threshold declaration in the shell"
+else
+  no "no second threshold declaration in the shell" \
+     "$(grep -nE '^[[:space:]]*THRESHOLD_(5H|7D)=' "$SHELL_ENTRY")"; fi
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/quota-tick-interval.test.sh
+++ b/tests/quota-tick-interval.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# quota-tick-interval.test.sh — the evaluation interval tightens near the cap.
+#
+# Regression origin: _cache.py rate-limited its _watch.py kick to once per 30s,
+# flat. Claude Code adopts a swapped credential on its next API request — but
+# that speed is unreachable if the threshold is only EVALUATED every 30 seconds.
+# With parallel subagents burning fast, the cap gets crossed inside that blind
+# window and the rotation lands after the wall it existed to prevent.
+#
+# Scenario 5 is the guard that matters beyond this change: the kick must pass the
+# WORSE of the two usage numbers. Passing only the 5h figure would leave a 7d
+# cap crawling at the slow interval, which is the same blind window wearing a
+# different hat.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CACHE_PY="$ROOT/hooks/claude-identity/_cache.py"
+PASS=0; FAIL=0
+ok(){ printf '  ok   %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+echo "quota-tick-interval: $CACHE_PY"
+
+probe(){ python3 - "$CACHE_PY" <<PYEOF
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("c", sys.argv[1])
+c = importlib.util.module_from_spec(spec); spec.loader.exec_module(c)
+$1
+PYEOF
+}
+
+# 1-2. Slow lane while there is headroom; fast lane inside the hot zone.
+out="$(probe 'print(c.tick_interval(0), c.tick_interval(50))')"
+if [ "$out" = "30 30" ]; then ok "stays cheap with headroom"; else
+  no "stays cheap with headroom" "got: $out"; fi
+
+out="$(probe 'print(c.tick_interval(90), c.tick_interval(99))')"
+if [ "$out" = "3 3" ]; then ok "tightens inside the hot zone"; else
+  no "tightens inside the hot zone" "got: $out"; fi
+
+# 3. The boundary is inclusive and lands on the fast side.
+out="$(probe 'print(c.tick_interval(c.HOT_ZONE_PCT - 0.1), c.tick_interval(c.HOT_ZONE_PCT))')"
+if [ "$out" = "30 3" ]; then ok "hot zone boundary is inclusive"; else
+  no "hot zone boundary is inclusive" "got: $out"; fi
+
+# 4. Junk must degrade to the CHEAP lane, never to a spawn-every-render loop.
+out="$(probe 'print(c.tick_interval(None), c.tick_interval("abc"), c.tick_interval(""))')"
+if [ "$out" = "30 30 30" ]; then ok "unusable input degrades to the slow lane"; else
+  no "unusable input degrades to the slow lane" "got: $out"; fi
+
+# 5. The call site must feed it the worst of the two windows, not just the 5h.
+if grep -A2 'kick_watcher(' "$CACHE_PY" | grep -q 'max(' \
+   && grep -A2 'kick_watcher(' "$CACHE_PY" | grep -q 'seven_day_pct'; then
+  ok "kick passes the worst of the 5h and 7d numbers"
+else
+  no "kick passes the worst of the 5h and 7d numbers" \
+     "a 7d cap would crawl at the slow interval"; fi
+
+# 6. The fast lane must actually be faster — a config typo making them equal
+#    would pass every test above while silently restoring the old behaviour.
+out="$(probe 'print(c.WATCH_TICK_SECS_HOT < c.WATCH_TICK_SECS)')"
+if [ "$out" = "True" ]; then ok "the hot interval is strictly shorter"; else
+  no "the hot interval is strictly shorter" "got: $out"; fi
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #15 — or most of it; two calls at the bottom are still yours.

`hooks/claude-identity/` was documented macOS-only, so every operator running two or more Anthropic accounts on Linux had **no rate-limit autopilot at all** — they hit the 5h cap mid-task with no fallback, which is the exact situation the feature exists to prevent.

Porting it surfaced four things. **Three are bugs in the existing macOS implementation** and affect operators today; the fourth is a documented premise that measurement contradicts. That ratio is the useful part: a port is an unusually good auditor, because it forces every assumption to be read out loud.

---

## The three macOS bugs land first, and cherry-pick clean

You said 2–4 want their own PR and their own tests. They are the first three commits here, in dependency-free order, so you can take them ahead of the port if you want them out sooner.

**Verified, not assumed:** all three cherry-pick onto a clean `main` with no conflict, their tests pass on that tree, and a negative control confirms the platform backend is absent from it.

| | commit | what was wrong |
|---|---|---|
| **#2** | `e7e65f8` | The configured threshold never reached the process that enforces it |
| **#3** | `98095cb` | Rotation landed on accounts that were still capped |
| **#4** | `e1f7c55` | A flat 30s evaluation interval was the real ceiling |

### #2 — the threshold was inert, and inert in the direction that hides it

`claude-identity.sh` declared `THRESHOLD_5H`/`THRESHOLD_7D` and **nothing read them**. Not exported, no consumer in that file, and the path that actually fires — statusLine → `_cache.py` → `_watch.py` — never sources the shell at all.

So two declarations of one value could disagree forever, and the one an operator can *find* was the one that did nothing. Set 92, watch a 96% reading log `no swap`, get no error anywhere.

The fix is one owner rather than a second wiring: `_watch.py` owns the default, the shell stops defining a competitor, and `claude-switch watch --threshold` answers **from the enforcing process** so the reported value cannot drift from the applied one. Out-of-range and non-integer overrides are rejected and say so — a `0` rotates every tick and a `150` never rotates, and both fail silently if honoured. The default stays **98**, as documented; my own vault runs 92 and that stays an env var, which is what the env var is for.

### #3 — and a bug this change would otherwise have introduced

`pick_target()` walks USER.md in order and skips any account whose recorded cap has not expired. The data was already in hand and being discarded: `rate_limits` carries `resets_at`, so persisting the active account's limits each tick is what lets the watcher reason about accounts it is not standing on. Declining is now a first-class outcome that reports **when capacity returns**, rather than a swap to nowhere.

Worth flagging because I nearly shipped it: `recently_swapped()` took the last swap-log line **regardless of action**, so the new `declined` rows would have armed the 15-minute cooldown — blinding the watcher at precisely the moment it most needs to keep looking, since the other account's window may roll seconds later. The cooldown now keys off the last row where the account genuinely changed. A decline changed nothing and has nothing to debounce.

### #4 — the interval, not the swap, was the bottleneck

The credential swap lands in milliseconds. That speed is unreachable if the threshold is only *evaluated* every 30 seconds: with parallel subagents burning fast, the cap gets crossed inside the blind window. Now 3s above 85% usage, 30s below. Unusable input degrades to the **slow** lane deliberately — the failure mode of guessing fast is a subprocess per statusLine render.

---

## The port

- **Credential backend** (`8c3a230`) — platform-detected. macOS keeps Keychain, byte-for-byte unchanged. Linux uses the plaintext `$CLAUDE_CONFIG_DIR/.credentials.json` at mode 600 **that Claude Code itself writes**. That is the answer to your mapping question: not libsecret, not `secret-tool`, not a keyring — anything else would store the credential somewhere the application never reads. Two non-obvious properties: the write **validates the blob as JSON before replacing**, because this path overwrites a working credential in place and a bad one surfaces as a logged-out session rather than an error; and it is **atomic via rename**, because the mtime bump is the signal a live session rides, and a truncate-and-write risks a torn read and can leave mtime unchanged.
- **Scheduler** (`77159ca`) — systemd **user** timer beside the launchd agent, same 30-minute cadence. Two things launchd gives free that systemd must be asked for, both easy to omit and never notice: `Persistent=true` (run on resume if a run was missed — without it the safety net has a hole across exactly the gap it covers) and `loginctl enable-linger` for headless boxes, documented in the unit header since the symptom is simply nothing ever happening.
- **`CLAUDE_CONFIG_DIR`** (`6b3079d`) — honoured by all three components. This is what makes the safe capture flow possible, and it matters beyond Linux: **`/login` performs a server-side revoke of the previous refresh token**, so the currently documented "log in, then `--capture`" can kill an identity you already captured, depending on ordering. Logging the new account into an isolated config dir removes the hazard — nothing to log out of. The test asserts the components *agree*, because if one lags the relocation every path still resolves and the watcher just reads one account's state while you work in another.
- **Adoption detector** (`6d32f3b`) — the safety net for finding #1. The autopilot leans on Claude Code re-reading its credential store on the next request. That is measured, not promised, and if it ever stops the failure is **mute**: swap succeeds, log says rotated, session keeps burning the capped account. Since we only rotate to an account with real capacity, the reported percentage must fall; still high minutes later means it never landed. Also makes `notify()` platform-detected — it shelled out to `osascript` unconditionally and swallowed the exception, so **off macOS every notification this module ever sent was silently dropped**, including the two that matter most.
- **Docs** (`d61c67e`) — five surfaces asserted macOS-only, including a README precondition instructing Claude to abort setup outright. Windows is now called out as explicitly unsupported rather than left ambiguous: the credential layout matches Linux, but no scheduler is wired and nothing has been tested there. Claiming it because the path happens to match would be the same shape of error this PR exists to fix.

---

## Tests

Six suites, **48 assertions**, all wired into CI (ubuntu; `quota-threshold` also in the bash-3.2 lane). Every one was **validated by making it fail** against the pre-fix tree — a guard never seen failing is supposed, not proven:

| suite | new | fails pre-fix |
|---|---|---|
| `quota-threshold` | 9 | 9 |
| `quota-rotation-target` | 10 | 9 — the one pass is *"a real recent swap still arms the cooldown"*, behaviour that must survive, so its passing is the point |
| `quota-tick-interval` | 6 | 6 |
| `quota-config-dir` | 6 | 6 |
| `credential-backend` | 9 | 6 — the other 3 pass vacuously with no backend to extract, which the first assertion exists to expose |
| `adoption-detector` | 8 | n/a — new subsystem |

The file-backend cases skip on a macOS runner rather than assert something untrue there.

---

## Two calls still yours

**1. `_resume.py` — I said my default was delete. I am not doing that here, and I think that is the right call.**

It is not loose dead code: it sits behind `CLAUDE_AUTOSWAP_RESPAWN=1`, an opt-in the 2026-05-28 CHANGELOG entry explicitly offers to operators running unattended overnight agents. Removing an escape hatch someone may be using is a maintainer's decision, not a side effect of a port. What *is* unambiguously wrong is the docstring, which still opens by asserting the problem measurement disproves — so `4b747ca` fixes that in place, keeps the original rationale marked known-wrong for context, and names the chain-burn hazard your own CHANGELOG documents. Deleting it stays a one-line follow-up whenever you want it.

**2. Canonical or operator extension.** I read *"say the word and I will not duplicate the work"* as the port being wanted upstream and built it that way. If you would rather it live as an extension, say so and I will re-shape it — the three bug-fix commits stand alone either way.

---

## Two things I noticed and did not touch

Both are out of scope for this PR and both are yours to want or not:

- **`tests/route-insight.test.sh` is not wired into any CI job.** It shipped in the 2026-08-11 batch and nothing runs it. Same class as the four backstops that entry is named for — a check that cannot fire.
- **The exec-bit issue you flagged on #14 was bigger than one file, and the cause is worth having.** `core.fileMode` was already `true`, so the 644 was real rather than a config artifact. My vault's **first commit predates my Windows→Linux migration**: it has 462 files and all 462 are `100644` — not one executable, because the exec bit does not exist on the filesystem it was created on. Everything added after the migration was born `100755` correctly. A committed mode does not self-heal (git diffs content; `/aios:update` overwrites content and leaves the index's mode entry alone), so it survived four syncs invisibly across **33 files**. Fixed on my side against your `main` tree, so this PR does not carry it. The general shape, if it is worth a note anywhere: an operator who set their vault up on Windows and later moved has this silently, and checking `git config core.fileMode` will not reveal it — the config is correct, the history is what is wrong.
