### PR TITLE
fix(close-session): the gate answered SKIP for everyone — a bash-only loop in a zsh shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ## 2026-08-13 — Four checks that reported green without measuring, and a setup step that could not fail loudly
 
-`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · 1c4d72d · a395d92 · 901b42d · {PR-HEAD}`
+`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · 1c4d72d · a395d92 · 901b42d · 88753eb`
 
 ### The duplicate-detector answered SKIP for everyone — it was written with a bash-only loop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,19 @@
 
 ## 2026-08-13 — Four checks that reported green without measuring, and a setup step that could not fail loudly
 
-`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · 1c4d72d · a395d92 · 901b42d`
+`hash: 200bec5 · 7b5a2d9 · 7055d09 · 9c95388 · 94963d8 · 1c4d72d · a395d92 · 901b42d · {PR-HEAD}`
+
+### The duplicate-detector answered SKIP for everyone — it was written with a bash-only loop
+
+> **What this delivers.** The provenance-scoped gate shipped hours earlier iterated its commit list with `for c in $RANGE`. **Under bash that word-splits and works; under zsh — the session shell — it does not**, so the loop body received the entire newline-separated list as one value, every lookup failed, the count stayed 0, and the gate answered **SKIP**. That is the *dangerous* direction: it would have suppressed every legitimate second close and **lost the block**, which is precisely the failure the gate's own design principle forbids (*degrade toward a block, never toward silence*).
+
+**What you can now do:**
+- **Close twice in one day again.** The loop uses the portable `printf | while IFS= read -r` form the rest of the framework already prescribes, so a genuine second close appends as intended.
+- **Trust the count.** It is computed via command substitution rather than incremented inside a piped `while` — that runs in a **subshell**, so the increments would have been discarded on exit even after the splitting was fixed. Two bugs, one line.
+
+**Action required — none.** If you closed a session twice today and the second block did not appear, this is why; re-running `/close-session` now works.
+
+*Caught by running the gate for a real close and reading a result that disagreed with the evidence in front of it: 18 commits in range, 4 of them mine and carrying the trailer, and the gate still said 0. **The 13-assertion suite passed the whole time, because it runs under bash.** Test 14 now runs under **zsh** and reproduces the broken form on purpose — the same lesson, and the same fix, as the `$LAYERS` pathspec earlier today.*
 
 ### Same-day snapshots no longer overwrite each other
 

--- a/plugins/aios/commands/close-session.md
+++ b/plugins/aios/commands/close-session.md
@@ -73,15 +73,23 @@ Announce the detected mode: "Detected: **vault session** — writing to daily no
    #   · own close    = subject starts "session: " — bookkeeping, never "work"
    if [ -n "$STAMPED" ]; then
      RANGE=$(git -C "$HOME/aios" log --format='%H' "${STAMPED}..HEAD" 2>/dev/null)
-     TAGGED=$(printf '%s\n' "$RANGE" | grep -c . )                       # commits in range
-     MINE=0; ANYTAG=0
-     for c in $RANGE; do
+     # ⚠️ `printf | while read`, NEVER `for c in $RANGE` — the session shell is zsh, which does
+     # NOT word-split an unquoted expansion, so the loop body would receive the ENTIRE newline-
+     # separated list as ONE value, every `git log -1` would fail, MINE would stay 0, and the gate
+     # would answer SKIP — losing a legitimate second close. Same bug class as /aios:update Step 2.
+     # Counting via command substitution (not a bare `while` pipeline) because a piped `while` runs
+     # in a SUBSHELL, so `MINE=$((MINE+1))` inside one is discarded on exit.
+     ANYTAG=$(printf '%s\n' "$RANGE" | while IFS= read -r c; do
+       [ -n "$c" ] || continue
+       git -C "$HOME/aios" log -1 --format='%B' "$c" 2>/dev/null | grep -q '^AIOS-Session: ' && echo x
+     done | grep -c .)
+     MINE=$(printf '%s\n' "$RANGE" | while IFS= read -r c; do
+       [ -n "$c" ] || continue
        B=$(git -C "$HOME/aios" log -1 --format='%B' "$c" 2>/dev/null)
-       printf '%s' "$B" | grep -q '^AIOS-Session: ' && ANYTAG=1
        printf '%s' "$B" | grep -q "^AIOS-Session: ${SID}$" || continue   # not mine → ignore
        printf '%s' "$B" | head -1 | grep -qE '^session: ' && continue    # my own close → not work
-       MINE=$((MINE+1))
-     done
+       echo x
+     done | grep -c .)
      if [ "$ANYTAG" -eq 1 ]; then
        WORK=$MINE                                                        # precise path
      else

