### PR TITLE
fix(update): the changelog scan hid entries and Step 2 under-reported — both found by RUNNING the command

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -111,6 +111,25 @@ jobs:
           bash tests/source-detector.test.sh
           echo "OK: template prose does not vote on the operator's configuration"
 
+      - name: Changelog scan handles multi-hash entries; layer pathspec is an array
+        run: |
+          set -e
+          # Two silent bugs found by RUNNING /aios:update instead of hand-executing it.
+          # The scan took the first of N cited hashes, so a day's entry with 3 synced +
+          # 1 new hash read as fully synced and its new subsections were never shown.
+          # And the layer pathspec was a space-joined string passed unquoted — under
+          # zsh (the session shell) that is ONE pathspec matching nothing, so every
+          # layer change was invisible to Step 2 while Step 6.5 quietly applied it.
+          #
+          # ⚠️ The dynamic half of this suite REQUIRES zsh: under bash the buggy form
+          # works, so a bash-only run cannot prove it. Install zsh here so the proof
+          # actually executes rather than reporting a skip that reads like a pass.
+          sudo apt-get install -qq -y zsh >/dev/null 2>&1 || true
+          command -v zsh >/dev/null 2>&1 && echo "zsh present — dynamic proof will run" \
+            || echo "::warning::zsh unavailable; only the static assertions will run"
+          bash tests/update-changelog-scan.test.sh
+          echo "OK: multi-hash entries surface, and the layer pathspec survives zsh"
+
       - name: SETUP.md prescribes the right Claude Code installer per platform
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,26 @@
 
 ## 2026-08-13 — Four checks that reported green without measuring, and a setup step that could not fail loudly
 
-`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8`
+`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · {PR-HEAD}`
+
+### `/aios:update` was hiding new changelog entries and under-reporting what it synced
+
+> **What this delivers.** Two silent bugs in `/aios:update` itself, found by **running** the command rather than hand-executing its steps. Neither ever failed: the sync landed correctly both times, only the *account* of it was wrong — which is the worst combination, because there is nothing to notice.
+>
+> **1. A day's entry could hide its own later sections.** The changelog scan assumed **one hash per entry**. Entries now accumulate a `###` subsection per merge, each citing its own PR head — so today's cites six. The scan checked the *first* hash, and if that one was already synced it declared the whole entry synced and **stopped**. An operator who synced mid-morning would never be shown the afternoon's subsections, and any `Action required` inside them would never run.
+>
+> **2. Every layer change was invisible to Step 2.** The layer pathspec was built as a space-joined string and passed **unquoted**. Your session shell is **zsh**, which performs no word splitting on unquoted expansion, so `agents/ hooks/ plugins/ …` arrived at `git diff` as **one** pathspec matching nothing. Measured on a live vault: **0 paths** unquoted versus **1** with a quoted array. Only the individually-quoted root docs survived. Step 6.5's reconcile applied the files anyway — which is exactly why nobody noticed.
+
+**What you can now do:**
+- **See every entry that applies to you.** An entry counts as new if **any** of its hashes is unsynced; scanning stops only when **all** of them are ancestors. Being shown a subsection twice is a trivially cheaper error than being shown none.
+- **Trust the "Applied (Tier 1)" list.** Step 2 now reports what actually changed instead of silently listing only root docs.
+- **Rely on an unreachable hash never counting as "synced."** It falls back to date+title comparison rather than satisfying the test by accident.
+
+**Action required — none.** Both are inside the command. If a past sync seemed to show fewer changes than expected, this is why.
+
+*Locked with `tests/update-changelog-scan.test.sh` (11 assertions). **The dynamic half requires zsh, and CI installs it deliberately** — under bash the buggy pathspec *works*, so a bash-only test passes on broken code, which is precisely how this survived weeks of green CI. Test 3 asserts the old rule hid the entry; test 11 reproduces the 0-paths failure. The three static assertions fail against the pre-fix spec.*
+
+*Found on the first run of `/aios:update` as an actual command rather than by hand — the operator's "be user 0 of every update" rule, earning itself on its first outing. Hand-executing performs the author's **intent**; only the real invocation executes the **literal code**.*
 
 ### Setup step 5 could leave you with a `claude` that doesn't run — now it can't
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ## 2026-08-13 — Four checks that reported green without measuring, and a setup step that could not fail loudly
 
