### PR TITLE
fix(close-session): Mode A had no idempotency rule, so a re-fired close duplicated the block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,22 @@
 2. **Read the "Recovered by completeness reconcile" section of its report.** If it names files, **that is this fix working**: your vault had a silent gap that no previous update could detect. Nothing further to do — they have been applied.
 3. **If that section is empty, you were already whole.** Most vaults will be. That is a clean result, not a failed one.
 4. **Claude sessions running this:** report recovered files *loudly and by name* rather than folding them into the applied list. A recovery means the tracker was over-claiming and the operator was missing framework content — they should know which. And do **not** "finish the job" by deriving the root-doc list too: `validate.yml` asserts every root `*.md` appears literally quoted in `update.md`, and that guard is what fails the build when a new root doc is added without being wired in. Deriving it would disarm the check — the reason the second commit on this branch exists.
+### `/close-session` could be made to write the same block over and over
+
+> **What this delivers.** Mode B has had an idempotency rule since it was written — *"if the same session runs `/close-session` twice on one date, overwrite its own file."* **Mode A had none**, and its per-day multi-block design is what made the gap invisible: the note genuinely *should* hold several `## Session —` blocks (one per session), so nothing could distinguish **a second session** from **the same session firing twice**. The heading carries no session identity. Measured today: a misbehaving command-bus request delivered `/aios:close-session --auto` to a session **four times in twelve minutes**, and to a second session with an identical signature. Four blocks would have meant four copies of the same wins in the daily note **and** four copies of the same Tier A/Tier B candidates for `/close-day` to route into observed context — the consolidator amplifying the noise it exists to reduce.
+
+**What you can now do:**
+- **Let a close fire twice without paying for it.** Each block is stamped `<!-- close-session: {session-id} @ {vault HEAD} -->` under its heading. On the next close, if *this* session already stamped a block **and** the vault HEAD has not moved, the append is skipped with a plain message. An HTML comment renders invisibly in Obsidian, so your note reads exactly as before.
+- **Still close twice on purpose.** A long session that closes at noon, works on, and closes again at 18:00 appends normally — because `HEAD` moved. The gate keys on *whether anything was committed*, not on elapsed time: a re-fire two minutes later and a genuine second close two minutes later are indistinguishable by clock, and identical by `HEAD` only in the first case.
+- **Keep multi-session days working untouched.** A different session closing has no matching stamp, so it always appends. Verified against a real note holding three blocks from three sessions.
+- **Fail toward a block, never toward silence.** If `CLAUDE_CODE_SESSION_ID` is unavailable the gate degrades to the old always-append behaviour. A duplicated block is recoverable; a missing one is lost work.
+
+**Why the fix belongs here and not only in whatever glitched.** The bus bug is being fixed separately in the App. This one is still worth having: **a consumer must not be corruptible by a misbehaving producer.** A retrying bus, a double-clicked button, a broadcast overlapping its own previous run — the command cannot enumerate the ways it will be called twice, so it should be safe when it is. Defence in depth; neither fix makes the other redundant.
+
+**Action required — none, and one thing to know.** The gate is **forward-only**: blocks already in your notes carry no stamp, so a session that closed *before* this sync and closes again after it will append a second block. That self-corrects the first time each session closes post-sync. Nothing to run, nothing to migrate.
+
+*Found by a bus glitch firing the same close four times at one session — the loop was harmless only because the receiving session declined to act on invocations 2–4 by hand. This makes that judgement a rule.*
+
 
 ## 2026-08-11 — Four backstops that could not see the thing they existed to catch
 
@@ -95,8 +111,6 @@
 
 1. **If your `session-insights.md` uses `- **bullet**` entries** (rather than `### ` headings), your `/close-day` buffer gardening has been doing nothing. Nothing is lost — the entries are all still there — but your Emerging section is probably over its ≤10 cap. Let the next `/close-day` garden it, or check now: `grep -c '^- \*\*' "vault/00 - notes/context/observed/session-insights.md"`.
 2. **If you documented a source as unused in `USER.md`** and have been seeing a red ❌ for it every morning, that stops on this sync.
-
----
 
 ### 🖥️ Running the AIOS App on your Mac?
 

