### PR TITLE
fix(close-session): the duplicate-detector could never fire; brand-neutral examples; cache parity report

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,6 +82,17 @@ jobs:
           bash tests/update-tier0-denylist.test.sh
           echo "OK: tests/ + .github/ remain canonical-only, and Tier 0 is documented"
 
+      - name: close-session idempotency gate stays falsifiable
+        run: |
+          set -e
+          # The gate's FIRST version was inert: it compared the stamped hash against HEAD, but
+          # appending a block COMMITS it, so HEAD always advanced and the equal branch was
+          # unsatisfiable by construction. Its logic had 9 trap cases; its reachability had
+          # none. Test 1 asserts the duplicate branch CAN fire; test 2 asserts the original
+          # logic answers differently on that same input — so neither can pass vacuously.
+          bash tests/close-session-idempotency.test.sh
+          echo "OK: the duplicate branch is reachable and the fix is falsifiable"
+
       - name: Required infra folders + custom/ subfolders exist
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@
 
 ---
 
-## 2026-08-13 — `/aios:update` left empty directories in vault roots, and nothing could see them
+## 2026-08-13 — `/aios:update` left empty directories in vault roots, and two checks could not fire
 
-`hash: 200bec5`
+`hash: 200bec5 · 7b5a2d9`
 
 ### Stray empty directories from a previous update are now found and removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,26 @@
 
 **Action required — none.** The sweep is its own once-per-run step (3.9), so it runs on your next `/aios:update` **even if nothing else changed** — which matters, because the residue is damage from a *past* run: a vault that is already current is the most likely to be carrying it and the least likely to be looked at. To look now: `find ~/aios -maxdepth 1 -type d -name '*.[A-Za-z0-9]* *'`. Anything it lists is empty by construction, so `rm -rf` on it loses nothing.
 
