### PR TITLE
fix(docs,today): a shipped platform called unsupported, and a green tick for a source nobody connected

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -294,6 +294,40 @@ jobs:
           done
           echo "OK: all 6 agent bundles present at agents/aios/{bundle}/ with README.md, and agents/_index.md is in place"
 
+      - name: No root doc claims a surface is limited to one platform
+        run: |
+          set -e
+          # WHY: SETUP.md told Windows and Linux operators "The AIOS App is macOS-only for now"
+          # for THREE DAYS after both platforms shipped (Linux v0.8.2 on 08-12, Windows v0.8.3 on
+          # 08-13). A Windows visitor following it was routed to install an IDE *and* an extension
+          # when one installer would do — the "download, wizard, working" bar pointing backwards.
+          # It was found by watching a real person onboard, which is the expensive way to find it.
+          #
+          # This is the second time in one week a doc outlived a shipped platform, so the class
+          # gets a check rather than another correction. A platform-exclusivity claim about our own
+          # surfaces is a fact with an expiry date, and the docs cannot know when it expired.
+          #
+          # Deliberately NARROW: it forbids the exclusivity CLAIM, not the platform names. Naming
+          # macOS, Windows or Linux is normal and necessary in an install guide; asserting a
+          # surface exists on only one of them is the thing that rots.
+          #
+          # CHANGELOG.md is EXCLUDED, and not as a convenience. It is append-only history, so an
+          # entry describing what was true on its own date is correct BY DEFINITION — `843` reads
+          # "The app is macOS-only today", which was accurate when written and is evidence now.
+          # Rewriting it to satisfy a check would be editing the record to make the present tidy.
+          # Caught by this check's own control on its first run, which flagged exactly that line.
+          BAD=""
+          for f in $(git ls-files '*.md' | grep -v '/' | grep -v '^CHANGELOG.md$'); do
+            hits=$(grep -nEi '(app|glass|aios)[^.]{0,24}\bis (macos|mac|windows|linux)-only' "$f" || true)
+            [ -n "$hits" ] && BAD="$BAD$f:"$'\n'"$hits"$'\n'
+          done
+          if [ -n "$BAD" ]; then
+            echo "::error::A root doc asserts one of our surfaces is limited to a single platform. If that was true when written, it has an expiry date — check what actually ships before re-asserting it:"
+            printf '%s' "$BAD"
+            exit 1
+          fi
+          echo "OK: no root doc claims a single-platform limitation"
+
       - name: Every tracked .sh carries the exec bit
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,51 @@
 >
 > A changelog that only lists *what changed* pushes comprehension-debt onto the operator — they'd have to read a skill's source to know what it does for their day. So every entry leads with a **"What you can now do"** section: the new capabilities in **plain language, with a concrete example**, phrased as things the operator can *do* now — not a component inventory. Keep the full component list too (for the record), but lead with the practical read, and flag the load-bearing behavioral changes worth an actual read. `/aios:update` surfaces this section to the operator after applying an entry, so their own Claude session tells them what the new version unlocks. **The rule:** *translate every shipped change into a capability the operator can use — or it isn't really shipped to them, just to the repo.*
 
