### PR TITLE
fix(skills): anthropic/ registers, and the exclusion premise is now checked (#49)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1068,6 +1068,14 @@ jobs:
         # claiming it has one.
         run: bash tests/connector-manifests.test.sh
 
+      - name: an agent's declared skills exist, and the registrar checks its own premise
+        # Issue #49, item 4. The root failure was not the exclusion in
+        # skills/setup.sh — it was that "an agent DECLARES a skill" and "that skill
+        # is available" were never checked against each other. Eight bundled agents
+        # named a skill and received nothing; nothing errored, they just answered
+        # worse. Silent by construction, so it has to be a test.
+        run: bash tests/agent-skills-resolve.test.sh
+
       - name: every suite in tests/ is actually invoked by this workflow
         # This job's step list is hand-typed, so a suite can be committed, shipped, and
         # never run — it rots without one red mark. This repo has already been bitten twice

--- a/skills/setup.sh
+++ b/skills/setup.sh
@@ -4,11 +4,33 @@
 # superpowers/anthropic skills load). Run once after cloning, or after
 # /aios:update adds a new skill. Idempotent. Usage: bash skills/setup.sh
 #
-# Registers skills/<source>/<skill>/ for every source EXCEPT `anthropic/` and
-# `superpowers/` — those are provided via Claude Code marketplaces
-# (`claude plugin install …`), so linking the vendored mirrors would double
-# them. Also skips any name already present in ~/.claude/skills (re-run safe;
-# never clobbers a marketplace- or hand-installed skill).
+# Registers skills/<source>/<skill>/ for every source EXCEPT `superpowers/`,
+# which IS reliably provided via a Claude Code marketplace, so linking the
+# vendored mirror would double it. Skips any name already present in
+# ~/.claude/skills (re-run safe; never clobbers a marketplace- or hand-installed
+# skill).
+#
+# `anthropic/` USED TO BE EXCLUDED HERE ON THE SAME PREMISE, AND THE PREMISE WAS
+# FALSE. One sentence — "those are provided via Claude Code marketplaces" —
+# covered two sources, and it happened to be true of only one. Measured on two
+# independent vaults: superpowers 14 sources, 0 missing; anthropic 11 sources,
+# 10 and 11 missing respectively. Excluding them together is exactly what hid it,
+# because superpowers kept proving the rule while anthropic quietly broke it.
+#
+# The consequence was not an error. It was silence: eight bundled agents declare
+# one of those skills in their `## Skills` block and received nothing —
+# content-writer, sales-proposal-writer, protocol-steward (doc-coauthoring),
+# email-drafter, report-drafter (internal-comms), deck-builder (theme-factory),
+# aios-builder (mcp-builder, skill-creator). An agent that silently lacks the
+# skill it declares still answers; it just answers worse, and nothing anywhere
+# says why. That is a defect for every operator who installs this framework, on
+# any day — the kind of thing you only find by measuring rather than by hitting
+# an error.
+#
+# The presence check below is what would have caught it without anyone noticing an
+# agent underperform, and it stays regardless of which sources are excluded: it
+# asserts the assumption instead of trusting it, so if superpowers' premise ever
+# stops holding, this script says so on the next run.
 #
 # Skills register as standalone skills-dir entries — they do NOT touch the
 # `aios` commands plugin. Restart Claude Code sessions to pick up new links.
@@ -21,6 +43,7 @@ echo ""
 
 linked=0
 skipped=0
+skipped_sources=""
 for skill_md in "$SCRIPT_DIR"/*/*/SKILL.md; do
   [ -e "$skill_md" ] || continue
   skill_dir="$(dirname "$skill_md")"
@@ -28,8 +51,10 @@ for skill_md in "$SCRIPT_DIR"/*/*/SKILL.md; do
   name="$(basename "$skill_dir")"
 
   # Marketplace-provided sources — skip (avoid duplicating installed skills).
+  # ONLY superpowers: its premise is measured true. See the header for why
+  # anthropic was removed from this list.
   case "$source_dir" in
-    anthropic | superpowers) continue ;;
+    superpowers) skipped_sources="$skipped_sources $name"; continue ;;
   esac
 
   target="$DEST/$name"
