### PR TITLE
fix(secret-scan): the private-key pattern never fired — grep parsed it as options

### DIFF
--- a/hooks/git/secret-scan.sh
+++ b/hooks/git/secret-scan.sh
@@ -14,6 +14,8 @@ PATTERNS=(
   'xox[baprs]-[A-Za-z0-9-]{10,}'         # Slack token
   'AIza[0-9A-Za-z_-]{35}'                # Google API key
   'glpat-[A-Za-z0-9_-]{20,}'             # GitLab PAT
+  'GOCSPX-[A-Za-z0-9_-]{20,}'            # Google OAuth client secret
+  '<string>[0-9a-f]{40}</string>'        # 40-hex token in a launchd plist
 )
 
 files=()
@@ -26,7 +28,18 @@ fi
 
 hit=0
 for pat in "${PATTERNS[@]}"; do
-  match=$(grep -InE "$pat" "${files[@]}" 2>/dev/null | head -3 || true)
+  # -e is load-bearing: a pattern beginning with '-' (the private-key header) is otherwise
+  # parsed by grep as an OPTION BUNDLE. grep then exits 2 (TROUBLE, not "no match"), writes
+  # its usage to stderr — which this call discards — and leaves $match empty, which reads
+  # here as "clean". That pattern therefore never fired. A failed measurement must never be
+  # read as a substantive result.
+  match=$(grep -InE -e "$pat" "${files[@]}" 2>/dev/null | head -3); rc=$?
+  # rc: 0 = matched · 1 = no match · >1 = grep itself failed. Fail CLOSED on >1 rather than
+  # silently treating an unusable scan as a pass.
+  if [ "$rc" -gt 1 ]; then
+    echo "secret-scan: FAILED to scan for pattern: $pat (grep exit $rc) — refusing to pass." >&2
+    exit 1
+  fi
   if [ -n "$match" ]; then
     [ "$hit" = 0 ] && echo "secret-scan: BLOCKED — secret-shaped string(s) found:" >&2
     printf '%s\n' "$match" | sed 's/^/  /' >&2

--- a/tests/secret-scan.test.sh
+++ b/tests/secret-scan.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# tests/secret-scan.test.sh
+#
+# Guards hooks/git/secret-scan.sh — the commit-time credential block.
+#
+# WHAT THIS IS PROTECTING
+# -----------------------
+# secret-scan.sh is the last thing between a credential and the remote, and it is called
+# from two places: the pre-commit hook (porcelain commits) and aios-commit's self-scan
+# (plumbing commits bypass hooks entirely, so the scanner must be invoked directly). A
+# pattern silently missing from the list is invisible in normal use — the scanner exits 0,
+# the commit succeeds, and nothing anywhere reports that a class of secret is unguarded.
+# There is no failure state to observe: a scanner that catches nothing and a repository
+# with no secrets produce identical output.
+#
+# So the coverage has to be asserted, one case per credential class. Each assertion below
+# corresponds to exactly one entry in PATTERNS, and adding a pattern without adding its
+# case here re-opens the same silent gap.
+#
+# FAKE CREDENTIALS ARE BUILT AT RUNTIME, NEVER WRITTEN LITERALLY.
+# A literal secret-shaped string in this file would make the file itself unstageable by
+# the very scanner it tests — the guard would block its own guard. Every probe below is
+# assembled from fragments that individually match nothing.
+#
+# Run:  bash tests/secret-scan.test.sh
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCAN="$ROOT/hooks/git/secret-scan.sh"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/secret-scan-test.XXXXXX"); trap 'rm -rf "$TMP"' EXIT
+
+A=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA        # 40 filler chars
+H=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa        # 40 hex filler
+DASH=$(printf -- -)
+
+# blocks <name> <probe-string>  — the scanner must exit non-zero on a file containing it
+blocks(){
+  printf 'harmless line\n%s\nanother line\n' "$2" > "$TMP/probe.txt"
+  "$SCAN" "$TMP/probe.txt" >/dev/null 2>&1
+  [ $? -ne 0 ] && ok "$1" || no "$1" "scanner exited 0 — this credential class is UNGUARDED"
+}
+
+echo "── 1. every PATTERNS entry has a live assertion ──"
+blocks "Anthropic API key"        "key = sk${DASH}ant${DASH}api03${DASH}$A"
+blocks "AWS access key id"        "id  = AKIA$(printf %s AAAAAAAAAAAAAAAA)"
+blocks "private key header"       "$(printf -- '-----BEGIN RSA PRIVATE')$(printf -- ' KEY-----')"
+blocks "GitHub PAT (classic)"     "tok = ghp$(printf %s _)$(printf %s AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)"
+blocks "GitHub PAT (fine)"        "tok = github_pat_${A}${A}"
+blocks "Slack token"              "tok = xoxb${DASH}${A}"
+blocks "Google API key"           "key = AIza${A}"
+blocks "GitLab PAT"               "tok = glpat${DASH}${A}"
+blocks "Google OAuth secret"      "sec = GOCSPX${DASH}${A}"
+blocks "launchd plist 40-hex tok" "<string>${H}</string>"
+
+echo "── 2. clean input is not blocked (no false positive) ──"
+printf 'ordinary prose about tokens, keys and secrets\nGOCSPX is a prefix\n' > "$TMP/clean.txt"
+"$SCAN" "$TMP/clean.txt" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "benign file passes" || no "benign file blocked" "false positive"
+
+echo "── 3. no-input is not an error ──"
+"$SCAN" "$TMP/does-not-exist.txt" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "absent path exits 0" || no "absent path exits non-zero"
+
+echo "── 4. a blocked run names the offending line ──"
+printf 'a\nsec = GOCSPX%s%s\nb\n' "$DASH" "$A" > "$TMP/loud.txt"
+out=$("$SCAN" "$TMP/loud.txt" 2>&1 >/dev/null)
+printf '%s' "$out" | grep -q "GOCSPX" && ok "error output quotes the match" || no "error output does not show what matched"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## The bug: the private-key pattern has never fired