+## 2026-08-17 — A first run that stopped asserting things it had never measured
+
+`hash: 3d93fe9 · f202b3b` *(`3d93fe9` is an external contribution — PR #34)*
+
+### Windows: two hooks died on the first accented character, and the failure looked like an unconfigured vault
+
+> **What this delivers.** Two Python hooks read and wrote text without an explicit encoding, so on Windows Python fell back to the **locale codepage** (cp1252 on a Western-European install) and both failed on the first non-ASCII character. Any vault written in an accented language met this on day one. `pipeline-executor.py` raised `UnicodeDecodeError` on `USER.md` and died **before a single source loaded** — and the traceback went *only* to its own log, so `/today` and `/close-day` ran blind and reported zero API data with no visible cause. **The failure was indistinguishable from a vault that simply had nothing configured.** `route-insight.py` had explicit UTF-8 on its file IO but not on `stdout`, and it echoes the entry it excises: `session-insights.md` entries routinely contain `→` arrows, so on Windows it aborted on close to every call — measured at 2 of 4 Emerging-cap excisions failing in one `/close-day`, the other 2 surviving only because their text happened to be ASCII.
+
+**What you can now do:**
+- **Run `/today` and `/close-day` on Windows in a non-English locale.** Fixed additively — `encoding="utf-8"` where it was missing, plus the same `win32` stdout guard `pipeline-executor.py` already carried at line 30. **No behavior change on macOS or Linux**, where UTF-8 is already the default; nothing removed, nothing reordered, no control flow touched.
+- **Trust the Emerging-cap pass to actually excise.** Arrows, emoji and accented characters in a routed entry no longer abort the run.
+
+**Action required — none.** If you are on Windows and your rituals have been reporting no calendar, task or Slack data, this is very likely why; re-run `/today` after syncing and the sources will report their real state.
+
+*Verified live on **Windows 11, Python 3.14, Spanish locale** by the contributor — before: the executor crashed on every ritual; after: it completes and `/close-day` finished a full Tier-A routing pass (1 promotion, 1 route, 4 Emerging-cap expirations). The step most fixes skip was included: with the source **deliberately misconfigured**, the executor still reports `not configured` rather than crashing — proof the encoding change did not simply silence the signal.*
+
+*One observation in that PR outlives its own fix, and it is now recorded as a named failure mode: **the log's own IO carried the same gap**, which means the diagnostic channel could fail by the same cause as the fault it was recording — the exact property the module's own docstring argues against. We met the same shape from another direction three days earlier, when a CI guard written *inside* the workflow it protected made that workflow invalid, producing zero jobs while four separate surfaces reported success. The instrument sitting inside the blast radius of what it measures.*
+
+*The contributor also asked which they should do — fix only what fired, or sweep the class — and handed the call back rather than assuming. **Narrow was the right answer**, and their own measurement is why: the class is 41 unencoded text-IO call sites across 8 files, and the bulk sit in the credential-rotation and quota machinery, a subsystem that has already produced one incident where an apparently-additive change wrote through to a live credential. The residue in the fixed file is 5 sites, all `json` on credential and token files, which `json.dumps` writes as pure ASCII — **latent, not live**, which is precisely why it can have a deliberate pass instead of an urgent one. Keyed separately, with the class guard that belongs to it.*
+
+### `SETUP.md` told Windows and Linux operators the App was macOS-only, three days after both shipped
+
+> **What this delivers.** Four lines still read *"The AIOS App is macOS-only for now"* and routed everyone to a `.dmg` — while Linux had shipped in `v0.8.2` (08-12) and Windows in `v0.8.3` (08-13). The cost is not cosmetic: a Windows visitor following the guide was told to install **an IDE and an extension** when one installer would do — the *"download, wizard, working"* bar pointing backwards, in the one document that meets someone before they have any reason to trust us. Found by watching a real person onboard, which is the expensive way to find it.
+
+**What you can now do:**
+- **Follow `SETUP.md` on any of the three platforms and be offered the App.** Each OS block now names its own artifact, and the Windows block states up front that SmartScreen **warns rather than blocks** on first run, so the unsigned-binary prompt is expected rather than alarming.
+- **Rely on a release failing if a doc outlives a platform again.** This was the second time in one week that documentation survived a shipped platform, so the class now has a check: no root doc may assert one of our surfaces exists on only one platform. A claim like that is **a fact with an expiry date**, and the doc cannot know when it expired. Deliberately narrow — it forbids the exclusivity *claim*, not the platform names an install guide obviously needs.
+
+**Action required — none**, unless you previously concluded from `SETUP.md` that you had to install an IDE on Windows or Linux. You do not; the App is a supported surface on both.
+
+*The check's own control is worth recording, because it caught something the check was about to get wrong. On its first run it flagged `CHANGELOG.md:843` — *"The app is macOS-only today"* — which was **accurate when written**. Append-only history describing a past state is evidence, not drift, and rewriting it to satisfy a linter would be editing the record to make the present look tidy. `CHANGELOG.md` is now excluded for that stated reason rather than for convenience.*
+
+### `/today` gave two brand-new operators a green tick for a Slack they had declined
+
+> **What this delivers.** The `## Slack triage` section was **unconditional** in the `/today` template, and its clean case renders *"✅ Sin unreads ni action items pendientes en Slack."* — a green checkmark asserting a **measured** clean state for a source that was never connected. Both new operators hit it on day one; neither uses Slack and both had declined the connection. That is worse than noise: it is a confident report about nothing, and it lands in the **first daily note a person ever reads**, exactly while they are deciding whether this system is genuinely looking at *them*.
+
+**What you can now do:**
+- **Get a daily note that only reports on what you actually connected.** When Slack is not a configured source the section is omitted **entirely, heading included** — not rendered empty, and above all not rendered clean.
+
+**Action required — none.**
+
+*The mechanism already existed and this one section simply did not use it: `/today` reads source configuration from `USER.md` twenty-five lines earlier, and **`close-day.md` already did it right** — *"skip this section silently"* when the recap is absent. Verified rather than assumed, which is also how we know the class is closed by this single fix instead of left half-done. Same family as the App greeting a new operator as `{{first-name}}`: first-run artifacts that reveal the system is not looking at this particular person, arriving at the moment that costs most.*
+
+---
+
 ## 2026-08-14 — The quota autopilot runs on Windows, and a credential guard that only covered one of two backends
 
 `hash: 51e3dd6 · 600e642 · 09af065 · 7e71521` *(`51e3dd6` is an external contribution — PR #30)*

--- a/SETUP.md
+++ b/SETUP.md
@@ -64,7 +64,7 @@ The AIOS is *one filesystem, two surfaces*: somewhere to **read and think**, and
 | What | Role | Why it earns its place |
 |---|---|---|
 | **[Obsidian](https://obsidian.md/)** — **required on every path** | *Reading and thinking* | Beautiful read of your vault — daily notes, project notes, observed context, reflections. Wikilinks resolve, graph view shows connections, the markdown structure compounds visually. It is also what the bundled Obsidian MCP talks to, so it is not a preference. |
-| **[AIOS App](https://github.com/The-AIOS/aios-app/releases)** — *pick this **or** the IDE* | *Executing, the simplest way* | The AIOS as a normal Mac app: rituals, agents, sessions, terminals and your vault in one window, point-and-click. **No IDE and no extension** — it is its own glass layer, so skip the Antigravity and AIOS Glass steps below entirely. |
+| **[AIOS App](https://github.com/The-AIOS/aios-app/releases)** — *pick this **or** the IDE* | *Executing, the simplest way* | The AIOS as a normal desktop app — macOS, Windows and Linux: rituals, agents, sessions, terminals and your vault in one window, point-and-click. **No IDE and no extension** — it is its own glass layer, so skip the Antigravity and AIOS Glass steps below entirely. |
 | **[Antigravity IDE](https://antigravity.google/product/antigravity-ide) + AIOS Glass** — *pick this **or** the app* | *Executing, beside a real editor* | Bundles Claude Code natively — agents run in IDE terminals (one per spawn), file edits and git ops feel native. Choose this if you also write code. VS Code works as the alternative; Antigravity is just batteries-included. Then add Glass (below). |
 
 **Pick ONE execution surface.** Both drive the same vault through the same Claude Code, so this is a preference, not a fork — and you can add the other later without redoing anything.
@@ -88,8 +88,9 @@ brew install node git gh python uv
 brew install --cask obsidian
 
 # 4. ONE execution surface — pick a) or b), not both (see "The two things you'll use daily")
-# a) AIOS App — simplest: download the .dmg from https://github.com/The-AIOS/aios-app/releases
+# a) AIOS App — simplest: download the macOS .dmg from https://github.com/The-AIOS/aios-app/releases
 #    and drag it to Applications. Nothing else; skip the Glass step later.
+#    (Windows and Linux have their own artifacts on the same releases page — see those sections.)
 # b) Antigravity IDE — download from https://antigravity.google/product/antigravity-ide
 #    (no brew cask yet — drag the .dmg to Applications), then install AIOS Glass.
 
@@ -121,8 +122,11 @@ winget install GitHub.cli
 winget install Python.Python.3.12
 
 # 2. Obsidian + your execution surface (see "The two things you'll use daily" above).
-#    The AIOS App is macOS-only for now, so on Windows the surface is the IDE + AIOS Glass.
+#    Either surface works on Windows — the AIOS App ships a Windows installer (v0.8.3+).
 winget install Obsidian.Obsidian
+# For the AIOS App (simplest — no IDE, no extension): download the Windows installer from
+#   https://github.com/The-AIOS/aios-app/releases  — then skip the Antigravity and Glass steps.
+#   SmartScreen warns on first run (unsigned): "More info" -> "Run anyway". It does not block.
 # For Antigravity IDE (recommended — Claude Code bundled): download from https://antigravity.google/product/antigravity-ide
 # For VS Code as the IDE alternative: winget install Microsoft.VisualStudioCode
 
@@ -170,7 +174,9 @@ curl -fsSL https://claude.ai/install.sh | bash
 claude --version
 
 # 5. Obsidian + your execution surface (see "The two things you'll use daily" above).
-#    The AIOS App is macOS-only for now, so on Linux the surface is the IDE + AIOS Glass.
+#    Either surface works on Linux — the AIOS App ships a Linux build (v0.8.2+).
+# AIOS App (simplest — no IDE, no extension): grab the Linux artifact from
+#   https://github.com/The-AIOS/aios-app/releases — then skip the Antigravity and Glass steps.
 # Obsidian — download the AppImage from https://obsidian.md/download
 # Antigravity IDE (recommended, Claude Code bundled) — https://antigravity.google/product/antigravity-ide
 #   or VS Code as the alternative: sudo snap install code --classic

--- a/plugins/aios/commands/today.md
+++ b/plugins/aios/commands/today.md
@@ -273,7 +273,9 @@ Structure:
 {Today's meetings and time-bound events from all configured Google Calendars, merged chronologically. If multiple accounts are configured, tag personal events with [personal] to distinguish from work events. Skip all-day non-task events. Skip calendars marked as "Skip" in USER.md Sources. Format: HH:MM – HH:MM — Event name. If no events, write "No events today."}
 
 ## Slack triage
-{Scan the pre-loaded Slack data (unreads + daily recap) for anything that needs the user's attention. Two checks:
+{**OMIT THIS ENTIRE SECTION — heading included — when Slack is not a configured source.** The executor reports each source as configured or not; if Slack is absent from it, or `USER.md` has no Slack source, write nothing at all here. Do not render the heading, do not render an empty state, and above all do not render the clean line: **"✅ Sin unreads ni action items pendientes en Slack" is a green checkmark asserting a measured clean state, and for an operator who declined Slack it asserts a state that was never measured.** That is worse than noise — it is a confident report about nothing, and it lands in the FIRST daily note the operator ever reads, exactly while they are deciding whether this system is actually looking at them. Hit live by both new operators on day one (2026-08-15); neither uses Slack, both declined the connection, and both got the tick. The same source-configuration signal is already read further up this command — use it here too rather than assuming presence.
+
+Scan the pre-loaded Slack data (unreads + daily recap) for anything that needs the user's attention. Two checks:
 
 1. **Unreads:** If there are unread conversations, list each with a one-line summary and whether it needs a response. If no unreads, say "Sin unreads."
 2. **Action items from recap:** Scan the daily recap for messages that require the user to do something — questions directed at them, requests, decisions pending their input, approvals needed. Extract each as a one-liner with the person who needs the response. If nothing needs action, say "Sin action items pendientes."


### PR DESCRIPTION
Two operator-facing first-run defects from the weekend's onboarding of two new operators, plus a guard for the class behind the first. Both `[canonical]`, both pre-specified on the roadmap, both verified against the actual files rather than taken from the row.

## `AI-113` — `SETUP.md` outlived a shipped platform by three days

Four lines still read *"The AIOS App is macOS-only for now"* and routed everyone to a `.dmg`, while Linux shipped in `v0.8.2` (08-12) and Windows in `v0.8.3` (08-13). Verified live at `:67`, `:91`, `:94`, `:124`, `:173`.

**The cost isn't cosmetic.** A Windows visitor was told to install **an IDE and an extension** when one installer would do — the *"download, wizard, working"* bar pointing backwards, in the one doc that meets someone before they have any reason to trust us. Found by watching a real person onboard.

Now platform-neutral, each OS block offering its own artifact, and the Windows block states up front that **SmartScreen warns rather than blocks** so the unsigned-binary prompt is expected rather than alarming.

### And a guard, because this was the second time in one week

The row itself asked whether *"a release should fail if the docs still name the old platform set"* — so: **no root doc may assert one of our surfaces exists on only one platform.** That claim is a fact with an expiry date and the doc cannot know when it expired.

Deliberately narrow: it forbids the exclusivity **claim**, not the platform names an install guide obviously needs. Control confirmed against the pre-fix `SETUP.md` — fires on `:124` and `:173`.

**The control also caught something the check was about to get wrong.** On its first run it flagged `CHANGELOG.md:843` — *"The app is macOS-only today"* — which was **accurate when written**. Append-only history describing a past state is evidence, not drift; rewriting it to satisfy a linter would be editing the record to make the present tidy. `CHANGELOG.md` is excluded for that stated reason, not for convenience.

## `AI-115` — a green checkmark for a Slack that was never connected

`## Slack triage` was **unconditional** in the `/today` template, and its clean case renders:

```
✅ Sin unreads ni action items pendientes en Slack.
```

A green tick asserting a **measured** clean state for a source that does not exist. Both new operators hit it on day one — neither uses Slack, both declined. Worse than noise: a confident report about nothing, in the **first daily note a person ever reads**, precisely while they decide whether this system is looking at *them*.

Now omitted **entirely, heading included** — not rendered empty, and above all not rendered clean.

**Verified rather than assumed:** the mechanism already existed (`/today` reads source config 25 lines earlier) and **`close-day.md` already did it right** — *"skip this section silently"*. So `today.md` was the only site, and the class is closed by this one fix rather than left half-done.

Same family as `AI-112` (`{{first-name}}`): first-run artifacts revealing the system isn't looking at this particular person, arriving at the moment it costs most.

## Verification

- 16/16 suites green · workflow-expression scan clean · YAML parses
- Zero `macOS-only` claims remain across 13 root docs; the guard's control fires on the pre-fix tree
- The `/today` clean line is **preserved** for the configured case — this gates the section, it doesn't delete the feature

## Not in this PR

`AI-114` (*"what can I truly do with this?"*) — the row wants the answer in the operator's own words, and my read found 12 existing matches for that language in a 345-line agent, so it may be a framing gap rather than an absence. That one needs a decision I shouldn't make alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS