### PR TITLE
docs(google-workspace): Testing mode is not permanent — it expires the token every 7 days

### DIFF
--- a/mcps/google-workspace-mcp/personal-account-setup.md
+++ b/mcps/google-workspace-mcp/personal-account-setup.md
@@ -4,13 +4,24 @@
 >
 > Written from a real setup (2026-07-22) on a fortress agent machine. Uses the **local** MCP (its own OAuth client, `uvx`-launched) per the AIOS MCP policy — not the claude.ai-hosted Google connector, which is bound to the active claude.ai OAuth grant and breaks on account switch.
 
-## The two traps (read first — they cost the most time)
+## The three traps (read first — they cost the most time)
 
 1. **`Error 403: org_internal` — "can only be used within its organization."**
    The OAuth client belongs to a Google Cloud project whose consent screen is **Internal** (locked to a Workspace org). A **personal gmail can never use an Internal client.** → Create a **fresh project under the personal account itself** (no org → **External** consent available). Do *not* reuse a client from a work/org project.
 
 2. **`Error 403: access_denied` — "has not completed the Google verification process / developer-approved testers."**
-   The app is in **Testing** mode and the account isn't on the test-user list. → Add the account as a **Test user** (below). You do **not** need to publish/verify the app — Testing + test-user is the correct, permanent state for a personal setup.
+   The app is in **Testing** mode and the account isn't on the test-user list. → Add the account as a **Test user** (below). Testing + test-user is enough to *authorize* and gets you running today — but it is **not a permanent state**. See trap #3, which is the bill for stopping here.
+
+3. **The whole thing works, then dies exactly 7 days later — `invalid_grant: Token has been expired or revoked`.**
+   Google expires the **refresh token** of an app whose publishing status is **Testing** after 7 days. Nothing is misconfigured and nothing was revoked by a human: the grant reached its built-in expiry.
+
+   This is the trap that costs the most over the life of the setup, and it costs the most *because it does not fail during setup*. Traps #1 and #2 fail loudly while you are still holding the context — you are in the console, you read the error, you fix it. This one fails on a Tuesday three weeks later, on a machine you are not looking at, and it presents as "the MCP broke" rather than "a policy clock ran out". Whatever depends on this server — a daily-ritual pipeline, a scheduled routine, an agent that reads your calendar every morning — goes dark once a week until a human clicks through a consent screen. The setup guide is the only place that can warn you, because by the time it happens nobody connects the symptom to the step that caused it.
+
+   → **The lever is the publishing status, not verification.** The 7-day clock is attached to **Testing**; moving the app to **In production** (Audience → *Publish app*) is what stops it. Publishing and *being verified* are two different things — an app can sit in Production **unverified**, still showing the "Google hasn't verified this app" screen this document already tells you to expect.
+
+   → **Check what Google asks of you before assuming it is free, because this MCP uses sensitive scopes.** Gmail and Drive are not the basic `email`/`profile`/`openid` trio; they are the scope classes that pull an app into Google's verification requirements, and the requirements (and any user caps on an unverified Production app) are Google's to change, not this document's to promise. **Read what the Audience screen tells you at the moment you click Publish** — that is the only current answer. If it does ask for verification and you do not want to go through it, that is a real decision, not a formality.
+
+   → **Whichever way you go, write the cost down** next to whatever depends on this server. Staying in Testing means **a manual re-auth every 7 days, forever** — a legitimate choice for a throwaway experiment, and the wrong default for a server a daily automation depends on, which is exactly what this document is setting up.
 
 ## Part A — Google Cloud Console (the human clicks)
 
@@ -81,6 +92,7 @@ At the consent screen you'll see **"Google hasn't verified this app"** — this 
 |---|---|---|
 | `403 org_internal` | client from an org/Internal project | new project under the personal account, External consent |
 | `403 access_denied` (testers) | account not a test user | add it under Audience → Test users |
+| `invalid_grant` after ~7 days | app publishing status still **Testing** | move it to **In production** (trap #3) — check what Google asks at that screen; these are sensitive scopes |
 | `redirect_uri_mismatch` | client isn't Desktop type | recreate as Desktop, or add `http://localhost:8000/` |
 | consent URL never prints | Python stdout buffered while `run_local_server` blocks | run `python -u` / `PYTHONUNBUFFERED=1` |
 | "scope has changed" error | Google added `openid` | `OAUTHLIB_RELAX_TOKEN_SCOPE=1` |


### PR DESCRIPTION
## What

`mcps/google-workspace-mcp/personal-account-setup.md` currently tells the reader:

> You do **not** need to publish/verify the app — Testing + test-user is the correct, **permanent** state for a personal setup.

Testing + test-user does authorize correctly, so the setup works on day 1. But Google expires the **refresh token** of an app whose publishing status is **Testing** after 7 days. The state the guide calls permanent has a one-week lifetime.

The symptom is `invalid_grant: Token has been expired or revoked`.

## Why it belongs in the setup guide and not in troubleshooting alone

Traps #1 and #2 in that section fail **during setup** — the operator is in the console, reads the error, fixes it, moves on. This one fails a week later on a machine nobody is watching, and it presents as *"the MCP broke"* rather than *"a policy clock ran out"*. By the time it happens, nobody connects the symptom back to the step that caused it.

That matters more than usual for this particular server, because AIOS itself schedules work on top of it — the daily-ritual pipeline reads Calendar and Tasks through this exact credential store. A weekly outage that requires a human to click a consent screen is a poor foundation for anything automated, and the guide is the only place that can say so in time.

## What the patch does

- Renames the section **two traps → three traps** and adds trap #3.
- Softens trap #2 from *"the correct, permanent state"* to *"enough to authorize and gets you running today — but not a permanent state"*, pointing at #3.
- Adds one troubleshooting row: `invalid_grant` after ~7 days → publishing status still Testing.

## What the patch deliberately does NOT claim

An earlier draft of this change said publishing to Production needs no Google review, reasoning by analogy with the OAuth-login case where basic `email`/`profile`/`openid` scopes are non-sensitive. **That reasoning does not transfer here** — this MCP requests Gmail and Drive, which are exactly the sensitive/restricted scope classes that pull an app into verification. Shipping that sentence would have replaced one confidently-wrong claim with another.

So the patch separates the two things that were being conflated — **publishing status** (what the 7-day clock is attached to) from **verification** (a separate process an app may or may not need) — and then points the reader at the Audience screen as the only current answer, rather than hardcoding a policy detail that Google owns and can change. It also states the alternative plainly: staying in Testing is a legitimate choice, and it costs a manual re-auth every 7 days, forever.

## How it was found

An operator following this guide has been re-authenticating roughly weekly since mid-August, on Windows, with the pipeline going quiet each time until they did. The cause was mis-attributed locally for two weeks before it was traced to the publishing status.

Docs-only change — no code, no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfUDZuZLHAD4kxdDUhiTR1