### PR TITLE
fix(spawn): default task must be an instruction, not a placeholder

### DIFF
--- a/hooks/claude-identity/install-wrappers.ps1
+++ b/hooks/claude-identity/install-wrappers.ps1
@@ -258,7 +258,23 @@ function spawn {
     [CmdletBinding()]
     param(
         [Parameter(Position=0)] [string] $Name,
-        [Parameter(Position=1)] [string] $Task = 'Start session.',
+        # DEFAULT TASK -- an actionable instruction, never a placeholder.
+        # A bare `spawn <name>` promised instructions and delivered none.
+        #
+        #   The launcher always passes `Read <task-file> and follow the instructions inside.`
+        #   as the bootstrap, so a task file whose contents are `Start session.` is a prompt
+        #   pointing at a file with nothing to follow. The worker takes its turn, finds no
+        #   instruction, answers blandly, and never runs the Session Start Ritual: no declared
+        #   or observed context, no agent match for the session name, no greeting. The terminal
+        #   is open and the session looks idle, which reads as a hang rather than a default.
+        #
+        #   The primary-session shorthand below already passes a real instruction for exactly
+        #   this reason. Its note -- "spawn never had this problem, but only by accident: it
+        #   ALWAYS passes a bootstrap ... and that turn is what triggers the ritual" -- is true
+        #   about the turn and not about the ritual: passing a bootstrap only starts the ritual
+        #   when the bootstrap CONTAINS an instruction. With an explicit task it always did;
+        #   with the default it never did, and that is the path a first-time operator takes.
+        [Parameter(Position=1)] [string] $Task = 'Run the CLAUDE.md Session Start Ritual now: load my declared + observed context, match your session name to your role, and greet me in character before awaiting my task.',
         # -Tier mechanical|judgment. mechanical routes to the SECOND-BEST model
         # (cheaper; "always aim second-best" auto-tracks the lineup). judgment/none
         # keeps the frontier default (Invoke-ClaudeWithRespawn's CLAUDE_MODEL fallback).

--- a/hooks/claude-identity/install-wrappers.sh
+++ b/hooks/claude-identity/install-wrappers.sh
@@ -315,7 +315,23 @@ spawn() {
   set -- "${_args[@]}"
 
   local name="$1"
-  local task="${2:-Start session.}"
+  # DEFAULT TASK -- an actionable instruction, never a placeholder.
+  # A bare `spawn <name>` promised instructions and delivered none.
+  #
+  #   The launcher always passes `Read <task-file> and follow the instructions inside.`
+  #   as the bootstrap, so a task file whose contents are `Start session.` is a prompt
+  #   pointing at a file with nothing to follow. The worker takes its turn, finds no
+  #   instruction, answers blandly, and never runs the Session Start Ritual: no declared
+  #   or observed context, no agent match for the session name, no greeting. The terminal
+  #   is open and the session looks idle, which reads as a hang rather than a default.
+  #
+  #   The primary-session shorthand below already passes a real instruction for exactly
+  #   this reason. Its note -- "spawn never had this problem, but only by accident: it
+  #   ALWAYS passes a bootstrap ... and that turn is what triggers the ritual" -- is true
+  #   about the turn and not about the ritual: passing a bootstrap only starts the ritual
+  #   when the bootstrap CONTAINS an instruction. With an explicit task it always did;
+  #   with the default it never did, and that is the path a first-time operator takes.
+  local task="${2:-Run the CLAUDE.md Session Start Ritual now: load my declared + observed context, match your session name to your role, and greet me in character before awaiting my task.}"
 
   # Map tier → model id. Empty spawn_model = no override → _claude_with_respawn
   # uses its frontier default. Second-best today = Sonnet 4.6.


### PR DESCRIPTION
## The problem

`spawn <name>` with no task is the path a first-time operator takes, and it is the one path where the Session Start Ritual never runs.

```
spawn accountant
  → task defaults to "Start session."
  → written to /tmp/spawn-task-accountant.md
  → launcher passes: "Read /tmp/spawn-task-accountant.md and follow the instructions inside."
  → that file contains: "Start session."
```

The bootstrap promises instructions and the file delivers none. The worker takes its turn, finds nothing to follow, answers blandly, and never loads declared/observed context, never matches its session name against `agents/`, never greets. The terminal is open and the session looks **idle** — which reads as a hang rather than as a default.

With an explicit task (`spawn accountant "review Q1"`) the ritual always ran. Only the bare form was affected.

## Why it was missed — the reasoning is already in the file

The primary-session shorthand carries this note:

> A FRESH session is launched with a bootstrap prompt. Without one, `claude` opens idle and waits [...] **`spawn` never had this problem, but only by accident: it ALWAYS passes a bootstrap ("Read \<task-file\> …"), and that turn is what triggers the ritual.**

That is true about the *turn* and not about the *ritual*. Passing a bootstrap only starts the ritual when the bootstrap **contains an instruction**. The shorthand right below it already passes a real one (`"Session start — follow the Session Start Ritual in CLAUDE.md: load declared + observed context, then greet me."`) for exactly this reason.

This PR doesn't introduce a new criterion — it applies the one that note already states to the single path left out of it.

## Both platforms, not one

`.sh:318` and `.ps1:261` carried the same placeholder, so both are fixed together rather than leaving the platforms divergent.

## Testing, and what it does not cover

- Running live on **Windows 11, Spanish locale** since 2026-08-14; workers spawned bare now run the ritual and greet.
- Installer re-run today after a full `/aios:update`; idempotent, profile verified **against the live `$PROFILE`** rather than against the installer's success message.
- `bash -n install-wrappers.sh` → clean.
- PowerShell `Parser::ParseFile` on `install-wrappers.ps1` → 0 errors.

**Not tested: the `.sh` path executed.** There is no macOS or Linux machine behind this change — the shell edit is mirrored, not run. This is the mirror image of the 2026-08-18 model bump, which shipped the `.ps1` unexecuted and said so; naming it seems better than implying parity of evidence.

## The upstream question

The wording of the default is the part worth a maintainer's call. I used a role-aware phrasing because a spawned worker has a name to match, which the primary shorthand does not:

> `Run the CLAUDE.md Session Start Ritual now: load my declared + observed context, match your session name to your role, and greet me in character before awaiting my task.`

If you'd rather the two paths share one string verbatim, that's a smaller diff and I'm happy to change it.
