### PR TITLE
fix(close-session): the duplicate-detector counted PEERS' commits as this session's work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ## 2026-08-13 — Four checks that reported green without measuring, and a setup step that could not fail loudly
 
-`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · 1c4d72d · {PR-HEAD}`
+`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · 1c4d72d · a395d92`
 
 ### Your commits now say which session made them — and the duplicate-detector needed it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,23 @@
 
 ## 2026-08-13 — Four checks that reported green without measuring, and a setup step that could not fail loudly
 
-`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · 1c4d72d`
+`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · 1c4d72d · {PR-HEAD}`
+
+### Your commits now say which session made them — and the duplicate-detector needed it
+
+> **What this delivers.** A vault is written by **several Claude sessions at once**, and git cannot tell them apart: same author, same committer, no distinguishing field. So anything asking *"did **I** do this?"* had to infer it from the commit **subject** — a convention, not a fact. `/close-session`'s duplicate-detector was the first consumer to hit the limit: it counted every commit that was not its own close-bookkeeping, so **a peer's commit read as "this session did work"** and a spurious re-fire would append a duplicate block anyway. Measured the day it shipped: one session had **10 non-close commits since its stamp and only 1 was its own.**
+
+**What you can now do:**
+- **Tell your sessions' commits apart.** `aios-commit` writes an `AIOS-Session:` trailer, so `git log --format=%B | grep AIOS-Session` answers *who made this* — useful well beyond this fix when several agents share one vault.
+- **Get the duplicate-detector you were promised.** It now counts only commits carrying **your** session id, so a peer working in parallel can no longer make a re-fire look like new work.
+- **Keep working exactly as before if you're not a session.** The trailer is **additive**: no `CLAUDE_CODE_SESSION_ID` → no trailer. A human at a terminal, a script, or an older Claude is unaffected, and a session id containing anything but letters, digits or hyphens is **rejected rather than written** (a multi-line value would otherwise forge a trailer line).
+- **Rely on a safe degradation.** If no commit in the range carries a trailer — a vault predating this — the gate falls back to the old coarse rule, which errs toward **appending**. A duplicated block is recoverable; a missing one is lost work.
+
+**Action required — none.** The trailer starts appearing on your next commit; nothing is rewritten.
+
+*Locked with 3 new assertions in `tests/aios-commit.test.sh` (**20 passed**) and 5 in `tests/close-session-idempotency.test.sh` (**13 passed**). **Test 10 asserts the previous rule answers differently on the same state** — a peer commit where the old gate says APPEND and the new one says SKIP — so the fix cannot pass vacuously.*
+
+*Found while closing the session that shipped the detector, by running its own gate and reading the 10 commits it counted. **Record provenance; do not infer it from a naming convention.***
 
 ### `/aios:update` was hiding new changelog entries and under-reporting what it synced
 

--- a/hooks/aios-commit
+++ b/hooks/aios-commit
@@ -186,6 +186,28 @@ if [ "${#PARENTS[@]}" -gt 0 ] && GIT_INDEX_FILE="$TMPIDX" git diff-index --quiet
 fi
 
 TREE=$(GIT_INDEX_FILE="$TMPIDX" git write-tree) || die "write-tree failed"
+
+# ── session provenance trailer ────────────────────────────────────────────────
+# WHY: a vault is written CONCURRENTLY by several Claude sessions, and git cannot
+# tell them apart — same author, same committer, no distinguishing field. Anything
+# that needs to ask "did *I* do this?" has been forced to infer it from the commit
+# SUBJECT, which is a convention, not a fact. /close-session's duplicate detector
+# was the first consumer to hit the limit: it counts commits that are not its own
+# close-bookkeeping, so a PEER's commit reads as "this session did work" and a
+# spurious re-fire appends a duplicate block anyway. Measured 2026-08-13: 10
+# non-close commits since one session's stamp, only 1 of them its own.
+# Record the provenance instead of inferring it. Additive: an empty CLAUDE_CODE_SESSION_ID
+# (a human at a terminal, a script, an older Claude) simply omits the trailer, and every
+# consumer MUST treat "no trailer" as unknown-not-mine and degrade to its old behaviour.
+if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+  case "$CLAUDE_CODE_SESSION_ID" in
+    *[!a-zA-Z0-9-]*) : ;;    # refuse anything that could forge a trailer line
+    *) MSG="$MSG
+
+AIOS-Session: $CLAUDE_CODE_SESSION_ID" ;;
+  esac
+fi
+
 # ${PARENTS[@]+"${PARENTS[@]}"} — PARENTS is EMPTY on a root commit (no HEAD yet), and bash 3.2
 # (the macOS system bash) treats "${arr[@]}" on an empty array as unbound under `set -u` → the
 # very first commit in a fresh repo aborts. The +alternate form is empty-safe on 3.2 and 4+.