@@ -61,3 +86,55 @@ echo "Restart Claude Code sessions to load newly-registered skills."
 # agent `## Skills` reference resolves to a shipped SKILL.md; an orphan skill
 # (shipped but named by nobody) is a candidate for skills/custom/.
 # ─────────────────────────────────────────────────────────────────────────────
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Presence check — assert the exclusion premise instead of trusting it.
+#
+# Every source skipped above is skipped because it is *believed* to arrive from a
+# marketplace. That belief is a claim about the operator's machine, and it was
+# wrong once, silently, for months. So verify it: for each skipped skill, is the
+# name actually in ~/.claude/skills? If not, the skill this script declined to
+# register is not there by any other route either, and anything declaring it gets
+# nothing.
+#
+# This check is deliberately independent of WHICH sources are excluded. It costs
+# one stat per skipped name and it is the only thing standing between a false
+# premise and an agent that quietly underperforms.
+# ─────────────────────────────────────────────────────────────────────────────
+absent=""
+for name in $skipped_sources; do
+  [ -e "$DEST/$name" ] || absent="$absent $name"
+done
+
+if [ -n "$absent" ]; then
+  n_absent=$(echo $absent | wc -w | tr -d ' ')
+  # Is the marketplace that provides them installed YET? This script runs early in
+  # setup — before the interview's plugins step installs the superpowers
+  # marketplace — so on a fresh machine these skills are legitimately "not here
+  # yet" rather than missing. Distinguishing the two is the whole difference
+  # between a check worth reading and a wall of text a first-timer learns to skip.
+  mkt_installed=0
+  for m in "$HOME"/.claude/plugins/marketplaces/*superpowers*/ \
+           "$HOME"/.claude/plugins/cache/*superpowers*/; do
+    [ -d "$m" ] && { mkt_installed=1; break; }
+  done
+
+  echo ""
+  if [ "$mkt_installed" -eq 1 ]; then
+    # The marketplace IS installed and the skills still are not there. That is the
+    # real defect: the premise is false on this machine, right now.
+    echo "⚠️  $n_absent skill(s) skipped on the assumption a marketplace provides them, but"
+    echo "    they are NOT in $DEST — and the marketplace IS installed:"
+    for n in $absent; do echo "     · $n"; done
+    echo ""
+    echo "   Anything declaring one of these receives nothing — no error, just silence."
+    echo "   Drop that source from the exclusion list in this script so it registers"
+    echo "   like any other. (This is exactly how anthropic/ was found.)"
+  else
+    # Expected on a fresh install. State it once, quietly, and do not enumerate.
+    echo "ℹ️  $n_absent skill(s) come from a marketplace that is not installed yet —"
+    echo "    the cold-start interview installs it at its plugins step. Nothing to do."
+    echo "    If they are still absent after that, re-run this script: it will say so"
+    echo "    loudly, because at that point the assumption really is broken."
+  fi
+fi

--- a/tests/agent-skills-resolve.test.sh
+++ b/tests/agent-skills-resolve.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# A bundled agent's declared skills must exist in the repo (issue #49, item 4)
+#
+# The root failure behind #49 was not the exclusion in skills/setup.sh. It was
+# that "an agent DECLARES a skill" and "that skill is actually available" were
+# never checked against each other. So an agent could name a skill in its
+# `## Skills` block, receive nothing, and still answer — just worse, with nothing
+# anywhere reporting why. Eight bundled agents were in that state:
+#
+#   content-writer · sales-proposal-writer · protocol-steward  (doc-coauthoring)
+#   email-drafter · report-drafter                             (internal-comms)
+#   deck-builder                                               (theme-factory)
+#   aios-builder                                    (mcp-builder, skill-creator)
+#
+# This asserts the repo-side half, which is the half canonical controls: every
+# skill an agent names must EXIST as a bundled source. Whether it is registered
+# into ~/.claude/skills is machine state, checked by skills/setup.sh's own
+# presence check — a test cannot assert another operator's machine, and pretending
+# to would be the same over-claiming this whole class of bug is made of.
+#
+# The failure this catches is silent by construction: nothing errors, an agent
+# simply underperforms. That is why it is a test and not a convention.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; return 0; }
+
+# The set of skills the repo actually ships, across every bundled source.
+avail=$(find skills -mindepth 2 -maxdepth 3 -name SKILL.md 2>/dev/null \
+        | while IFS= read -r f; do basename "$(dirname "$f")"; done | sort -u)
+n_avail=$(printf '%s\n' "$avail" | grep -c . )
+
+echo "── 1. the available-skill set is non-empty ──"
+# Without this the whole suite passes by comparing against nothing — the
+# fail-open shape that has bitten several guards in this repo.
+[ "${n_avail:-0}" -ge 20 ] \
+  && ok "found $n_avail bundled skills to check against" \
+  || no "only ${n_avail:-0} bundled skills found" "every assertion below would pass vacuously"
+
+echo "── 2. every skill a bundled agent declares exists in the repo ──"
+bad=0
+for a in $(find agents/aios -name '*.md' 2>/dev/null | sort); do
+  # Only the `## Skills` block, and only backticked names in its bullets.
+  # NOTE: an earlier version piped through `tr -d '\x60-'`, which deletes hyphens
+  # INSIDE the name too — `doc-coauthoring` became `doccoauthoring` and this suite
+  # reported 57 failures that were all its own parser mangling the input. sed the
+  # delimiters only; never character-class away a character the data contains.
+  decl=$(awk '/^## Skills/{f=1;next} f&&/^## /{exit} f' "$a" \
+         | sed -nE 's/^- `([a-z0-9][a-z0-9-]*)`.*/\1/p')
+  [ -z "$decl" ] && continue
+  for d in $decl; do
+    printf '%s\n' "$avail" | grep -qx "$d" || {
+      no "$(basename "$a" .md) declares '$d', which no bundled source provides" \
+         "the agent receives nothing and still answers — no error is raised"
+      bad=$((bad+1)); }
+  done
+done
+[ "$bad" -eq 0 ] && ok "every declared skill resolves to a bundled source"
+
+echo "── 3. the registrar excludes a source only on a premise it CHECKS ──"
+# anthropic/ was excluded on a premise measured false on two vaults. The exclusion
+# list may exist; what may not exist is an exclusion with nothing verifying it.
+if grep -qE '^\s*(anthropic \| superpowers|anthropic)\)' skills/setup.sh; then
+  no "skills/setup.sh still excludes anthropic/" "measured: 11 sources, 10-11 absent from ~/.claude/skills on two vaults"
+else
+  ok "anthropic/ is no longer excluded"
+fi
+if grep -qF 'absent="$absent $name"' skills/setup.sh && grep -qiE 'marketplace is not installed yet|premise' skills/setup.sh; then
+  ok "the registrar verifies its own exclusion premise at runtime"
+else
+  no "no presence check behind the exclusion list" "an unverified premise is what produced this bug"
+fi
+
+echo "── 4. CONTROL — section 2 must be able to fail ──"
+T=$(mktemp -d); mkdir -p "$T/agents/aios/x" "$T/skills/aios/real-skill"
+touch "$T/skills/aios/real-skill/SKILL.md"
+printf '## Skills\n\n- `no-such-skill` — invented for the control.\n' > "$T/agents/aios/x/ghost.md"
+hits=$(cd "$T" && {
+  av=$(find skills -mindepth 2 -maxdepth 3 -name SKILL.md | while IFS= read -r f; do basename "$(dirname "$f")"; done | sort -u)
+  c=0
+  for a in $(find agents -name '*.md'); do
+    for d in $(awk '/^## Skills/{f=1;next} f&&/^## /{exit} f' "$a" | sed -nE 's/^- `([a-z0-9][a-z0-9-]*)`.*/\1/p'); do
+      printf '%s\n' "$av" | grep -qx "$d" || c=$((c+1))
+    done
+  done
+  echo "$c"; })
+rm -rf "$T"
+[ "${hits:-0}" -ge 1 ] \
+  && ok "CONTROL FIRES: an agent declaring a nonexistent skill is detected" \
+  || no "CONTROL DID NOT FIRE — section 2 proves nothing"
+
+printf '\nRESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## `anthropic/` registers, and the exclusion premise is now checked