--- a/tests/close-session-idempotency.test.sh
+++ b/tests/close-session-idempotency.test.sh
@@ -16,9 +16,10 @@
 # cannot happen is not a check. Every other test here is downstream of that one.
 
 set -u
-PASS=0; FAIL=0
+PASS=0; FAIL=0; SKIP=0
 ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
 no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+sk(){ SKIP=$((SKIP+1)); printf '  skip %s\n' "$1"; }
 have(){ [ "$1" = "$2" ] && ok "$3" || { no "$3"; printf '       expected %s, got %s\n' "$2" "$1"; }; }
 
 WORK=$(mktemp -d) || { echo "cannot mktemp"; exit 1; }
@@ -175,6 +176,27 @@ git add "$NOTE"; git commit -q -m "session: 11:00 w"
 have "$(gate3 "$SID")" "SKIP" "12. no trailers in range → degrades to the coarse rule, still correct here"
 commit_as "" "feat: untagged peer work"
 have "$(gate3 "$SID")" "APPEND" "13. untagged work in range → APPEND (degrade toward a block, never silence)"
+
+# ---------------------------------------------------------------------------
+# TEST 14 — SHELL PORTABILITY, and it must run under ZSH to mean anything.
+# The shipped gate first used `for c in $RANGE`. Under bash that word-splits and
+# works; under zsh (the session shell) it does NOT, so the loop body gets the whole
+# newline-separated list as ONE value, every lookup fails, MINE stays 0 and the gate
+# answers SKIP — losing a legitimate second close. A bash-only suite passes on that
+# broken code, which is exactly how it shipped.
+# ---------------------------------------------------------------------------
+if command -v zsh >/dev/null 2>&1; then
+  Z=$(zsh -c '
+    cd '"$WORK"'
+    RANGE=$(git log --format=%H -3)
+    broken=0; for c in $RANGE; do git log -1 --format=%H "$c" >/dev/null 2>&1 || broken=1; done
+    fixed=$(printf "%s\n" "$RANGE" | while IFS= read -r c; do [ -n "$c" ] && git log -1 --format=%H "$c" >/dev/null 2>&1 && echo x; done | grep -c .)
+    echo "$broken:$fixed"' 2>/dev/null)
+  have "${Z%%:*}" "1" "14a. under zsh the bare for-loop DOES break (the bug, reproduced)"
+  have "${Z##*:}" "3" "14b. under zsh the printf|while form resolves all 3 commits"
+else
+  sk "14. zsh unavailable — the portability proof cannot run"
+fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Found by **running the gate for a real close** and reading a result that contradicted the evidence in front of it: 18 commits in range, 4 of them mine and visibly carrying the `AIOS-Session` trailer — and the gate reported **0**.

## The bug, and it fails in the dangerous direction

`for c in $RANGE`. Under **bash** that word-splits and works. Under **zsh** — the session shell — it does not, so the loop body received the entire newline-separated list as **one value**, every `git log -1` failed, the count stayed 0, and the gate answered **SKIP**.

That suppresses a **legitimate second close and loses the block** — precisely what the gate's own stated principle forbids: *degrade toward a block, never toward silence.*

**A second bug hid in the same line:** even with splitting fixed, `MINE=$((MINE+1))` inside a piped `while` runs in a **subshell**, so the increments are discarded on exit. Both are fixed by counting through command substitution over `printf | while IFS= read -r` — the portable form this framework prescribes elsewhere, and which I had written into `/aios:update` Step 2 **hours earlier today**.

## Why 13/13 stayed green

The suite runs under **bash**, where the broken form works. Test 14 now runs under **zsh**:

- **14a** asserts the bare for-loop **does** break there (the bug, reproduced)
- **14b** asserts the fixed form resolves all three commits

So a bash-only run can no longer green-light this class. **Second time today** that actually using zsh in a test was the difference between a test and a decoration — and I wrote that lesson down before making this mistake.

## Verification

close-session **15/15** · aios-commit 20/20 · source-detector 11/11 · update-changelog-scan 11/11 · tier0 7/7.