--- a/plugins/aios/commands/close-session.md
+++ b/plugins/aios/commands/close-session.md
@@ -68,13 +68,33 @@ Announce the detected mode: "Detected: **vault session** — writing to daily no
    PRIOR=$(grep -o "<!-- close-session: ${SID} @ [0-9a-f]* -->" "$NOTE" 2>/dev/null | tail -1)
    STAMPED=$(printf '%s' "$PRIOR" | sed -E 's/.* @ ([0-9a-f]*) -->/\1/')
 
-   # Has any NON-CLOSE work landed since that stamp? Every commit a close makes is
-   # prefixed "session: ", so excluding those isolates real work from the close's
-   # own bookkeeping.
+   # Did THIS SESSION do non-close work since that stamp?
+   #   · own commits  = carry `AIOS-Session: $SID` (stamped by aios-commit)
+   #   · own close    = subject starts "session: " — bookkeeping, never "work"
    if [ -n "$STAMPED" ]; then
-     WORK=$(git -C "$HOME/aios" log --format=%s "${STAMPED}..HEAD" 2>/dev/null | grep -cvE '^session: ')
+     RANGE=$(git -C "$HOME/aios" log --format='%H' "${STAMPED}..HEAD" 2>/dev/null)
+     TAGGED=$(printf '%s\n' "$RANGE" | grep -c . )                       # commits in range
+     MINE=0; ANYTAG=0
+     for c in $RANGE; do
+       B=$(git -C "$HOME/aios" log -1 --format='%B' "$c" 2>/dev/null)
+       printf '%s' "$B" | grep -q '^AIOS-Session: ' && ANYTAG=1
+       printf '%s' "$B" | grep -q "^AIOS-Session: ${SID}$" || continue   # not mine → ignore
+       printf '%s' "$B" | head -1 | grep -qE '^session: ' && continue    # my own close → not work
+       MINE=$((MINE+1))
+     done
+     if [ "$ANYTAG" -eq 1 ]; then
+       WORK=$MINE                                                        # precise path
+     else
+       # No commit in range carries a trailer → this vault predates the stamping,
+       # so provenance is unknowable. Degrade to the old coarse rule, which errs
+       # toward APPEND. Never toward skipping: a duplicate block is recoverable,
+       # a missing one is lost work.
+       WORK=$(printf '%s\n' "$RANGE" | while IFS= read -r c; do [ -n "$c" ] && git -C "$HOME/aios" log -1 --format=%s "$c"; done | grep -cvE '^session: ')
+     fi
    fi
    ```
+
+   > **Why this needed provenance rather than a better heuristic.** The first version counted every commit whose subject was not `session: `-prefixed — which correctly ignored *this* command's bookkeeping but counted **other sessions' work as mine**. In a vault written by several sessions at once that is not an edge case: measured 2026-08-13, one session had **10 non-close commits since its stamp and only 1 was its own**. A spurious re-fire would then append a duplicate on the strength of a peer's commit. Git cannot tell sessions apart on its own — same author, same committer — so `aios-commit` now stamps an `AIOS-Session:` trailer and this reads it. **Record provenance; do not infer it from a naming convention.**
 
    - **A prior stamp exists AND `$WORK` is 0** → nothing but this command's own commits have landed. This is a **duplicate**: skip the append, skip every step below, and say so plainly (*"already closed at {HH:MM}; no work since — not duplicating"*). Under `--auto` this is the normal outcome of a re-fire and must not read as an error.
    - **A prior stamp exists AND `$WORK` is ≥ 1** → real work landed since. This is a **legitimate second close**: proceed and append a new block. A long session that closes at noon, works on, and closes again at 18:00 is a case the gate must never block.

--- a/tests/aios-commit.test.sh
+++ b/tests/aios-commit.test.sh
@@ -217,6 +217,32 @@ R=$(newrepo); ( cd "$R"; echo v1>f; git add -A; git commit -qm init; echo v2>f
   && ok "dead holder reclaimed and the commit landed" || no "reclaim broken by the classification change"
 rm -rf "$R"
 
+# ── session-provenance trailer (added 2026-08-13) ────────────────────────────
+# A vault is written by several Claude sessions at once and git cannot tell them
+# apart (same author, same committer). Consumers asking "did *I* do this?" were
+# forced to infer it from the commit SUBJECT — a convention, not a fact. This
+# records it. Additive by design: no env var → no trailer, so a human at a
+# terminal or an older Claude is unaffected.
+R=$(mktemp -d); ( cd "$R" && git init -q . && git config user.email t@t && git config user.name t \
+  && git config commit.gpgsign false && echo x > a.md && git add a.md && git commit -qm base ) >/dev/null 2>&1
+
+( cd "$R" && echo y > a.md && CLAUDE_CODE_SESSION_ID="sess-abc-123" "$AC" --no-push -m "feat: tagged" -- a.md >/dev/null 2>&1 \
+  && git log -1 --format='%B' | grep -q '^AIOS-Session: sess-abc-123$' ) \
+  && ok "session trailer written when CLAUDE_CODE_SESSION_ID is set" \
+  || no "session trailer missing when the env var is set"
+
+( cd "$R" && echo z > a.md && env -u CLAUDE_CODE_SESSION_ID "$AC" --no-push -m "feat: untagged" -- a.md >/dev/null 2>&1 \
+  && ! git log -1 --format='%B' | grep -q 'AIOS-Session' ) \
+  && ok "no session id → no trailer (additive, never required)" \
+  || no "a trailer appeared with no session id — the change must be additive"
+
+( cd "$R" && echo w > a.md && CLAUDE_CODE_SESSION_ID='bad
+AIOS-Session: forged' "$AC" --no-push -m "feat: hostile" -- a.md >/dev/null 2>&1 \
+  && ! git log -1 --format='%B' | grep -q 'AIOS-Session' ) \
+  && ok "a session id with illegal characters is REJECTED, not injected" \
+  || no "a multi-line session id forged a trailer line"
+rm -rf "$R"
+
 echo ""
 echo "── RESULT: $PASS passed, $FAIL failed  (bash $BASH_VERSION) ──"
 [ "$FAIL" = "0" ] || exit 1

--- a/tests/close-session-idempotency.test.sh
+++ b/tests/close-session-idempotency.test.sh
@@ -112,5 +112,69 @@ have "$(gate "$SID")" "APPEND" "7. legacy note with no stamp → APPEND"
 # ---------------------------------------------------------------------------
 have "$(gate "unknown")" "APPEND" "8. SID 'unknown' → APPEND (degrade toward a block, never lose one)"
 
+# ---------------------------------------------------------------------------
+# TESTS 9-12 — provenance. The v2 gate counted any non-"session:" commit, so a
+# PEER's commit read as "this session did work". Git cannot tell sessions apart,
+# so aios-commit stamps AIOS-Session: and the gate reads it.
+# ---------------------------------------------------------------------------
+SID2="aaaabbbb-cccc-dddd-eeee-ffff00001111"
+
+commit_as(){ # $1=session-id ("" = none) $2=subject
+  echo "$RANDOM" >> f; git add f
+  if [ -n "$1" ]; then git commit -q -m "$2
+
+AIOS-Session: $1"
+  else git commit -q -m "$2"; fi
+}
+
+# the v3 gate, transcribed from close-session.md Step 4.5
+gate3(){
+  local sid="$1" prior stamped range mine=0 anytag=0 b
+  prior=$(grep -o "<!-- close-session: ${sid} @ [0-9a-f]* -->" "$NOTE" 2>/dev/null | tail -1)
+  [ -z "$prior" ] && { echo APPEND; return; }
+  stamped=$(printf '%s' "$prior" | sed -E 's/.* @ ([0-9a-f]*) -->/\1/')
+  range=$(git log --format='%H' "${stamped}..HEAD" 2>/dev/null)
+  for c in $range; do
+    b=$(git log -1 --format='%B' "$c" 2>/dev/null)
+    printf '%s' "$b" | grep -q '^AIOS-Session: ' && anytag=1
+    printf '%s' "$b" | grep -q "^AIOS-Session: ${sid}$" || continue
+    printf '%s' "$b" | head -1 | grep -qE '^session: ' && continue
+    mine=$((mine+1))
+  done
+  if [ "$anytag" -eq 1 ]; then
+    [ "$mine" -eq 0 ] && echo SKIP || echo APPEND
+  else
+    local w
+    w=$(printf '%s\n' "$range" | while IFS= read -r c; do [ -n "$c" ] && git log -1 --format=%s "$c"; done | grep -cvE '^session: ')
+    [ "$w" -eq 0 ] && echo SKIP || echo APPEND
+  fi
+}
+
+# fresh note + a stamped close carrying provenance
+printf '# note\n' > "$NOTE"
+echo seed >> f; git add f; git commit -q -m "base"
+printf '## Session — 10:00 | work\n<!-- close-session: %s @ %s -->\nbody\n' "$SID" "$(git rev-parse HEAD)" >> "$NOTE"
+git add "$NOTE"; commit_as "$SID" "session: 10:00 work"
+
+# 9 — a PEER commits. This session did nothing → must SKIP.
+commit_as "$SID2" "feat: a different session's work"
+have "$(gate3 "$SID")" "SKIP" "9. a PEER's commit does NOT count as this session's work"
+
+# 10 — the v2 rule on that same state, to prove the test is not vacuous.
+have "$(gate "$SID")" "APPEND" "10. v2 rule says APPEND on that same state (the imprecision)"
+
+# 11 — this session then does real work → APPEND.
+commit_as "$SID" "feat: my own work"
+have "$(gate3 "$SID")" "APPEND" "11. this session's own non-close commit → APPEND"
+
+# 12 — untagged range (a vault predating the trailer) degrades to the coarse rule.
+printf '# note2\n' > "$NOTE"
+echo x >> f; git add f; git commit -q -m "base2"
+printf '## Session — 11:00 | w\n<!-- close-session: %s @ %s -->\nb\n' "$SID" "$(git rev-parse HEAD)" >> "$NOTE"
+git add "$NOTE"; git commit -q -m "session: 11:00 w"
+have "$(gate3 "$SID")" "SKIP" "12. no trailers in range → degrades to the coarse rule, still correct here"
+commit_as "" "feat: untagged peer work"
+have "$(gate3 "$SID")" "APPEND" "13. untagged work in range → APPEND (degrade toward a block, never silence)"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Found while **closing the session that shipped the detector this morning** — by running its own gate and reading the commits it counted.

## The defect

A vault is written by **several Claude sessions concurrently**, and git cannot tell them apart — same author, same committer, no distinguishing field. So the gate inferred ownership from the commit **subject**: count everything not prefixed `session: `. That correctly ignores this command's own bookkeeping and **wrongly counts every peer's work as mine**.

Measured on a live vault:

```
10 non-close commits since the stamp — only 1 was this session's
```

So a spurious re-fire appends a duplicate block on the strength of somebody else's commit. Narrow — it fails toward *writing* a block, never toward losing one — but the gate's documentation claimed a precision it did not have, and **I wrote that documentation this morning.**

## The fix is provenance, not a better heuristic

`aios-commit` now stamps an `AIOS-Session:` trailer from `CLAUDE_CODE_SESSION_ID`; the gate counts only commits carrying **its own** id. **Record the fact instead of inferring it from a naming convention** — the same lesson as the rest of today, one layer down.

The trailer is useful beyond this fix: with several agents sharing one vault, *"which session made this commit?"* previously had **no answer at all**.

## Additive and safely degrading — both tested, not asserted

| condition | behaviour |
|---|---|
| no `CLAUDE_CODE_SESSION_ID` | **no trailer** — a human at a terminal or an older Claude is unaffected |
| id with illegal characters | **rejected, not written** — a multi-line value would forge a trailer line, and the test feeds it exactly that |
| no trailers anywhere in range | falls back to the **old coarse rule**, which errs toward APPEND |

That last row is deliberate: **a duplicated block is recoverable, a missing one is lost work.**

## Verification

- `tests/aios-commit.test.sh` **17 → 20**
- `tests/close-session-idempotency.test.sh` **8 → 13**
- **Test 10 asserts the previous rule answers differently on the same state** (peer commit: old says APPEND, new says SKIP) — so test 9 cannot pass vacuously. That control is the one I have needed three separate times today.
- Full gate: source-detector 11/11 · update-changelog-scan 11/11 · tier0 7/7 · `validate.yml` 12 jobs.

## Process

Shipped via branch → PR → CI → merge, with the entry citing **this PR's head** per the flow adopted earlier today: **no `TBD-ON-MERGE`, and no commit pushed directly to `main`."**