+### `/close-session`'s duplicate-detector could never once fire
+
+> **What this delivers.** Yesterday's idempotency gate compared the stamped vault hash against the current `HEAD` — and appending a session block **commits** it, so `HEAD` advances on every close while the stamp can only hold the value from *before* that commit. `stamped == HEAD` was unsatisfiable **by construction**: the "HEAD moved → real work" branch always won, and the gate always appended. It had nine trap cases proving its logic and none proving it could fire. Measured on a live note: all four stamps differed from `HEAD`. It now compares **non-close commits** — every commit a close makes is prefixed `session: `, so excluding those asks the real question: *did anything happen other than me writing this block?*
+
+**What you can now do:**
+- **Actually get the protection.** A re-fired close — a retrying bus, a double-clicked button, an overlapping broadcast — is now detected and skipped instead of adding a near-duplicate block plus a second copy of the same Tier A/B candidates for `/close-day` to route.
+- **Still close twice on purpose.** A long session that closes at noon, works on, and closes again at 18:00 appends normally, because a non-`session:` commit landed in between.
+
+**Action required — none.** The gate is inside the command; nothing to run. If you closed a session between yesterday and today you may have one duplicate block — harmless, and `/close-day` reconciles it.
+
+*Locked with `tests/close-session-idempotency.test.sh`, now in CI. **Test 1 asserts the duplicate branch is reachable and test 2 asserts the original logic answers differently on the same input** — the reachability control whose absence is the entire reason this shipped broken. The lesson generalises: a comparison is only a check if both outcomes can happen, and "is it right?" is a different question from "does it run?"*
+
+### Real brand names removed from framework examples, and a plugin-cache parity report
+
+**What you can now do:**
+- **Read the docs without decoding someone else's ventures.** `START-HERE.md` and `/aios:company` illustrated multi-company mounting and voice sign-offs with the framework author's own brand names — which mean nothing in your vault. They now describe **roles and registers** (*"your own venture and a client's company"*, *"an institutional/precision-first voice"*), which is both neutral and more useful, since an archetype tells you how to pick *yours*.
+- **See a cache/manifest version gap before it becomes two live copies.** `/aios:update` now reports when your installed plugin-cache directory is named for an older version than `plugin.json` declares, and gives you the aligning command (`claude plugin update aios@the-aios`). Harmless today — the sync globs any version directory — but if a re-resolve mints a new one, the old directory lingers and the sync keeps writing to **both**. It **reports and never prunes**: the running client may hold references, and a wrong deletion costs you your working commands to save a few kilobytes.
+
+**Action required — none.** Both are silent when there is nothing to say.
+
 ### Also shipped: the company template's stock examples no longer name anyone real
 
 The sibling [`company-template`](https://github.com/The-AIOS/company-template) repo (`85d09e3`, PR #1 — **not** this repo, so it is not part of this hash) shipped **four** personal references in `agents/onboarding-{company}.md`: a change-digest example naming a real teammate, two voice sign-off examples naming real brands, and a post-sync nudge hardcoding one of those brands where a `{company}` placeholder belonged. That file is copied into **every scaffolded company repo**, so each reference propagated into other operators' repositories. Fixed, with a role-aware `personal_leak` CI job that enforces only in the template and skips scaffolded repos — because your own venture-context repo *should* name your own people.

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -35,7 +35,7 @@ The AIOS uses three layers of repos, each with a different concern:
 | **The AIOS framework** (`The-AIOS/aios` — public) | Shared infrastructure (commands, hooks, MCPs, plugins, skills, agent bundles, templates) | **No** — pulls only via `/aios:update`. Updates from upstream flow to everyone on AIOS. |
 | **Company venture-context repo(s)** (`{org}/venture-context` — per company you mount) | Company-specific shared knowledge (about, positioning, GTM, pricing, design.md, brand.md, CLAUDE.md operating manual, primitives, culture) | Depends on access — write permission lives in GitHub/Drive. From the AIOS side it's **pulled only** via `/company --sync`. |
 
-**Multi-company support:** you can mount **0, 1, or many** companies. An independent consultant might mount their own ChuyCepeda venture AND a client's company. A Sovra employee mounts just Sovra. A non-business operator mounts none. The model adapts.
+**Multi-company support:** you can mount **0, 1, or many** companies. An independent consultant might mount their own venture **and** a client's company. Someone employed at one company mounts just that one. A non-business operator mounts none. The model adapts.
 
 **This separation is intentional:**
 - Your personal observations never leak upstream

--- a/plugins/aios/commands/close-session.md
+++ b/plugins/aios/commands/close-session.md
@@ -63,17 +63,26 @@ Announce the detected mode: "Detected: **vault session** — writing to daily no
    ```bash
    NOTE="$HOME/aios/vault/01 - calendar/{YYYY-MM}/{YYYY-MM-DD}.md"
    SID="${CLAUDE_CODE_SESSION_ID:-unknown}"
-   VHEAD=$(git -C "$HOME/aios" rev-parse HEAD)
 
-   # Did this session already stamp a block, and was the vault at the same commit then?
+   # Did this session already stamp a block on this note?
    PRIOR=$(grep -o "<!-- close-session: ${SID} @ [0-9a-f]* -->" "$NOTE" 2>/dev/null | tail -1)
+   STAMPED=$(printf '%s' "$PRIOR" | sed -E 's/.* @ ([0-9a-f]*) -->/\1/')
+
+   # Has any NON-CLOSE work landed since that stamp? Every commit a close makes is
+   # prefixed "session: ", so excluding those isolates real work from the close's
+   # own bookkeeping.
+   if [ -n "$STAMPED" ]; then
+     WORK=$(git -C "$HOME/aios" log --format=%s "${STAMPED}..HEAD" 2>/dev/null | grep -cvE '^session: ')
+   fi
    ```
 
-   - **A prior stamp exists AND its hash equals `$VHEAD`** → nothing has been committed since that close. This is a **duplicate**: skip the append, skip every step below, and say so plainly (*"already closed at {HH:MM}; no commits since — not duplicating"*). Under `--auto` this is the normal outcome of a re-fire and must not read as an error.
-   - **A prior stamp exists but its hash DIFFERS** → real work landed since. This is a **legitimate second close**: proceed and append a new block. A long session that closes at noon, works on, and closes again at 18:00 is a case the gate must never block.
+   - **A prior stamp exists AND `$WORK` is 0** → nothing but this command's own commits have landed. This is a **duplicate**: skip the append, skip every step below, and say so plainly (*"already closed at {HH:MM}; no work since — not duplicating"*). Under `--auto` this is the normal outcome of a re-fire and must not read as an error.
+   - **A prior stamp exists AND `$WORK` is ≥ 1** → real work landed since. This is a **legitimate second close**: proceed and append a new block. A long session that closes at noon, works on, and closes again at 18:00 is a case the gate must never block.
    - **No prior stamp** → first close today for this session. Proceed.
 
-   > **Why the vault HEAD and not a timestamp:** elapsed time does not distinguish a duplicate from real work — a re-fire two minutes later and a genuine second close two minutes later look identical by clock. `HEAD` moves if and only if something was committed, which is the property actually being asked about. And it is *measured*, not inferred. (`SID` falls back to `unknown` rather than failing: a session with no id still gets a block — degrading to the old always-append behaviour is the right failure direction, since a missing block is worse than a duplicated one.)
+   > **Why non-close commits and not the raw HEAD.** The first version of this gate compared the stamped hash directly against the current `HEAD`, and it was **inert** — it could never once fire. Appending a block *commits* it (`aios-note-append` → `aios-commit`), so `HEAD` advances on every close, while the stamp can only record the value from *before* that commit. `stamped == HEAD` was therefore unsatisfiable by construction, the "HEAD moved → real work" branch always won, and the gate always appended. Measured on a live note: all four stamps differed from `HEAD`. **Excluding `session: `-prefixed commits is what makes the two sides comparable** — it asks "did anything happen other than me writing this block", which is the actual question. (`SID` falls back to `unknown` rather than failing: a session with no id still gets a block, degrading to always-append, because a missing block is worse than a duplicated one.)
+   >
+   > **The lesson generalises past this gate:** a comparison is only a check if both outcomes are *reachable*. When you write one, prove the equal branch can happen — `tests/close-session-idempotency.test.sh` asserts exactly that, and it fails against the original logic.
 
    **Stamp the block you are about to write** — immediately under its `## Session —` heading, so the next invocation can find it:
 

--- a/plugins/aios/commands/company.md
+++ b/plugins/aios/commands/company.md
@@ -370,7 +370,7 @@ Default (a) if no answer in 60s.
   - Path A product-walk reordered to match the operator's actual offering ladder structure
   - Bilingual / multilingual code-switching rules if voice.md indicates them
   - Voice-specific examples in the change-digest section (drawn from positioning + brand)
-  - Sign-off line in the company's tone (Sovra's "Bienvenido al equipo"; ChuyCepeda's "Clarity before velocity. AI amplifies what is already clear.")
+  - Sign-off line in the company's tone — read its `voice.md` and match the register, e.g. an institutional/precision-first voice lands "Bienvenido al equipo" while a warm/philosophical one lands something closer to "Clarity before velocity."
   
   Show the diff. Operator accepts / edits / reverts to (a). Ship the accepted version.
 
@@ -378,7 +378,7 @@ Default (a) if no answer in 60s.
 
 **Always tell the operator they can edit the agent any time post-create** — it lives at `agents/onboarding-{company}.md` in the repo. Edits propagate to mounters on their next `/aios:company --sync`.
 
-**Why offer (b):** the template is necessarily generic (it serves Sovra + ChuyCepeda + Acme + any future operator equally). But each company has a *distinct* voice + offering shape that the template can't anticipate. Claude has the just-filled context fresh in mind and can spot specific customizations that improve fit — it's a low-cost, high-value moment of polish.
+**Why offer (b):** the template is necessarily generic (it serves every mounted company equally — yours, your client's, any future operator's). But each company has a *distinct* voice + offering shape that the template can't anticipate. Claude has the just-filled context fresh in mind and can spot specific customizations that improve fit — it's a low-cost, high-value moment of polish.
 
 ### Step 5 — Push to remote
 
@@ -591,7 +591,7 @@ If `about_venture.md` changed, surface Tier-3 advisory: *"ℹ️ The `{name}` ve
 If the sync was **substantive** (≥1 new file OR ≥3 modified files in `context/`/`agents/`/`templates/`/`plugins/`/`hooks/`/`mcps/`/`skills/`), AND the bundle ships `agents/onboarding-{name}.md`, **offer** (don't auto-fire) the digest:
 
 ```
-🆕 Sovra-context shipped N changes since your last sync. Want a brief
+🆕 {company}-context shipped N changes since your last sync. Want a brief
    digest from the onboarding agent? (yes / skip)
 ```
 

--- a/plugins/aios/commands/update.md
+++ b/plugins/aios/commands/update.md
@@ -155,6 +155,16 @@ Concrete rules for what's currently in the framework (the operator-environment-s
   # cache path is VERSION-AGNOSTIC — glob the installed version dir (never hard-pin a version; the plugin bumps but this string outlives the bump). Guard handles the no-match case.
   for d in "$HOME"/.claude/plugins/cache/the-aios/aios/*/commands/; do [ -d "$d" ] && cp $HOME/aios/plugins/aios/commands/*.md "$d"; done
   ```
+
+  **Then report cache/manifest version parity — do not act on it.** The glob above is deliberately version-agnostic, so the sync is *correct* even when the installed cache directory is named for an older version than the manifest declares. But that mismatch means the plugin has not been re-resolved since the last version bump, and it has a real consequence worth naming: if a re-resolve ever mints a directory for the new version, **the old one lingers and the loop above keeps writing to both forever** — a second copy that is live, invisible, and drifts the moment anything writes to only one of them.
+
+  ```bash
+  MANIFEST=$(python3 -c "import json;print(json.load(open('$HOME/aios/plugins/aios/.claude-plugin/plugin.json'))['version'])" 2>/dev/null)
+  CACHED=$(for d in "$HOME"/.claude/plugins/cache/the-aios/aios/*/; do [ -d "$d" ] && basename "$d"; done | tr '\n' ' ')
+  # Report only — never delete a cache directory the running client may hold open.
+  ```
+
+  If `$CACHED` names anything other than `$MANIFEST`, say so once and give the operator the aligning command — *"plugin cache is at {cached} while the manifest declares {manifest}; `claude plugin update aios@the-aios` realigns it. Harmless today (the sync is version-agnostic), worth doing before it becomes two live copies."* **Never prune the directory yourself**: the running client may hold references, and a wrong deletion costs the operator their working commands to save a few kilobytes. If `$CACHED` is empty, say nothing — a directory-source install may legitimately have no cache yet.
 - **`mcps/setup.sh` or any other dep-installer updated** → surface in the report as a recommended manual step, with the exact command. Don't auto-run.
 
 If a future framework update adds a new state-producing installer under `hooks/`, the principle extends naturally — add it to the rule above and it gets auto-run. Library scripts (`*.py` invoked indirectly) are picked up by their callers; no auto-execution needed.

--- a/tests/close-session-idempotency.test.sh
+++ b/tests/close-session-idempotency.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression suite for /close-session Mode A's idempotency gate (Step 4.5).
+#
+# The gate exists because a misbehaving command bus delivered `/aios:close-session --auto`
+# to one session four times in twelve minutes (2026-08-12). Four blocks would have meant
+# four copies of the same wins in the daily note AND four copies of the same Tier A/B
+# candidates for /close-day to route into observed context.
+#
+# The FIRST version of the gate compared the stamped vault hash directly against the
+# current HEAD. It was inert: appending a block commits it, so HEAD advances on every
+# close, while the stamp can only hold the pre-commit value. `stamped == HEAD` was
+# unsatisfiable, so the gate always appended and could never once fire.
+#
+# TEST 1 IS THE CONTROL THAT WOULD HAVE CAUGHT THAT, and it is the reason this file
+# exists: it asserts the duplicate branch is REACHABLE. A comparison whose equal branch
+# cannot happen is not a check. Every other test here is downstream of that one.
+
+set -u
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+have(){ [ "$1" = "$2" ] && ok "$3" || { no "$3"; printf '       expected %s, got %s\n' "$2" "$1"; }; }
+
+WORK=$(mktemp -d) || { echo "cannot mktemp"; exit 1; }
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK" || exit 1
+
+git init -q . 2>/dev/null
+git config user.email t@example.com; git config user.name Test; git config commit.gpgsign false
+
+SID="11111111-2222-3333-4444-555555555555"
+NOTE="note.md"
+
+# --- the gate, transcribed from close-session.md Step 4.5 -------------------
+# Returns: SKIP (duplicate) | APPEND (first close or real work since)
+gate(){
+  local sid="$1"
+  local prior stamped work
+  prior=$(grep -o "<!-- close-session: ${sid} @ [0-9a-f]* -->" "$NOTE" 2>/dev/null | tail -1)
+  [ -z "$prior" ] && { echo APPEND; return; }
+  stamped=$(printf '%s' "$prior" | sed -E 's/.* @ ([0-9a-f]*) -->/\1/')
+  work=$(git log --format=%s "${stamped}..HEAD" 2>/dev/null | grep -cvE '^session: ')
+  [ "$work" -eq 0 ] && echo SKIP || echo APPEND
+}
+
+# --- the ORIGINAL (broken) gate, kept so test 1 can prove it fails ---------
+gate_v1(){
+  local sid="$1" prior stamped head
+  prior=$(grep -o "<!-- close-session: ${sid} @ [0-9a-f]* -->" "$NOTE" 2>/dev/null | tail -1)
+  [ -z "$prior" ] && { echo APPEND; return; }
+  stamped=$(printf '%s' "$prior" | sed -E 's/.* @ ([0-9a-f]*) -->/\1/')
+  head=$(git rev-parse HEAD)
+  [ "$stamped" = "$head" ] && echo SKIP || echo APPEND
+}
+
+# simulate a close: stamp the CURRENT head into the note, then commit the note
+# (this ordering is the whole point — the stamp cannot know its own commit's hash)
+do_close(){
+  local sid="$1"
+  printf '## Session — 10:00 | work\n<!-- close-session: %s @ %s -->\nbody\n\n' \
+    "$sid" "$(git rev-parse HEAD)" >> "$NOTE"
+  git add "$NOTE"; git commit -q -m "session: 10:00 work"
+}
+
+printf 'close-session idempotency gate\n'
+
+echo "seed" > f; git add f; git commit -q -m "initial work"
+
+# ---------------------------------------------------------------------------
+# TEST 1 — THE CONTROL. The duplicate branch must be reachable.
+# ---------------------------------------------------------------------------
+do_close "$SID"
+have "$(gate "$SID")" "SKIP" "1. duplicate branch is REACHABLE — a re-fire right after a close SKIPs"
+
+# ---------------------------------------------------------------------------
+# TEST 2 — the same scenario against the original logic. MUST differ, or test 1
+# proves nothing about the fix (a test that passes both ways is not a regression test).
+# ---------------------------------------------------------------------------
+have "$(gate_v1 "$SID")" "APPEND" "2. original logic returns APPEND on that same duplicate (i.e. was inert)"
+
+# ---------------------------------------------------------------------------
+# TEST 3 — real work since the stamp must still append.
+# ---------------------------------------------------------------------------
+echo "more" >> f; git add f; git commit -q -m "feat: real work landed"
+have "$(gate "$SID")" "APPEND" "3. real (non-close) work since the stamp → APPEND"
+
+# ---------------------------------------------------------------------------
+# TEST 4 — a second close after real work stamps again and re-arms the gate.
+# ---------------------------------------------------------------------------
+do_close "$SID"
+have "$(gate "$SID")" "SKIP" "4. after a legitimate 2nd close, a further re-fire SKIPs again"
+
+# ---------------------------------------------------------------------------
+# TEST 5 — a DIFFERENT session must never be blocked by another's stamp.
+# ---------------------------------------------------------------------------
+have "$(gate "99999999-8888-7777-6666-555555555555")" "APPEND" "5. a different session id → APPEND (never blocked by a peer)"
+
+# ---------------------------------------------------------------------------
+# TEST 6 — several close commits in a row (block + observed context) still read as 0 work.
+# ---------------------------------------------------------------------------
+git commit -q --allow-empty -m "session: 2026-08-13 observed context — routed inline"
+have "$(gate "$SID")" "SKIP" "6. multiple 'session:' commits (block + observed) still count as no work"
+
+# ---------------------------------------------------------------------------
+# TEST 7 — an unstamped legacy note appends (forward-only, loses nothing).
+# ---------------------------------------------------------------------------
+printf '## Session — 09:00 | legacy\nbody\n' > "$NOTE"
+have "$(gate "$SID")" "APPEND" "7. legacy note with no stamp → APPEND"
+
+# ---------------------------------------------------------------------------
+# TEST 8 — a missing session id degrades to append, never to silence.
+# ---------------------------------------------------------------------------
+have "$(gate "unknown")" "APPEND" "8. SID 'unknown' → APPEND (degrade toward a block, never lose one)"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Three fixes plus a release-flow change that resolves a carry which had been offered four times.

## 1. The idempotency gate could never once fire

Yesterday's gate compared the stamped vault hash against the current `HEAD`. But appending a block **commits** it (`aios-note-append` → `aios-commit`), so `HEAD` advances on every close, while the stamp can only hold the value from *before* that commit. **`stamped == HEAD` was unsatisfiable by construction** — the "HEAD moved → real work" branch always won and the gate always appended.

Measured on a live note: all four stamps differed from `HEAD`.

**Fix:** count commits since the stamp whose subject does *not* start with `session: `. Every commit a close makes carries that prefix, so excluding them asks the real question — *did anything happen other than me writing this block?*

**Why it shipped broken:** the gate had **nine trap cases proving its logic and zero proving it could fire.** #94 already names this family; this is the variant *both branches must be attainable*.

**Locked with close-session idempotency gate
  ok   1. duplicate branch is REACHABLE — a re-fire right after a close SKIPs
  ok   2. original logic returns APPEND on that same duplicate (i.e. was inert)
  ok   3. real (non-close) work since the stamp → APPEND
  ok   4. after a legitimate 2nd close, a further re-fire SKIPs again
  ok   5. a different session id → APPEND (never blocked by a peer)
  ok   6. multiple 'session:' commits (block + observed) still count as no work
  ok   7. legacy note with no stamp → APPEND
  ok   8. SID 'unknown' → APPEND (degrade toward a block, never lose one)

8 passed, 0 failed** (8 tests, now a CI step):
- **Test 1** asserts the duplicate branch is *reachable* — the control whose absence is the entire reason this shipped
- **Test 2** asserts the **original** logic answers differently on that same input, so test 1 cannot pass vacuously

## 2. Real brand names out of framework examples

`START-HERE.md` and `/aios:company` illustrated multi-company mounting and voice sign-offs with the framework author's own venture names — 4 sites. They resolve to nothing in a stranger's vault, and an archetype is better teaching anyway: *"an institutional / precision-first voice"* tells a reader how to pick **theirs**. Now roles and registers throughout.

`CHANGELOG` keeps its historical occurrences **deliberately** — those describe what changed, and rewriting them would be worse than leaving them.

## 3. Plugin-cache parity report

`/aios:update` now reports when the installed cache directory is named for an older version than `plugin.json` declares (live here: cache `0.4.0`, manifest `0.5.0`). The sync is already version-agnostic, so this is harmless **today** — but if a re-resolve mints a directory for the new version, the old one lingers and the loop keeps writing to **both**, giving two live copies that drift the moment anything writes to one.

**Reports and never prunes:** the running client may hold references, and a wrong deletion costs the operator their working commands to save a few kilobytes.

## 4. The release flow no longer needs a push to `main`

This entry cites `hash: 200bec5 · 7b5a2d9` — the second is **this PR's head**, which already resolves. No `TBD-ON-MERGE`.

That placeholder existed only because entries cited the *merge* commit, which doesn't exist while the PR is open. It was **forgotten twice yesterday** (#16 unfilled, #17 with no entry at all), and filling it afterwards requires a commit pushed **directly to `main`** — which is precisely why branch protection was incompatible with this flow, and why that carry sat unresolved through four offers.

A PR head is an ancestor of `main` after merge, so `merge-base --is-ancestor` resolves it identically. **Verified against two already-merged PR heads (`954f81a`, `af019a2`) before adopting it here.**

## Verification

`aios-commit` 17/17 · tier0 7/7 · **close-session idempotency 8/8** · `validate.yml` 12 jobs · zero real brands outside CHANGELOG · CHANGELOG amended in place (same day, one entry, four subsections).

Not included, by your call: antifragile compaction (you're on it), and branch protection — which I'd now **drop as worded**, since removing the direct-to-`main` step is the fix it was reaching for.