Closes items **1, 2 and 4** of #49. Independent of #52 — separate concern, separate PR.

### One sentence excluded two sources and was true of only one

`skills/setup.sh` skipped `anthropic/` **and** `superpowers/` on a single stated premise: *"those are provided via Claude Code marketplaces."* Measured across two independent vaults:

| source | bundled | absent from `~/.claude/skills` | verdict |
|---|---|---|---|
| `superpowers/` | 14 | **0** | premise holds — exclusion correct |
| `anthropic/` | 11 | **10–11** | premise false — the exclusion *is* the bug |

**Excluding them together is precisely what hid it.** Superpowers kept proving the rule while anthropic quietly broke it.

### The consequence was silence, not an error

Eight bundled agents declare one of those skills and received nothing:

| Skill | Declared by |
|---|---|
| `doc-coauthoring` | content-writer · sales-proposal-writer · protocol-steward |
| `internal-comms` | email-drafter · report-drafter |
| `theme-factory` | deck-builder |
| `mcp-builder` · `skill-creator` | aios-builder |

An agent that lacks the skill it declares **still answers** — just worse, with nothing anywhere reporting why. This is a defect for **every operator who installs this framework**, independent of any date or event; it simply becomes visible at scale whenever a group installs together.

### What changed

**1 · `anthropic/` registers like any other source.** Dry-run in a sandbox `HOME`: 36 linked, including all five skills that had bundled consumers. `superpowers/` stays excluded, because its premise is measured true.

**2 · The registrar now verifies the premise behind every remaining exclusion** — and distinguishes two states that look identical:

- **marketplace installed, skills absent** → the premise is false *here, now*. Name every one, and say to drop that source from the exclusion list.
- **marketplace not installed yet** → expected: this script runs at `SETUP` step 3, and the interview installs that marketplace at its plugins step. One quiet line, no enumeration.

That split matters more than it looks. Without it, a first-timer meets a **14-line alarm about skills arriving five steps later** — which is exactly how a warning gets trained into noise. Both branches were dry-run and verified.

**4 · `tests/agent-skills-resolve.test.sh`** asserts the half canonical controls: every skill a bundled agent names exists as a bundled source. Whether it is *linked into* `~/.claude/skills` is machine state, owned by the registrar's own presence check — **a test cannot assert another operator's machine**, and pretending to would be the same over-claiming this bug is made of.

### Still open on #49

**Item 3** — verify on a fresh install. The 0-vs-1 count difference between the two vaults suggests install history matters, and understanding *why* is worth more than the count. Needs a machine I don't have.

### One thing about this PR's own suite

Its first run reported **57 failures** with names like `doccoauthoring`. The extraction piped through `tr -d` with a hyphen in the delete set, stripping hyphens *inside* skill names — **the parser mangled the input; the agents were fine.** Fixed with `sed` on the delimiters only, and the reason is recorded in the file: never character-class away a character the data contains.

21/21 suites · control fires.

`hash: 20bbbd2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS
