### PR TITLE
fix(hooks): force UTF-8 encoding on Windows in two Python hooks

### DIFF
--- a/hooks/pipeline-executor.py
+++ b/hooks/pipeline-executor.py
@@ -87,12 +87,12 @@ def log(msg):
     """
     global _log_broken
     try:
-        with open(LOG_PATH, "a") as f:
+        with open(LOG_PATH, "a", encoding="utf-8") as f:
             f.write(f"{datetime.now().isoformat()} | {msg}\n")
         # Rotate occasionally (check every call is cheap, rewrite is rare)
         if LOG_PATH.stat().st_size > 100_000:  # ~100KB
-            lines = LOG_PATH.read_text().splitlines()
-            LOG_PATH.write_text("\n".join(lines[-MAX_LOG_LINES:]) + "\n")
+            lines = LOG_PATH.read_text(encoding="utf-8").splitlines()
+            LOG_PATH.write_text("\n".join(lines[-MAX_LOG_LINES:]) + "\n", encoding="utf-8")
     except Exception as e:
         if not _log_broken:
             _log_broken = True
@@ -218,7 +218,13 @@ def parse_sources():
         log(msg)
         return config
 
-    content = SOURCES_PATH.read_text()
+    # encoding is EXPLICIT, not incidental: USER.md is UTF-8 (accents, emoji), but
+    # Python on Windows defaults read_text() to the locale codepage (cp1252 on a
+    # Western-European install), which raises UnicodeDecodeError on the first accented
+    # character and kills the executor before a single source loads. The crash is only
+    # written to the log, so the calling command reports zero API data with no visible
+    # cause.
+    content = SOURCES_PATH.read_text(encoding="utf-8")
 
     if _mentions_enabled(content, "Google Calendar"):
         config["configured"].add("calendar")

--- a/hooks/route-insight.py
+++ b/hooks/route-insight.py
@@ -28,6 +28,14 @@ Exit codes: 0 = excised + validated; 2 = no/ambiguous match (no change);
 """
 import argparse, datetime, os, re, shutil, sys
 
+# Windows: stdout defaults to the locale codepage (cp1252 on a Western-European
+# install), so echoing an excised entry that contains an arrow, emoji or accented
+# character raises UnicodeEncodeError and aborts the excision. The file IO below is
+# already explicit UTF-8; only the report was not.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 def is_top_bullet(ln):
     """A top-level list item: `- ` at column 0. Indented facets (`  - `) are body, not entries."""
     return bool(re.match(r"^- \S", ln))


### PR DESCRIPTION
## The problem

Two Python hooks read or write text without an explicit encoding. On Windows, Python falls back to the **locale codepage** (cp1252 on a Western-European install), so both fail on the first non-ASCII character. Any vault written in an accented language hits this on day one.

### `hooks/pipeline-executor.py` — the whole run dies before a single source loads

`SOURCES_PATH.read_text()` raises `UnicodeDecodeError` on `USER.md`:

```
Pipeline executor crashed: 'charmap' codec can't decode byte 0x8f in position 5231
```

The traceback goes **only** to `pipeline-executor.log`, so the calling command reports zero API data with no visible cause. `/today` and `/close-day` run blind and look like they merely have nothing configured — the failure is indistinguishable from an unconfigured vault.

The log's own `open` / `read_text` / `write_text` had the same gap, which means **the diagnostic channel could fail by the same cause as the fault it was recording** — the exact property the module's own docstring argues against ("A diagnostic channel that can fail by the same cause as the fault is not a diagnostic channel").

### `hooks/route-insight.py` — the excision aborts on an arrow

File IO here was *already* explicit UTF-8; only `stdout` was not. The tool echoes the entry it excised, so a `UnicodeEncodeError` aborts the run:

```
UnicodeEncodeError: 'charmap' codec can't encode character '→' in position 549
```

`session-insights.md` entries routinely contain `→` arrows (they're in the documented buffer format), so on Windows this fires on close to every call. Observed: 2 of 4 Emerging-cap excisions in one `/close-day` failed this way; the other 2 succeeded only because their text happened to be ASCII.

## The fix

Additive only — `encoding="utf-8"` where it was missing, plus the same `win32` stdout guard `pipeline-executor.py` already carried at its top:

| File | Change |
|---|---|
| `pipeline-executor.py` | `encoding="utf-8"` on the `USER.md` read + all three log IO calls |
| `route-insight.py` | `sys.stdout` / `sys.stderr` reconfigure under `sys.platform == "win32"` |

**No behavior change on macOS or Linux**, where UTF-8 is already the default. Nothing is removed or reordered; no control flow is touched.

## Testing

Run live in a real vault on **Windows 11, Python 3.14, Spanish locale**:

- **Before:** the executor crashed on every `/today` and `/close-day` (both rituals silently produced no calendar, tasks or Slack data); `route-insight.py` could not excise any entry containing an arrow.
- **After:** the executor completes (`✅ calendar_primary`, sources correctly reported as configured/not-configured), and `/close-day` completed a full Tier-A routing pass — 1 promotion + 1 route + 4 Emerging-cap expirations, all through `route-insight.py`.

Also confirmed the encoding change does not mask a real failure: with the source deliberately misconfigured, the executor still reports `not configured` rather than crashing.

## Why this belongs in canonical rather than `custom/`

Neither file is operator-customizable — they're framework hooks called by `/today`, `/close-day` and the Emerging-cap pass. Because they're Tier 1, a local fix is **reverted by the next `/aios:update`**: the Step 6.5 completeness reconcile correctly reads the patched local file as drift and wants to overwrite it from canonical. So a vault on Windows either carries the bug or fights its own updater every sync — the same shape as the `install-wrappers.ps1` / `pwsh`-vs-`powershell` fix that already landed for Windows operators.

## Upstream question for the maintainer

The two spots fixed here are the ones that **actually fired** in a live Windows run. A quick grep suggests the same latent pattern exists elsewhere in the hooks (any `open()` / `read_text()` / `write_text()` without `encoding=`). Worth deciding whether you'd prefer:

1. **this narrow fix** (only what was observed to break), or
2. a **sweep** of every unencoded text IO call across `hooks/`, as one deliberate pass.

I've kept this PR to (1) so it's small and reviewable, but I'm happy to extend it to (2) if you'd rather close the class in one go. That's the call I don't think belongs to me.

## Notes

- No `CHANGELOG.md` entry included — the convention is one consolidated dated entry per day keyed to a merge hash, which I can't know pre-merge. Happy to add one if you'd like it in the PR; otherwise it folds naturally into the day's entry.
- No index or count changes (no capability added or removed).
- Not a git/shared-state change, so the 2-parallel-actor test doesn't apply.