--- a/plugins/aios/commands/close-session.md
+++ b/plugins/aios/commands/close-session.md
@@ -29,6 +29,7 @@ When invoked as `/close-session --auto` (the Glass Close-all broadcast fires thi
 - **Keep every step that captures / commits** — Mode A merge-appends its block via `aios-note-append`; Mode B writes its per-session report; the commit is `aios-commit`.
 - **Under `--auto`, DEFER all observed-context routing to `/close-day` (single-writer) — do NOT run the direct Tier A writes in steps 6–7.** A broadcast can close several *vault* sessions at once, and the daily-note lock does **not** protect the observed files (`session-insights.md`, `patterns.md`, `preferences.md`, `business.md`, `antifragile.md`) — those steps read-scan-edit-write, so two parallel closes clobber each other (last-writer-wins). Instead, **capture** each observation as a candidate in the block — Tier A → `**Observed (Tier A candidates):**`, Tier B → `**Observed (Tier B candidates):**` — commit only the block, and let `/close-day` route them as the sole writer. **Nothing is lost:** routing moves from per-session to the consolidator, exactly as Mode B workers already defer via their reports. This is *why* parallel closing can't "make a mess" — under a broadcast there is exactly **one** observed-context writer (close-day), so no clobber, no trip, and no staleness (close-day always routes). (Interactive single `/close-session` still writes Tier A inline — no concurrency there → no race → immediate value.)
 - **Finish promptly** — completion → idle is the contract `--auto` exists to honor.
+- **Step 4.5's idempotency gate applies here, and `--auto` is the mode that needs it.** A machine-fired close can arrive repeatedly — a retrying bus, a double-clicked button, a broadcast that overlaps its own previous run. Run the gate; if this session already stamped a block and the vault HEAD has not moved, **skip the append and finish** rather than adding a near-identical block. Under `--auto` that skip is a normal, successful outcome — report it and go idle, do not treat it as an error. (Measured 2026-08-12: one bus request delivered `--auto` four times in twelve minutes to two different sessions.)
 
 The rest of this command is the **interactive** (manual `/close-session`) flow. Under `--auto`, skip each input-waiting step, run each capture/route/commit step.
 
@@ -55,6 +56,33 @@ Announce the detected mode: "Detected: **vault session** — writing to daily no
 2. Read `00 - notes/context/observed/session-insights.md` — check current content for snapshotting
 3. Infer a session label from the conversation: current time (HH:MM) + a 2–4 word topic. Present it to the user for confirmation: "Session label: **{HH:MM} | {Topic}** — correct, or adjust?"
 4. Wait for user response on label
+4.5. **Idempotency gate — has THIS session already closed with no work since?** Mode B has had an idempotency rule from the start (*"If the same session runs `/close-session` twice on one date, overwrite its own file"*); Mode A had none, and its per-day multi-block design is exactly what makes the gap invisible — the note cannot tell **a second session** (legitimate, wants its own block) from **the same session firing twice** (a duplicate), because `## Session — {HH:MM}` carries no session identity.
+
+   That is not hypothetical. On 2026-08-12 a misbehaving command-bus request delivered `/aios:close-session --auto` to one session **four times in twelve minutes**. Four blocks would have meant four copies of the same wins in the daily note *and* four copies of the same Tier A/Tier B candidates for `/close-day` to route into observed context — the consolidator amplifying noise it was built to reduce. **A consumer must not be corruptible by a misbehaving producer**, so the gate lives here rather than only in whatever surface glitched.
+
+   ```bash
+   NOTE="$HOME/aios/vault/01 - calendar/{YYYY-MM}/{YYYY-MM-DD}.md"
+   SID="${CLAUDE_CODE_SESSION_ID:-unknown}"
+   VHEAD=$(git -C "$HOME/aios" rev-parse HEAD)
+
+   # Did this session already stamp a block, and was the vault at the same commit then?
+   PRIOR=$(grep -o "<!-- close-session: ${SID} @ [0-9a-f]* -->" "$NOTE" 2>/dev/null | tail -1)
+   ```
+
+   - **A prior stamp exists AND its hash equals `$VHEAD`** → nothing has been committed since that close. This is a **duplicate**: skip the append, skip every step below, and say so plainly (*"already closed at {HH:MM}; no commits since — not duplicating"*). Under `--auto` this is the normal outcome of a re-fire and must not read as an error.
+   - **A prior stamp exists but its hash DIFFERS** → real work landed since. This is a **legitimate second close**: proceed and append a new block. A long session that closes at noon, works on, and closes again at 18:00 is a case the gate must never block.
+   - **No prior stamp** → first close today for this session. Proceed.
+
+   > **Why the vault HEAD and not a timestamp:** elapsed time does not distinguish a duplicate from real work — a re-fire two minutes later and a genuine second close two minutes later look identical by clock. `HEAD` moves if and only if something was committed, which is the property actually being asked about. And it is *measured*, not inferred. (`SID` falls back to `unknown` rather than failing: a session with no id still gets a block — degrading to the old always-append behaviour is the right failure direction, since a missing block is worse than a duplicated one.)
+
+   **Stamp the block you are about to write** — immediately under its `## Session —` heading, so the next invocation can find it:
+
+   ```
+   ## Session — {HH:MM} | {Topic}
+   <!-- close-session: {SID} @ {VHEAD} -->
+   ```
+
+   An HTML comment renders invisibly in Obsidian and in every markdown preview, so the note stays clean for the human while carrying the identity the machine needs.
 5. **Append the session block via the race-safe helper — never write the note directly** (a concurrent Close-all broadcast fires several vault sessions at once; a direct read-append-write would clobber). Write the block (format below) to a temp file, then:
    ```bash
    ~/aios/hooks/aios-note-append \
@@ -122,6 +150,7 @@ Append this to the daily note:
 ---
 
 ## Session — {HH:MM} | {Topic}
+<!-- close-session: {CLAUDE_CODE_SESSION_ID} @ {vault HEAD at close} -->
 
 > {One sentence characterization — not a summary, a frame. What was this session really about?}
 


### PR DESCRIPTION
Mode B has had an idempotency rule since it was written — *"if the same session runs `/close-session` twice on one date, overwrite its own file."* **Mode A had none**, and its per-day multi-block design is exactly what hid the gap: the note *should* hold several `## Session —` blocks, one per session, so nothing could distinguish **a second session** from **the same session firing twice**. The heading carries no identity.

## Found in production, today

A misbehaving command-bus request delivered `/aios:close-session --auto` to one session **four times in twelve minutes**, and to a second session with an identical signature (`releases: 2`, same claiming surface). It was harmless *only* because the receiving session declined invocations 2–4 by hand. Four blocks would have meant four copies of the same wins in the daily note **and** four copies of the same Tier A/Tier B candidates for `/close-day` to route into observed context — the consolidator amplifying the noise it exists to reduce.

## The gate (new step 4.5)

Each block is stamped under its heading:

```
## Session — {HH:MM} | {Topic}
<!-- close-session: {CLAUDE_CODE_SESSION_ID} @ {vault HEAD at close} -->
```

| state | verdict |
|---|---|
| same session · HEAD unmoved | **skip** — duplicate, reported plainly |
| same session · HEAD moved | **append** — real work landed since |
| different session | **append** — no matching stamp |
| no stamp (legacy note) | **append** |
| `CLAUDE_CODE_SESSION_ID` unset | **append** — degrade, never lose a block |

**Why vault HEAD and not a timestamp:** a re-fire two minutes later and a genuine second close two minutes later are identical by clock. `HEAD` moves if and only if something was committed, which is the property actually being asked about — and it is measured, not inferred.

An HTML comment renders invisibly in Obsidian, so the note reads exactly as before.

## Why this belongs here and not only in the surface that glitched

The bus bug is being fixed separately in the App. This is still worth having: **a consumer must not be corruptible by a misbehaving producer.** A retrying bus, a double-clicked button, a broadcast overlapping its own previous run — the command cannot enumerate the ways it will be called twice, so it should be safe when it is. Defence in depth; neither fix makes the other redundant.

## Verification

Dry-run against a real git fixture — **all five branches behave**: duplicate SKIPs, legitimate second close APPENDs, different session APPENDs, legacy unstamped note APPENDs, unset SID APPENDs. Also checked against today's **live** note, which holds three blocks from three different sessions: the multi-session case is untouched.

Suite green: `aios-commit` 17/17 · `update-tier0-denylist` 7/7 · `validate.yml` parses (12 jobs).

**Forward-only, and the CHANGELOG says so:** existing blocks carry no stamp, so a session that closed before this sync and closes again after it appends once more. Self-corrects on each session's first post-sync close. Nothing to run, nothing to migrate.

## One process note

My CHANGELOG subsection first landed **below** the `2026-08-11` heading — filed under an already-synced date, where `/aios:update`'s ancestor scan would never surface it. Caught pre-commit by the merge-time gate added to `infra-aios` § Release discipline this morning (step 3: *is the entry in the right container*). Second instance of that error in two days; the grep-the-headings check found it both times.