-`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · {PR-HEAD}`
+`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · 1c4d72d`
 
 ### `/aios:update` was hiding new changelog entries and under-reporting what it synced
 

--- a/plugins/aios/commands/update.md
+++ b/plugins/aios/commands/update.md
@@ -242,8 +242,19 @@ If the SSH clone fails on a non-Windows machine, retry with the HTTPS form (`git
 
 Read `CHANGELOG.md` from the cloned repo root. If absent, skip silently. Otherwise:
 
-1. Parse `## ` entries (each is `## YYYY-MM-DD — title` followed by `` `hash: {short_hash}` ``).
-2. For each entry newest first, check if synced via `git -C /tmp/aios-update-check merge-base --is-ancestor {entry_hash} {stored_hash}` (exit 0 = synced, stop scanning; exit 1 = new, collect; exit 128 = hash unreachable in cloned repo → fall back to content-comparison against local CHANGELOG.md by date header + title).
+1. Parse `## ` entries. Each is `## YYYY-MM-DD — title` followed by `` `hash: {short_hash}` `` — **and that field carries one OR MANY hashes**, ` · `-separated (`` `hash: 200bec5 · 7b5a2d9 · 7055d09` ``), because a day's entry accumulates a `###` subsection per merge and each cites its own PR head. Parse the field into a **list**, always; a single hash is just a list of one.
+2. **For each entry newest first, an entry is NEW if ANY of its hashes is not yet synced. Stop scanning only when ALL of an entry's hashes are ancestors of `{stored_hash}`.**
+
+   ```bash
+   # Per hash: exit 0 = ancestor (synced) · exit 1 = new · 128 = unreachable in the clone.
+   git -C /tmp/aios-update-check merge-base --is-ancestor {hash} {stored_hash}
+   ```
+
+   - **any hash → exit 1** → the entry is **NEW**: collect it and keep scanning older entries.
+   - **every hash → exit 0** → fully synced: stop scanning.
+   - **any hash → exit 128** (unreachable) → treat that hash as **inconclusive, not synced**, and fall back to content-comparison against the local `CHANGELOG.md` by date header + title. Never let an unreachable hash *satisfy* the synced test.
+
+   > **Why "any", and why this is not a hypothetical.** The rule used to read *"check `{entry_hash}`… exit 0 = synced, stop scanning"*, written when an entry cited exactly one hash. Same-day accumulation broke that silently: on 2026-08-13 the entry cited **five** hashes, of which the first four were already ancestors of an operator's stored hash and the fifth was not. Taking the first hash returns exit 0, the scan stops, and **the entry reads as fully synced** — so the afternoon's subsections are never shown, and any `Action required` inside them is never executed. The operator sees a silent, plausible "nothing new" and has no way to notice. **The failure mode is under-reporting, which is exactly what a changelog cannot afford**, so bias the test the other way: one unsynced hash makes the whole entry new, and showing an already-seen subsection twice is a trivially cheaper error than hiding one.
 3. If new entries exist, show them before applying changes — **lead with each entry's "What you can now do" section** (the plain-language capability read — this is the part that actually tells the operator what the new version unlocks; read it back to them, don't make them open the file), then **Action required** (skip Why/FYI for brevity; full details in CHANGELOG.md). Aggregate + deduplicate Action required across all new entries. If an entry predates the convention and has no "What you can now do" section, fall back to its "What changed" / "What you're getting".
 4. Execute the action items inline as part of this run — don't list them and wait for the operator to ask. This command IS the implementation arm of CHANGELOG action items.
    - **After applying, close with a one-line-per-capability recap** — *"This update lets you: {do X}, {do Y}, {do Z}."* — so the operator leaves the sync knowing what they gained, not just that files changed. (This is the comprehension-debt guard for the framework's own release channel: an update the operator can't translate into a capability is debt, not a gift.)
@@ -267,11 +278,13 @@ CLONE="/tmp/aios-update-check"
 TIER0_DENY="tests .github vault .git .gitattributes"
 
 # Every top-level directory canonical actually has, minus the denylist.
