### PR TITLE
docs(notebooklm): the venv silently pins 0.1.1 when built on Python 3.9

### DIFF
--- a/mcps/_index.md
+++ b/mcps/_index.md
@@ -13,7 +13,7 @@ This is the **canonical list** referenced by `CLAUDE.md` → MCP Policy. When yo
 | Atlassian | `atlassian-mcp/` | Jira issues + Confluence pages | API token (scoped recommended for least-privilege, classic also works) |
 | GitHub | `github-mcp/` | Repos, issues, PRs, files, branches, workflows | PAT |
 | Stitch | `stitch-mcp/` | AI-native design → code pipeline (Stitch 2.0) | `npx` (no auth) |
-| NotebookLM | `notebooklm-mcp/` | Google NotebookLM — notebooks, audio/podcasts, quizzes | `notebooklm login` |
+| NotebookLM | `notebooklm-mcp/` | Google NotebookLM — notebooks, audio/podcasts, quizzes | `notebooklm login` ⚠️ **needs Python 3.10+ — see README** |
 | Playwright¹ | `playwright-mcp/` | Browser automation — auto-publish, testing, screenshots | Browser storage state (Chrome cookie import) |
 | Nano Banana | `nano-banana-mcp/` | Gemini 2.5 Flash Image generation (cover images, visuals) | `GEMINI_API_KEY` |
 | PDF Generator | `pdf-generator-mcp/` | pandoc (md → HTML) + Chrome (HTML → PDF) | None (local binaries) |

--- a/mcps/notebooklm-mcp/README.md
+++ b/mcps/notebooklm-mcp/README.md
@@ -12,21 +12,43 @@ Unofficial Python API for Google NotebookLM. Full programmatic access including 
 
 ## Install
 
+> ⚠️ **Requires Python 3.10+.** `notebooklm-py` uses PEP 604 syntax (`str | None`), so building the
+> venv against a system `python3` older than 3.10 — **macOS still ships 3.9.6** — leaves you with a
+> venv that *looks* installed and a CLI that crashes on import
+> (`TypeError: unsupported operand type(s) for |` in `cli/helpers.py`).
+>
+> The failure is worse than a clean crash: **pip resolves backwards** until it finds a release
+> compatible with the old interpreter and silently pins `notebooklm-py==0.1.1`, many minors behind
+> current. Nothing errors, so the version gap is invisible until a command that needs a newer API
+> quietly does the wrong thing. Use `uv`, which fetches its own interpreter:
+
 ```bash
 cd mcps/notebooklm-mcp
-python3 -m venv .venv
-source .venv/bin/activate
-pip install notebooklm-py
+uv venv --python 3.12 .venv
+VIRTUAL_ENV=.venv uv pip install 'notebooklm-py[browser]'
+./.venv/bin/notebooklm --version
 ```
+
+The **`[browser]`** extra (playwright) is **not optional**: without it `notebooklm login` cannot open
+a browser and `doctor` reports *Headless Reauth: unavailable*.
+
+> 💡 **A venv cannot be renamed** — its shebangs carry absolute paths. If you built it at the wrong
+> path, recreate it at the final one; moving it produces a venv whose entry points all fail.
 
 ## Setup
 
 ```bash
-source mcps/notebooklm-mcp/.venv/bin/activate
-notebooklm login
+./.venv/bin/notebooklm doctor --fix   # creates ~/.notebooklm/profiles/default
+./.venv/bin/notebooklm login          # Google OAuth — run by the operator, not an agent
+./.venv/bin/notebooklm doctor         # verify: Auth ✓
 ```
 
-This opens a browser for Google OAuth. After login, the session is cached.
+`doctor` is the canonical diagnostic — it reports profile, migration, auth and headless-reauth
+state in one table, and `doctor --fix` creates the profile directory a first `login` expects.
+
+**`login` is run by a person, not by a Claude session:** it opens Google's OAuth flow, and an agent
+does not enter credentials. Afterwards the session is cached in
+`~/.notebooklm/profiles/<profile>/storage_state.json`.
 
 ## Usage
 


### PR DESCRIPTION
The install instructions build the venv with `python3 -m venv`. On macOS that is still **3.9.6**, and `notebooklm-py` uses PEP 604 (`str | None`) — so the CLI crashes on import with `TypeError: unsupported operand type(s) for |` in `cli/helpers.py`.

**The part worth fixing is not the crash — it is that there usually is no crash.** pip resolves *backwards* until it finds a release the old interpreter accepts, and silently pins `notebooklm-py==0.1.1`, many minors behind current. Nothing errors. The venv looks installed, `pip list` looks fine, and the version gap only surfaces when a command needs an API the old release does not have and quietly does something else. A dependency that fails loudly is cheap; one that resolves to a stale version and reports success is not.

**Class, not incident:** any operator whose `python3` predates 3.10 gets this, and the default install line is what puts them there. macOS ships 3.9 out of the box, so the default path and the broken path are the same path.

## What changed

- **Install** now uses `uv venv --python 3.12` — `uv` fetches its own interpreter, so the fix does not depend on what the machine happens to ship or on the operator noticing a version.
- **`[browser]` documented as required, not optional.** Without playwright, `notebooklm login` cannot open a browser at all and `doctor` reports *Headless Reauth: unavailable*. The previous `pip install notebooklm-py` omits it.
- **Setup now leads with `doctor --fix`**, which creates the profile directory a first `login` expects, and closes with `doctor` as the verification step. `doctor` is the canonical diagnostic — profile, migration, auth and reauth in one table.
- **A venv cannot be relocated** — the entry-point shebangs carry absolute paths. Noted because the natural recovery from a wrong path is to move it, and that produces a venv whose commands all fail.
- `mcps/_index.md`: the NotebookLM row flags the Python floor and points at the README.

## Tested

Reproduced the backwards-resolution on a stock macOS `python3` (3.9.6 → `notebooklm-py==0.1.1`, CLI crash on import), then ran the documented path end to end in a live vault: `uv venv --python 3.12`, install with `[browser]`, `doctor --fix`, `login`, `doctor` all-pass, MCP registered and answering.

## Open question for the maintainer

The `manual_login.py` / `save_storage.py` helpers in this folder were written against **0.1.1**. Once operators are actually on a current release, it is worth checking whether the login race they work around still exists — they may be fixing something upstream has since resolved. I did not touch them here because I have not verified either way.