### PR TITLE
docs(skills): a flat skill is invisible to the registrar, in silence

### DIFF
--- a/skills/_index.md
+++ b/skills/_index.md
@@ -123,6 +123,30 @@ Their content lives in git history if anything needs to come back. 9 others (pyt
 
 ---
 
+## The registrar sees exactly TWO levels — a flat skill is invisible to it
+
+`skills/setup.sh` globs **`*/*/SKILL.md`**: source folder, then skill folder. A skill placed at
+`skills/<name>/SKILL.md` sits at **one** level, so it never enters the registrar's search space at
+all. It is not skipped over a name collision and it does not lose a tie — **it does not exist for
+the script.** Nothing is linked, and nothing is reported, because there is no iteration in which it
+could have failed.
+
+**This is worth using on purpose rather than only avoiding.** The flat position IS the
+*"versioned but not loaded"* state — an archive. So:
+
+- **A skill that must load** goes to `<source>/<name>/` (`aios/`, `custom/`, or a vendored source).
+- **A skill worth keeping but not worth its description in every session** can stay flat, deliberately.
+- **What must never happen** is a flat skill that something *declares* — an agent's `## Skills`
+  block, or a command that names it. There the caller receives silence: the reference resolves to a
+  file that is in the repo and not in the runtime, and no error distinguishes that from a skill
+  that loaded and had nothing to say.
+
+Two levels is a reasonable contract. The failure mode is that violating it is **silent in both
+directions** — nothing warns the author who placed a skill flat, and nothing warns the agent whose
+declared skill never arrives.
+
+---
+
 ## Adding skills
 
 **New AIOS-bundled skill** — drop into `skills/aios/<skill-name>/SKILL.md`, add to this index.


### PR DESCRIPTION
`skills/setup.sh` globs `*/*/SKILL.md` (line 24) — source folder, then skill folder, exactly two levels. A skill at `skills/<name>/SKILL.md` sits at **one** level, so it never enters the registrar's search space. It is not skipped over a collision and it does not lose a tie: it does not exist for the script. Nothing is linked and nothing is reported, because there is no iteration in which it could have failed.

Two levels is a fine contract. What makes it worth documenting is that **violating it is silent in both directions** — nothing warns the author who placed a skill flat, and nothing warns the agent whose declared skill never arrives. The caller receives silence, which is indistinguishable from a skill that loaded and had nothing to say.

## What changed

Documentation only — no behaviour change. Adds a section to `skills/_index.md` that states the two-level contract, and reframes the flat position as the deliberate **"versioned but not loaded"** state (an archive) rather than a mistake. Flat is genuinely useful: it keeps a skill in the repo without paying for its description in every session. The one case that must never happen is a flat skill that an agent's `## Skills` block declares.

## Open question, and it is the reason this is documentation rather than a patch

`setup.sh` excludes `anthropic/` and `superpowers/` (line 32) on a stated premise (lines 7-8): *"those are provided via Claude Code marketplaces"* — i.e. they already live in `~/.claude/skills`.

**Measured in a live vault, that premise did not hold: 0 of the 11 skills under `anthropic/` were present in `~/.claude/skills`.** Two of them exist as a marketplace *plugin*, which still has to be enabled and is not the same thing as a registered skill. The visible consequence was a bundled agent declaring one of them in its `## Skills` block and receiving nothing — the silent-reference case above, reached through the exclusion rather than through a flat folder.

I have one vault's evidence and no way to tell whether that is the general case or a local artifact of how this install was bootstrapped. And the fix has a real fork in it that is yours, not mine:

- If the premise holds for most installs, **the exclusion is right** and what is missing is a *check* — `setup.sh` could verify presence in `~/.claude/skills` and warn when a source it skipped is not actually there.
- If it does not hold, **the exclusion is the bug**, and vendored `anthropic/` skills should register like any other source.

Either way the current shape is the one that cannot be diagnosed from inside a session: the skills are in the repo, absent from the runtime, and nothing says so. I have deliberately not touched `setup.sh` — happy to build whichever direction you pick, or to gather evidence from more installs first if that is more useful.