-LAYERS=""
+# MUST be an ARRAY. A space-joined string here is the bug documented under the
+# `git diff` call below — it reaches git as ONE pathspec and matches nothing.
+LAYERS=()
 for d in $(cd "$CLONE" && ls -A); do
   [ -d "$CLONE/$d" ] || continue
   case " $TIER0_DENY " in *" $d "*) continue ;; esac
-  LAYERS="$LAYERS $d/"
+  LAYERS+=("$d/")          # ARRAY, not a space-joined string — see the note below
 done
 
 # Root docs stay ENUMERATED here on purpose — do not "finish the job" by deriving them
@@ -282,11 +295,24 @@ done
 # generically, so the belt (enumerated + guarded) and the braces (generic reconcile) are
 # deliberately different mechanisms. The DIRECTORY list below is the one that had no
 # equivalent guard, and is therefore the one that is derived.
+# ⚠️ `"${LAYERS[@]}"` — QUOTED ARRAY EXPANSION, never a bare `$LAYERS`. This line
+# carried the exact word-splitting bug that Step 3 warns about in prose, and it
+# went unnoticed for weeks because the *symptom is silence*: the session's shell
+# is zsh, which performs NO word splitting on unquoted parameter expansion, so a
+# space-joined "agents/ hooks/ plugins/ …" arrived at git as ONE pathspec that
+# matches nothing. Measured on a live vault the day it was found:
+#     unquoted $LAYERS  → 0 paths
+#     quoted array      → 1 path (plugins/aios/commands/update.md)
+# Every LAYER change was therefore invisible to this step; only the individually
+# quoted root docs above survived. Nothing failed — Step 6.5's reconcile applied
+# the files anyway — so the sync still landed while THIS step's report was wrong,
+# which is the worst combination: correct outcome, false account of it.
+# Bash 3.2 (macOS system bash) and zsh both handle `"${arr[@]}"` correctly.
 git -C "$CLONE" diff {stored_hash}..HEAD --name-only -- \
   "README.md" "START-HERE.md" "SETUP.md" "TOOLS.md" "CHEATSHEET.md" \
   "CONTRIBUTING.md" "CHANGELOG.md" "CLAUDE.md" "AGENTS.md" "EXTENSION-MAP.md" "LICENSE-AUDIT.md" \
   "LICENSE" "NOTICE" "FORTRESS.md" ".gitignore" \
