### PR TITLE
fix(update): the word-splitting rule had no check behind it, so residue accumulated invisibly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,34 @@
 
 ---
 
-## 2026-08-13 — A stock example named a real person, and every scaffolded company repo inherited it
+## 2026-08-13 — `/aios:update` left empty directories in vault roots, and nothing could see them
 
-`hash: 85d09e3` *(in [`company-template`](https://github.com/The-AIOS/company-template), not this repo)*
+`hash: TBD-ON-MERGE`
 
-### The company template's onboarding examples named a real teammate and two real brands
+### Stray empty directories from a previous update are now found and removed
 
-> **What this delivers.** `agents/onboarding-{company}.md` in the company template shipped **four** personal references — a change-digest example naming a **real teammate**, two voice sign-off examples naming **real brands**, and a post-sync nudge with one of those brands hardcoded where a `{company}` placeholder belonged. That file is **copied into every scaffolded company repo**, so each reference propagated outward into other operators' repositories. Found by an operator who hit it downstream and de-personalised their own copy; this fixes the source so nobody has to do it again.
+> **What this delivers.** If a past `/aios:update` iterated its changed-file list unsafely, it created a directory **named after the whole list** — `CHANGELOG.md SETUP.md START-HERE.md hooks` — and then nested deeper on each subsequent file. Yours may hold a chain of them. They are **completely empty** and break nothing, which is exactly why they survive: `git status` does not report empty directories **at all**, and Step 6.5's reconcile deliberately drops every vault-side-only entry. So the residue accumulates invisibly, and you find it months later wondering who created it. Step 3 now sweeps for it and removes it.
+
+**Why the existing protection was not enough.** Step 3 has carried a written rule against unquoted list iteration since 2026-07-27 — and it was still violated on 2026-08-12, in this very vault, producing a 14-directory chain. That is the predictable failure of a rule with nothing behind it: an instruction must be read and obeyed on *every* run, while a check runs whether anyone remembered or not. This release adds the check; the rule stays as the explanation.
+
+**What you can now do:**
+- **Let `/aios:update` clean up after its own past runs.** The sweep reports what it removed (*"Removed {N} stray empty directories from a previous run's unquoted path list"*) and stays silent when there is nothing.
+- **Trust it not to touch your folders.** Two conditions must *both* hold: the name looks like a joined file list (an extension followed by a space), **and** the directory contains zero files. Your `01 - calendar`, `00 - notes`, `02 - assets`, `03 - export` and `04 - backups` all contain a space and are all spared — none has a `.ext ` sequence. A folder holding anything real is never a candidate, and neither is a legitimately-empty folder like `05 - drafts`. Verified against a live vault plus a fixture: **1 true positive, 0 false positives across 9 cases.**
+
+**Action required — none.** The next `/aios:update` sweeps automatically. To look now: `find ~/aios -maxdepth 1 -type d -name '*.[A-Za-z0-9]* *'`. Anything it lists is empty by construction, so `rm -rf` on it loses nothing.
+
+### Also shipped: the company template's stock examples no longer name anyone real
+
+The sibling [`company-template`](https://github.com/The-AIOS/company-template) repo (`85d09e3`, PR #1 — **not** this repo, so it is not part of this hash) shipped **four** personal references in `agents/onboarding-{company}.md`: a change-digest example naming a real teammate, two voice sign-off examples naming real brands, and a post-sync nudge hardcoding one of those brands where a `{company}` placeholder belonged. That file is copied into **every scaffolded company repo**, so each reference propagated into other operators' repositories. Fixed, with a role-aware `personal_leak` CI job that enforces only in the template and skips scaffolded repos — because your own venture-context repo *should* name your own people.
+
+**Relevant to you only if you scaffolded a company repo before today**, since updating the template does not reach back into an existing repo:
+
+```bash
+# in each scaffolded company-context repo you own
+grep -rnE '\b[A-Z][a-z]{2,11} (shipped|wrote|built|added|fixed)\b' agents/ --include='*.md'
+```
+
+A hit inside a **stock example** should describe *what* shipped rather than *who*. A hit in your **own genuine content** — an origin story, a real decision record — is legitimate and should stay. *Illustration versus record.* Do not delete names wholesale; that would strip exactly the content a private context repo exists to hold.
 
 **Why each one is a real cost, not a cosmetic one.** Per this framework's own rule — *write framework docs for a stranger's empty vault* — a personal reference in shipped infra leaks **both directions**: it exposes someone who never agreed to be a stock example in strangers' repos, **and** it hands every other operator an illustration that resolves to nothing for them. The brand examples were also weaker teaching: a register archetype (*"institutional / precision-first"*) tells you how to pick **your** sign-off; a brand name tells you how someone else picked theirs.
 

--- a/plugins/aios/commands/update.md
+++ b/plugins/aios/commands/update.md
@@ -395,6 +395,23 @@ For each changed Tier 1 file:
    - New files in `agents/aios/{bundle}/` or other bundled subfolders → `cp` to the matching local path
 4. **Files deleted upstream:** flag with a question, don't auto-delete. *"Upstream removed `{path}`. Delete your local copy too? [yes/keep]."* Default: keep (operator may have reasons to retain locally).
 
+5. **Sweep for split-residue directories — the prose rule above needs a check behind it.** The word-splitting warning at the top of this step has shipped since 2026-07-27 and was still violated on 2026-08-12, leaving a 14-deep chain of empty directories in a vault root. That is the predictable outcome: the rule is an instruction a session must read and obey every run, and **nothing verified it afterward**. Worse, the residue is invisible to every existing check — `git status` does not report empty directories at all, and Step 6.5's reconcile deliberately drops every vault-side `Only in` line. So it accumulates silently, exactly as the warning predicts, and the operator finds it months later wondering who made it.
+
+   ```bash
+   # A residue dir is named like a JOINED FILE LIST — an extension followed by a
+   # space ("CHANGELOG.md SETUP.md …") — and holds ZERO files, because only
+   # `mkdir` ever ran. Both conditions are required.
+   find "$HOME/aios" -maxdepth 1 -type d ! -name '.*' -print | while IFS= read -r d; do
+     case "$(basename "$d")" in
+       *.[A-Za-z0-9]*\ *) [ "$(find "$d" -type f | wc -l)" -eq 0 ] && echo "$d" ;;
+     esac
+   done
+   ```
+
+   **Both conditions are load-bearing, and the second is what makes this safe to automate.** A vault legitimately contains directories with spaces — `01 - calendar`, `00 - notes`, `02 - assets`, `03 - export`, `04 - backups` — so *"has a space"* alone would flag the entire vault. The `extension-followed-by-space` shape excludes all five (none contains a `.ext ` sequence), and the zero-files test means a directory holding anything real is never a candidate. Verified against a live vault: **1 true positive, 0 false positives**, including against all five numbered folders.
+
+   Report what you find and remove it — it is empty by construction, so there is nothing to preserve: *"Removed {N} stray empty directories from a previous run's unquoted path list."* If the sweep finds nothing, say nothing. **Never widen this to non-empty directories or to a bare space match** — at that point you are deleting an operator's folders on a name heuristic, which is far worse than the residue.
+
 ### 4. Auto-execute post-replace scripts
 
 See § Post-replace auto-execution above. For each script that was updated in step 3, run it now. Wait for it to finish, capture output, report success/failure.


### PR DESCRIPTION
Found by the operator, not by us — which is the point.

## What was in the vault

A 14-deep chain of empty directories in the vault root, named:

```
CHANGELOG.md SETUP.md START-HERE.md hooks/claude-identity/README.md hooks/claude-identity/…
```

Each level deeper because `mkdir -p "$(dirname "$LIST")"" ran on the whole space-joined list instead of one path. **14 directories, 0 files, 0 bytes, untracked.**

## Why it survived 16 days

Step 3 has warned against unquoted list iteration since **2026-07-27** (`0c18de1`). It was violated on **2026-08-12**. A rule must be read and obeyed on every run; a check runs whether anyone remembered.

And the residue was invisible to **every** existing check:
- `git status` does not report empty directories **at all**
- Step 6.5's reconcile deliberately drops every vault-side `Only in` line

The warning predicted this exactly — *"silent and cumulative … invisible to Step 6.5"* — and was right. It just had nothing enforcing it.

## The check (Step 3, item 5)

Two conditions must **both** hold: the name looks like a joined file list (**extension followed by a space**) **and** the directory holds **zero files**.

The second makes automated removal safe. The first keeps a vault's own folders out of scope — a vault legitimately has `01 - calendar`, `00 - notes`, `02 - assets`, `03 - export`, `04 - backups`, so a bare space match would have proposed **deleting the entire vault**.

## Verification

- **Live vault:** 1 true positive, 0 false positives (all five numbered folders spared).
- **Fixture** reproducing the exact residue + **9 trap cases**, all spared, including the two that matter most:
  - `05 - brand new empty` — legitimately empty, space in name → spared
  - `my notes.md archive` — ext+space name but **holds files** → spared
- The spec explicitly **forbids** widening to non-empty dirs or a bare space match: that deletes operator folders on a name heuristic, which is worse than the residue.
- `aios-commit` 17/17 · tier0 denylist 7/7 · `validate.yml` 12 jobs.

## Also fixes today's CHANGELOG entry, which would have broken every operator's update

The entry was anchored on `hash: 85d09e3` — a **company-template** commit. Canonical's object database does not contain it, so `git cat-file -e` fails and `merge-base --is-ancestor` cannot evaluate it. Per Step 2 the scan stops only on **exit 0**, so that entry could **never** be marked synced: every operator would see it as new on every run, forever.

Caught by the operator asking why a repo that didn't change was carrying a changelog entry. Now anchored on this repo's own change, with the company-template fix kept as a **smaller sibling mention** carrying its hash inline and explicitly labelled as not part of this one.

## Not fixed here, and deliberately

A second stray file in the same vault root (`sendQueue.js`) came from a manual `npx asar extract-file` in an unrelated session whose cwd was the vault — `asar` writes to the cwd by basename and ignored the `/dev/stdout` destination. **The framework has zero `asar` references**, so no operator can reach that path through AIOS. Nothing to fix here; removed locally.