`hooks/git/secret-scan.sh` scans each pattern with:

```bash
match=$(grep -InE "$pat" "${files[@]}" 2>/dev/null | head -3 || true)
if [ -n "$match" ]; then …
```

One pattern begins with a dash — `'-----BEGIN [A-Z ]*PRIVATE KEY-----'` — so grep parses it as an **option bundle**, not a pattern:

```
$ grep -InE '-----BEGIN [A-Z ]*PRIVATE KEY-----' pk.txt
grep: unrecognized option `-----BEGIN [A-Z ]*PRIVATE KEY-----'
$ echo $?
2
```

Three things then combine to make it silent:

1. grep exits **2** — *TROUBLE*, which is not *"no match"* (that's 1).
2. The usage message goes to stderr, and the call discards stderr.
3. `$match` is empty, and empty is the caller's "clean" signal. `|| true` absorbs the status.

So **any commit containing a PEM private-key header passes this scanner**, and has since the pattern was written. There is no failure state to notice: an unguarded class and a clean repo produce identical output.

This is the same shape `plugins/aios/commands/update.md` already warns about in prose for `diff` — *"`diff` exits 0=same, 1=differ, 2=TROUBLE. Read as a boolean, TROUBLE becomes 'differ' … a comparison that never completed is indistinguishable from a real difference."* Same trap, different tool, and here it fails permissive rather than conservative.

## The fix

- **Pass the pattern with `-e`** so a leading dash is data, not flags.
- **Fail closed when grep exits `>1`.** An unusable scan must not read as a pass — this is the general form of the bug, so the guard is on the exit code, not on this one pattern.

## Two added patterns

| Pattern | Why |
|---|---|
| `GOCSPX-[A-Za-z0-9_-]{20,}` | Google OAuth **client secret** — distinct from the `AIza…` API key already covered, and what a Workspace/Drive/Gmail OAuth setup actually produces |
| `<string>[0-9a-f]{40}</string>` | A 40-hex token embedded in a **launchd plist** — the shape AIOS's own scheduled routines store tokens in, and a plist is easy to commit by reflex |

Both were in use in a downstream vault and are offered back; the OAuth one is the higher-value of the two.

## The test — `tests/secret-scan.test.sh`

Follows the existing `tests/*.test.sh` house style (PASS/FAIL counters, `mktemp` + trap, sectioned output). **One assertion per `PATTERNS` entry**, so adding a pattern without adding its case re-opens exactly this silent gap.

Verified in both directions:

```
against unpatched HEAD :  9 passed, 4 failed
against this branch    : 13 passed, 0 failed
```

The four pre-fix failures are the private-key pattern, the two new patterns, and the "error output names the match" assertion.

Reverting-to-prove-it-fails is safe for this defect specifically: a missed pattern's only effect when executed is a wrong exit code inside the harness — it writes nothing and reaches no external system, so no stubbing is needed.

⚠️ **One convention the test encodes deliberately:** every fake credential is assembled at runtime from fragments that individually match nothing. A literal secret-shaped string in the file would make the test file unstageable by the very scanner it tests — the guard blocking its own guard. This was not theoretical: the first draft used literal `AKIA…` and `ghp_…` values and the scanner correctly refused the commit.

## Scope / what to drop if you want less

- The **`-e` fix** is the security-relevant hunk and stands alone.
- The **fail-closed on `grep >1`** hunk is the generalisation; drop it if you'd rather keep the change minimal, though it's what stops the next pattern with an awkward leading character from failing the same silent way.
- The **two patterns** and the **test** are independent of both.

Happy to split this into separate PRs if you'd prefer them adjudicated apart.