-  $LAYERS "vault/.obsidian/"
+  "${LAYERS[@]}" "vault/.obsidian/"
 ```
 
 > ⚠️ **If you touch `TIER0_DENY`, you are changing what ships to every operator vault.** `.github/workflows/validate.yml` fails the build if `tests` or `.github` leave that list — deliberately, because this is the one edit whose blast radius is every vault at once.

--- a/tests/update-changelog-scan.test.sh
+++ b/tests/update-changelog-scan.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Regression suite for two bugs in /aios:update found by RUNNING the command
+# (2026-08-13) rather than hand-executing its steps. Both were silent: the sync still
+# landed, so nothing failed — only the account of it was wrong.
+#
+#   1. Step 1.5's changelog scan assumed ONE hash per entry. Same-day accumulation made
+#      entries cite many (`hash: a · b · c`), and taking the first returned "synced" for
+#      an entry whose later subsections were new — so the operator was never shown them
+#      and their `Action required` never ran.
+#
+#   2. Step 2 built its layer pathspec as a SPACE-JOINED STRING and passed it unquoted.
+#      THE SESSION SHELL IS ZSH, WHICH DOES NOT WORD-SPLIT, so the whole list reached
+#      git as one pathspec matching nothing: every layer change invisible to Step 2.
+#
+# TEST 3 IS THE ONE THAT MATTERS FOR BUG 2, AND IT MUST RUN UNDER ZSH.
+# Under bash the buggy form WORKS (bash word-splits), so a bash-only test passes on
+# broken code — that is precisely why this survived weeks of green CI.
+
+set -u
+PASS=0; FAIL=0; SKIP=0
+ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+sk(){ SKIP=$((SKIP+1)); printf '  skip %s\n' "$1"; }
+have(){ [ "$1" = "$2" ] && ok "$3" || { no "$3"; printf '       expected %s, got %s\n' "$2" "$1"; }; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPEC="$ROOT/plugins/aios/commands/update.md"
+[ -f "$SPEC" ] || { echo "cannot find update.md"; exit 1; }
+
+printf '/aios:update — changelog scan + layer pathspec\n'
+
+# ═══════════════════════════════════════════════════════════════════
+# BUG 1 — multi-hash changelog entries
+# ═══════════════════════════════════════════════════════════════════
+WORK=$(mktemp -d) || exit 1
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK" || exit 1
+git init -q .; git config user.email t@t; git config user.name t; git config commit.gpgsign false
+for i in 1 2 3 4 5; do echo "c$i" > f; git add f; git commit -qm "commit $i"; done
+H1=$(git rev-parse --short=7 HEAD~4); H2=$(git rev-parse --short=7 HEAD~3)
+H3=$(git rev-parse --short=7 HEAD~2); H5=$(git rev-parse --short=7 HEAD)
+STORED=$(git rev-parse HEAD~2)          # operator synced up to the 3rd commit
+
+# The rule under test: an entry is NEW if ANY cited hash is not an ancestor of STORED.
+entry_state(){ # $@ = hashes
+  local any_new=0 all_ok=1 h
+  for h in "$@"; do
+    if git merge-base --is-ancestor "$h" "$STORED" >/dev/null 2>&1; then :
+    else any_new=1; all_ok=0; fi
+  done
+  [ "$any_new" -eq 1 ] && echo NEW || echo SYNCED
+}
+# The OLD rule: look at the first hash only.
+entry_state_v1(){ git merge-base --is-ancestor "$1" "$STORED" >/dev/null 2>&1 && echo SYNCED || echo NEW; }
+
+have "$(entry_state "$H1" "$H2" "$H3")"      "SYNCED" "1. entry whose every hash is an ancestor → SYNCED"
+have "$(entry_state "$H1" "$H2" "$H3" "$H5")" "NEW"   "2. entry with 3 synced + 1 new hash → NEW (the reported bug)"
+have "$(entry_state_v1 "$H1")"                "SYNCED" "3. OLD rule returns SYNCED for that same entry (i.e. it hid it)"
+have "$(entry_state "$H5")"                   "NEW"    "4. single new hash → NEW (single-hash case still works)"
+have "$(entry_state "$H1")"                   "SYNCED" "5. single old hash → SYNCED"
+# An unreachable hash must never SATISFY the synced test.
+have "$(entry_state "$H1" "deadbeef")"        "NEW"    "6. unreachable hash counts as NOT synced, never as synced"
+
+# ═══════════════════════════════════════════════════════════════════
+# BUG 2 — the layer pathspec. Static assertion first (runs everywhere).
+# ═══════════════════════════════════════════════════════════════════
+grep -q '"${LAYERS\[@\]}"' "$SPEC" \
+  && ok "7. spec passes the layer list as a QUOTED ARRAY expansion" \
+  || no "7. spec must use \"\${LAYERS[@]}\" — a bare \$LAYERS matches nothing under zsh"
+grep -qE '^\s*\$LAYERS\b' "$SPEC" \
+  && no "8. spec still contains a bare unquoted \$LAYERS pathspec" \
+  || ok "8. no bare unquoted \$LAYERS pathspec remains"
+grep -q 'LAYERS=()' "$SPEC" \
+  && ok "9. LAYERS is declared as an array, not a string" \
+  || no "9. LAYERS must be declared as an array"
+
+# ═══════════════════════════════════════════════════════════════════
+# BUG 2 — dynamic proof, UNDER ZSH. Skipped (loudly) if zsh is absent,
+# because under bash the buggy form works and the test would be vacuous.
+# ═══════════════════════════════════════════════════════════════════
+mkdir -p agents hooks plugins/aios/commands
+echo a > agents/x.md; echo b > hooks/y.py; echo c > plugins/aios/commands/z.md
+git add -A; git commit -qm "layers"
+BASE=$(git rev-parse HEAD)
+echo changed > plugins/aios/commands/z.md; git add -A; git commit -qm "change a layer file"
+
+if command -v zsh >/dev/null 2>&1; then
+  STR=$(zsh -c '
+    LAYERS=""
+    for d in agents hooks plugins; do LAYERS="$LAYERS $d/"; done
+    git diff --name-only '"$BASE"'..HEAD -- $LAYERS 2>/dev/null | grep -c . ' 2>/dev/null)
+  ARR=$(zsh -c '
+    LAYERS=()
+    for d in agents hooks plugins; do LAYERS+=("$d/"); done
+    git diff --name-only '"$BASE"'..HEAD -- "${LAYERS[@]}" 2>/dev/null | grep -c . ' 2>/dev/null)
+  have "${ARR:-0}" "1" "10. under zsh: QUOTED ARRAY finds the changed layer file"
+  have "${STR:-x}" "0" "11. under zsh: unquoted string finds NOTHING (the bug, reproduced)"
+else
+  sk "10-11. zsh not available — the dynamic proof cannot run here"
+  printf '       NOTE: under bash the buggy form WORKS, so a bash-only run of this\n'
+  printf '       suite cannot prove bug 2. macOS runners have zsh; the static\n'
+  printf '       assertions (7-9) are the portable guard.\n'
+fi
+
+printf '\n%d passed, %d failed, %d skipped\n' "$PASS" "$FAIL" "$SKIP"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
First invocation of `/aios:update` as an **actual command** rather than a hand-execution of its steps, per the operator's *"be user 0 of every update"* rule. It found two bugs on its first outing.

**Neither was reachable by hand-executing.** Hand-executing performs the author's **intent**; only the real invocation executes the **literal code**.

## Bug 1 — a day's entry could hide its own later subsections

Step 1.5 assumed **one hash per entry**. Entries now accumulate a `###` subsection per merge, each citing its own PR head (the flow adopted earlier today), so today's cites **six**. The rule read *"check `{entry_hash}` … exit 0 = synced, stop scanning"* — which takes the **first** hash. Measured live:

```
200bec5 → SYNCED     ← the scan stops here
7b5a2d9 → SYNCED
7055d09 → SYNCED
9c95388 → SYNCED
94963d8 → NEW        ← never shown to the operator
```

An operator who synced mid-morning would **never see the afternoon's subsections**, and any `Action required` inside them would never execute. Silent under-reporting — the one thing a changelog cannot do.

**Now:** an entry is NEW if **any** cited hash is unsynced; stop only when **all** are ancestors; an unreachable hash counts as *inconclusive-not-synced* so it can never **satisfy** the test. Deliberately biased — showing a seen subsection twice is far cheaper than hiding one.

## Bug 2 — every layer change was invisible to Step 2

The layer pathspec was a space-joined string passed **unquoted**. The session shell is **zsh**, which performs no word splitting on unquoted expansion, so the whole list reached `git diff` as **one** pathspec matching nothing:

| form | paths found |
|---|---|
| `-- $LAYERS` (unquoted string) | **0** |
| `-- "${LAYERS[@]}"` (quoted array) | **1** |

Only the individually-quoted root docs survived. **Nothing failed**, because Step 6.5's reconcile applied the files anyway — correct outcome, false account of it, nothing to notice.

This is the exact word-splitting class **Step 3 warns about in prose**, sitting in **Step 2's own code** — the fourth instance today of a rule existing while the code beside it breaks it.

Fixed to `LAYERS=()` + `"${LAYERS[@]}"`, with the measurement recorded inline so the next person tempted to simplify it sees the number. **Checked the sibling site:** Step 6.5's reconcile iterates one path at a time with proper quoting and is correct as written — which is precisely why it was the thing that saved the sync.

## The test, and why it installs zsh

`tests/update-changelog-scan.test.sh` — 11 assertions, wired into CI.

**The dynamic half requires zsh, and the workflow installs it on purpose.** Under bash the buggy pathspec **works** (bash word-splits), so a bash-only test **passes on broken code** — that is how this survived weeks of green CI. Installing zsh is the difference between a test and a decoration.

- **Test 3** asserts the *old* rule returns SYNCED for the mixed entry — i.e. that it hid it
- **Test 11** reproduces the 0-paths failure under real zsh
- The three **static** assertions fail against the pre-fix spec (verified)

Full gate: `aios-commit` 17/17 · tier0 7/7 · close-session 8/8 · source-detector 11/11 · **update-changelog-scan 11/11** · `validate.yml` 12 jobs.

## Why this matters beyond the two fixes

The operator's rule was *"I want to be user 0, even though it's less efficient, because it makes us live what our users live."* It paid for itself on the first run — and the specific mechanism is worth naming: **a hand-execution cannot find a bug in the instructions**, because the hand doing it already knows what was meant.