### PR TITLE
fix(aios-commit): the post-commit index sync reports its own failure

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1057,6 +1057,17 @@ jobs:
         # Same finding, same cause: committed, never invoked.
         run: bash tests/route-insight.test.sh
 
+      - name: every bundled connector carries a manifest the App can read
+        # AI-122 Front A. The AIOS App builds its Connectors card from
+        # mcps/*/connector.json and ships NO copy of any register command, so a
+        # missing or malformed manifest does not degrade the card — it removes a
+        # connector from existence, silently. The criteria asserted are the silent
+        # ones: a literal ~/aios (a symlink on some machines, so documented != working,
+        # and invisible wherever they agree), an id that cannot be paired with a live
+        # registration, "MCP" in operator-facing copy, and a folder with no server
+        # claiming it has one.
+        run: bash tests/connector-manifests.test.sh
+
       - name: every suite in tests/ is actually invoked by this workflow
         # This job's step list is hand-typed, so a suite can be committed, shipped, and
         # never run — it rots without one red mark. This repo has already been bitten twice

--- a/hooks/aios-commit
+++ b/hooks/aios-commit
@@ -274,9 +274,30 @@ git update-ref HEAD "$COMMIT" || die "update-ref failed"
 # and the real index keeps the OLD content — so `git status` reports `MM` indefinitely and reads
 # as unpushed work that does not exist. Measured on three repos 2026-07-30. Per-path, one dead
 # pathspec costs only itself.
+#
+# THE FAILURE IS NOW REPORTED, because the comment above describes a symptom that
+# is invisible by construction: `2>/dev/null` discarded git's message and `|| true`
+# discarded its exit code, so a sync that did not happen looked exactly like one
+# that did. That silence has a cost measured on 2026-08-27 — a stale real-index
+# entry was found for a committed path, and by the time anyone looked, WHY the sync
+# missed it was unrecoverable. Two hypotheses were tested and both falsified; the
+# cause remains unknown, and it is unknown *because nothing recorded the failure at
+# the moment it happened*.
+#
+# Still non-fatal, deliberately: the commit has already succeeded by this point, and
+# failing here would turn a cosmetic index staleness into a hard error on work that
+# is safely committed and pushed. But non-fatal is not the same as unmentioned. One
+# line to stderr converts an unmeasurable failure into a measurable one, which is
+# the whole difference between this recurring and this being fixable next time.
 if [ ${#PATHS[@]} -gt 0 ]; then
   for _p in "${PATHS[@]}"; do
-    git add --all -- "$_p" 2>/dev/null || true
+    if ! _sync_err=$(git add --all -- "$_p" 2>&1); then
+      printf 'aios-commit: WARNING — post-commit index sync failed for: %s\n' "$_p" >&2
+      [ -n "$_sync_err" ] && printf 'aios-commit:   git said: %s\n' "$_sync_err" >&2
+      printf 'aios-commit:   Your commit SUCCEEDED; this only means the real index still holds\n' >&2
+      printf 'aios-commit:   the old content for that path, so `git status` may show it as\n' >&2
+      printf 'aios-commit:   modified indefinitely. Fix: git restore --staged -- <path>\n' >&2
+    fi
   done
 fi
 

--- a/mcps/_index.md
+++ b/mcps/_index.md
@@ -72,27 +72,73 @@ Three known Windows quirks have shipped helpers — bundled in the relevant MCP 
 
 The `spawn` wrapper itself has a PowerShell port — see `CLAUDE.md` → "Spawning sessions" → "On Windows (PowerShell)" for the full Invoke-ClaudeWithRespawn + spawn install block.
 
-## Canonical registration commands
+## Registration commands live in the manifests, not here
 
-Some MCPs need an explicit `--permissions` / `--tools` flag so the right services are loaded. Missing a service here means the tool surface silently lacks those endpoints (no error — they just don't appear). Use these commands as the source of truth:
+Every bundled folder carries a **`connector.json`** — machine-readable, beside the thing it describes:
 
-### Google Workspace
-
-```bash
-claude mcp add google-workspace \
-  -s local \
-  -e GOOGLE_OAUTH_CLIENT_ID=<your-client-id> \
-  -e GOOGLE_OAUTH_CLIENT_SECRET=<your-client-secret> \
-  -e MCP_SINGLE_USER_MODE=true \
-  -e USER_GOOGLE_EMAIL=<your-email> \
-  -e WORKSPACE_MCP_CREDENTIALS_DIR=$HOME/.google_workspace_mcp/credentials \
-  -- uvx workspace-mcp --single-user \
-  --permissions drive:full sheets:full slides:full docs:full calendar:full tasks:full gmail:full contacts:full forms:full
+```
+mcps/<id>-mcp/connector.json
 ```
 
-**Why this exact permission list:** every `:full` service we actually use in the vault workflow. Missing any of these = that service's tools silently don't appear. Services intentionally excluded: `chat` (redundant with Slack), `search` (redundant with built-in WebSearch), `appscript` (scope too broad, no current use). Add them to the list only when a workflow needs them.
+It holds the `id`, the operator-facing `service` name and `value`, the `connect` mode, anything the
+connector `requires` on disk, and the full `register` block (transport, command, args, env). **That is
+the single source of truth.** `mcps/setup.sh` installs dependencies and deliberately does not register
+anything; the AIOS App reads these manifests to build its Connectors card and ships **no copy** of any
+register command, so a missing manifest means a connector is simply not listed — honest silence rather
+than a guess.
 
-**On first call per service, browser opens for OAuth consent.** If you add new scopes to an already-registered server, users must re-consent (Google doesn't grant new scopes against an old token).
+**This section used to carry the commands, and that is exactly why it went stale.** It declared itself
+the source of truth while holding **one** entry (Google Workspace) out of eleven; the other ten lived
+in per-README prose in inconsistent shapes, three of them with no command at all. A section that
+*holds* data drifts from the thing it describes. A section that *points* cannot.
+
+**`{framework}` is mandatory in any manifest path — a literal `~/aios` is a bug.** `~/aios` is a
+symlink on some machines, so a hardcoded copy documents a path that differs from the one that actually
+works, and it is **invisible** on every machine where the clone and the symlink happen to agree. That
+was a real finding: a README documenting `~/aios/mcps/…` beside a live registration carrying the
+resolved path. Substitute `{framework}` with the resolved framework root at registration time.
+
+### Google Workspace — the permission list, stated once
+
+The nine `:full` services the vault workflow actually uses live in
+`mcps/google-workspace-mcp/connector.json`. **Deliberately excluded**, with reasons, because an
+exclusion needs a rationale a future reader can weigh:
+
+| Excluded | Why |
+|---|---|
+| `chat` | Redundant with Slack, which is the bundled connector for messaging |
+| `search` | Redundant with built-in WebSearch |
+| `appscript` | Scope far too broad for the benefit; no consumer in the framework |
+
+**Verified 2026-08-27, because "no current use" is a claim that decays:** a sweep of every
+`mcp__google-workspace__*` reference across `plugins/`, `agents/`, `skills/` and `hooks/` found **zero**
+consumers of any chat tool (`list_spaces`, `send_message`, `get_messages`, `search_messages`) and
+**zero** of any Apps Script tool. The exclusions hold on evidence, not on habit.
+
+> ⚠️ **A live registration carrying `chat:full appscript:full` is drift, not a newer decision.** It was
+> found on a real machine while this contract was being written, contradicting this file with no surface
+> anywhere reporting the difference — which is the diagnostic the App's Connectors card exists to
+> provide. **Correcting it is free:** removing a service needs no re-consent (the token keeps the scope
+> Google already granted; the tools simply stop being exposed), so re-register from the manifest and
+> restart. Adding scopes later is what costs a consent round-trip, not dropping them.
+
+**On first call per service a browser opens for OAuth consent.** Adding new scopes to an
+already-registered server requires re-consent — Google does not grant new scopes against an old token.
+
+### Registration scope — the trap worth knowing once
+
+`claude mcp add` defaults to **local** (per-directory) scope, so registrations land under
+`projects[<dir>].mcpServers` in `~/.claude.json` rather than at the top level. Two consequences a
+newcomer meets by accident:
+
+- **Open the same framework from a second directory and your connectors appear to vanish** — they are
+  still there, filed under the first directory.
+- **Register again from that second directory and you now maintain two copies**, which drift
+  independently and with nothing reporting it.
+
+Pass `-s user` when you want a registration that follows you across directories. Neither choice is
+wrong; the default simply is not the one most operators would pick if asked, and nothing asks.
+
 
 ## Bundling candidates (not yet bundled)
 
@@ -104,7 +150,20 @@ Services where teammates currently rely on claude.ai-hosted connectors. These sh
 
 1. Create a folder: `mcps/{name}-mcp/`
 2. Add the server code + `README.md` with: what it does, setup, auth, register command
-3. Add an install block to `mcps/setup.sh`
-4. Add a row to the **Bundled MCPs** table above
-5. Register it locally: `claude mcp add {name} -- {command}`
+3. **Add `connector.json`** (required — without it the AIOS App will not list the connector at all).
+   Copy the shape from any bundled folder. Non-negotiable fields:
+   - `id` **must equal the registered server name**, or a reader cannot match manifest to registration
+   - `service` is the service as the operator would name it — **never** containing the string "MCP"
+   - every path uses **`{framework}`**, never a literal `~/aios` (see above)
+   - `connect` is `one-click` (fully specified, no operator secret) · `needs-key` (command known, operator supplies values) · `guided` (multi-step auth a human must perform)
+   - `requires` lists anything that must exist on disk first, so a connector pointing at a `.venv`
+     `setup.sh` has not built yet is detectable **before** a registration is written rather than at
+     first use
+   - **not an MCP server at all?** Set `registers: false` and describe the real delivery path. Two
+     bundled folders are in this category (`notebooklm-mcp`, `playwright-mcp`) — they live under
+     `mcps/` by history, deliver capability through a skill and through direct Python respectively, and
+     have no server to register. A reader must not treat a missing registration for these as drift.
+4. Add an install block to `mcps/setup.sh`
+5. Add a row to the **Bundled MCPs** table above
+6. Register it locally: `claude mcp add {name} -- {command}` (prefer `-s user` — see the scope trap above)
 6. If it replaces a claude.ai-hosted connector, note the disable step in the README

--- a/mcps/_index.md
+++ b/mcps/_index.md
@@ -151,6 +151,12 @@ Services where teammates currently rely on claude.ai-hosted connectors. These sh
 1. Create a folder: `mcps/{name}-mcp/`
 2. Add the server code + `README.md` with: what it does, setup, auth, register command
 3. **Add `connector.json`** (required — without it the AIOS App will not list the connector at all).
+   **This applies to `mcps/custom/` too**, and that case is easier to miss because nothing in canonical
+   checks it: `/aios:update` never touches `custom/`, and the test suite is repo infrastructure that is
+   deliberately never synced to a vault. A custom MCP was found **registered and working with no
+   manifest** — invisible to the card while functioning perfectly — which surfaced only once the App
+   began reporting folders that have no manifest. See `mcps/custom/_index.md` for the operator-facing
+   version of this.
    Copy the shape from any bundled folder. Non-negotiable fields:
    - `id` **must equal the registered server name**, or a reader cannot match manifest to registration
    - `service` is the service as the operator would name it — **never** containing the string "MCP"

--- a/mcps/atlassian-mcp/connector.json
+++ b/mcps/atlassian-mcp/connector.json
@@ -1,0 +1,17 @@
+{
+  "id": "atlassian",
+  "service": "Atlassian (Jira & Confluence)",
+  "value": "Your Jira issues and Confluence pages — so work items and specs can be read and written where your team already keeps them.",
+  "infrastructure": false,
+  "connect": "needs-key",
+  "requires": [
+    "{framework}/mcps/atlassian-mcp/run.sh"
+  ],
+  "register": {
+    "transport": "stdio",
+    "command": "{framework}/mcps/atlassian-mcp/run.sh",
+    "args": [],
+    "env": {}
+  },
+  "docs": "README.md"
+}

--- a/mcps/custom/_index.md
+++ b/mcps/custom/_index.md
@@ -8,6 +8,23 @@ created: '2026-05-21'
 
 Add a folder per MCP server with its own README and `claude mcp add` instructions. Document each in the registry below.
 
+## Add a `connector.json` too — or the AIOS App will not know your MCP exists
+
+The App builds its Connectors card by reading `connector.json` from every folder under `mcps/`, **including this one**, and it ships no fallback list. So a custom MCP without a manifest is not shown as broken or unconfigured — it is **not shown at all**, and nothing says why.
+
+This is not hypothetical. `mint-mcp` was found **registered and working, with no manifest** — invisible to the card while functioning perfectly in every session. It surfaced only once the App started reporting folders that have no manifest; before that the absence looked exactly like a deliberate omission.
+
+Copy the shape from any bundled folder (`../google-workspace-mcp/connector.json` is a good reference) and keep these true:
+
+- **`id` must equal the name you registered with `claude mcp add`.** A reader pairs manifest to live registration by this field; get it wrong and a connected service reports as unconnected.
+- **`service`** is the service as *you* would say it out loud — never containing the string "MCP".
+- **every path uses `{framework}`**, never a literal `~/aios`. That path is a symlink on some machines, so a hardcoded copy documents something different from what actually works — and it is invisible on every machine where the clone and the symlink agree.
+- **`connect`** is `one-click` · `needs-key` · `guided`.
+- **`requires`** lists anything that must exist on disk first (a `.venv`, an OAuth file), so a connector pointing at something not yet built is detectable *before* a registration is written rather than at first use.
+- **not actually an MCP server?** Set `registers: false` and say how the capability is delivered instead. A reader must not read the absent registration as drift.
+
+> **Nothing in canonical validates this file for you.** `mcps/custom/` is yours — `/aios:update` never touches it, and the canonical test suite never reaches your machine (`tests/` is repo infrastructure and is deliberately not synced to vaults). The AIOS App's unmanifested-folder report is the surface that catches a missing manifest here. That asymmetry is worth knowing rather than discovering: the bundled folders are guarded by CI, and yours are guarded by the card telling you a folder is unlisted.
+
 ## Registry
 
 | MCP | Folder | Auth | Use case |

--- a/mcps/github-mcp/connector.json
+++ b/mcps/github-mcp/connector.json
@@ -1,0 +1,20 @@
+{
+  "id": "github",
+  "service": "GitHub",
+  "value": "Your repositories, issues and pull requests — so code work can be read, reviewed and shipped without leaving the conversation.",
+  "infrastructure": false,
+  "connect": "needs-key",
+  "requires": [],
+  "register": {
+    "transport": "stdio",
+    "command": "npx",
+    "args": [
+      "-y",
+      "@modelcontextprotocol/server-github"
+    ],
+    "env": {
+      "GITHUB_PERSONAL_ACCESS_TOKEN": "{ask:github-token}"
+    }
+  },
+  "docs": "README.md"
+}

--- a/mcps/google-workspace-mcp/connector.json
+++ b/mcps/google-workspace-mcp/connector.json
@@ -1,0 +1,34 @@
+{
+  "id": "google-workspace",
+  "service": "Google Workspace",
+  "value": "Your calendar, tasks, mail, Drive and Docs — so a daily plan can read your real day instead of guessing at it.",
+  "infrastructure": false,
+  "connect": "needs-key",
+  "requires": [],
+  "register": {
+    "transport": "stdio",
+    "command": "uvx",
+    "args": [
+      "workspace-mcp",
+      "--single-user",
+      "--permissions",
+      "drive:full",
+      "sheets:full",
+      "slides:full",
+      "docs:full",
+      "calendar:full",
+      "tasks:full",
+      "gmail:full",
+      "contacts:full",
+      "forms:full"
+    ],
+    "env": {
+      "GOOGLE_OAUTH_CLIENT_ID": "{ask:client-id}",
+      "GOOGLE_OAUTH_CLIENT_SECRET": "{ask:client-secret}",
+      "MCP_SINGLE_USER_MODE": "1",
+      "USER_GOOGLE_EMAIL": "{ask:google-email}",
+      "WORKSPACE_MCP_CREDENTIALS_DIR": "{home}/.google_workspace_mcp/credentials"
+    }
+  },
+  "docs": "README.md"
+}

--- a/mcps/nano-banana-mcp/connector.json
+++ b/mcps/nano-banana-mcp/connector.json
@@ -1,0 +1,19 @@
+{
+  "id": "nano-banana",
+  "service": "Image generation",
+  "value": "Generate and edit images from a description — covers and diagrams without a design tool.",
+  "infrastructure": false,
+  "connect": "needs-key",
+  "requires": [
+    "{framework}/mcps/nano-banana-mcp/.venv/bin/python"
+  ],
+  "register": {
+    "transport": "stdio",
+    "command": "{framework}/mcps/nano-banana-mcp/.venv/bin/python",
+    "args": [
+      "{framework}/mcps/nano-banana-mcp/server.py"
+    ],
+    "env": {}
+  },
+  "docs": "README.md"
+}

--- a/mcps/notebooklm-mcp/README.md
+++ b/mcps/notebooklm-mcp/README.md
@@ -10,6 +10,22 @@ Unofficial Python API for Google NotebookLM. Full programmatic access including 
 - Chat with notebooks (ask questions against your sources)
 - Share and collaborate
 
+## Not a connector — there is nothing to register
+
+This folder lives under `mcps/` by history, but **it contains no MCP server**: no server code, no
+`FastMCP`, no stdio transport. Verified 2026-08-27 while auditing all bundled folders for the connector
+manifest.
+
+Capability reaches you through the **bundled `notebooklm` skill** (`setup.sh` runs
+`notebooklm skill install`), plus the CLI documented below. `connector.json` here carries
+`registers: false`, which tells the AIOS App two things: never list this as a connector, and **never
+treat the absent registration as drift.**
+
+An earlier audit recorded this folder as *"bundled but registered nowhere, no register command in the
+README"* and proposed authoring one. That would have invented a server that does not exist — the App
+would then register a command that fails at first use, which is precisely the failure class this whole
+effort removes. The honest fix is this section.
+
 ## Install
 
 > ⚠️ **Requires Python 3.10+.** `notebooklm-py` uses PEP 604 syntax (`str | None`), so building the

--- a/mcps/notebooklm-mcp/connector.json
+++ b/mcps/notebooklm-mcp/connector.json
@@ -1,0 +1,19 @@
+{
+  "id": "notebooklm",
+  "service": "NotebookLM",
+  "value": "Research notebooks — reachable through the bundled `notebooklm` skill, not through a connector.",
+  "infrastructure": true,
+  "registers": false,
+  "delivery": "skill",
+  "entrypoint": "{framework}/mcps/notebooklm-mcp/.venv/bin/notebooklm",
+  "setup": [
+    "bash mcps/setup.sh notebooklm-mcp",
+    "{framework}/mcps/notebooklm-mcp/.venv/bin/notebooklm doctor --fix",
+    "{framework}/mcps/notebooklm-mcp/.venv/bin/notebooklm login   # operator runs this, never an agent",
+    "{framework}/mcps/notebooklm-mcp/.venv/bin/notebooklm doctor  # verify: Auth ✓"
+  ],
+  "connect": "guided",
+  "requires": [],
+  "docs": "README.md",
+  "_note": "NOT an MCP server. Verified 2026-08-27: no server code in this folder. `registers: false` means there is no registration to make and none to check for — a reader must not treat its absence as drift."
+}

--- a/mcps/obsidian-mcp/README.md
+++ b/mcps/obsidian-mcp/README.md
@@ -1,0 +1,41 @@
+# Obsidian vault bridge
+
+Lets the AIOS read and write your notes directly, instead of treating the vault as opaque files.
+
+## Infrastructure, not a connector
+
+This is the one MCP the framework needs to do its own job, so it is **never offered as a choice**.
+`connector.json` carries `infrastructure: true`, which tells the AIOS App to keep it out of the
+Connectors card entirely — an operator should never be asked whether they want the AIOS to be able to
+write the notes they just asked it to write.
+
+It is registered **silently** during `/aios:cold-start-interview`'s opening moments. There is nothing to
+decide: the package is published on npm, there is no account, and no token is ever involved.
+
+## Why this folder exists with no server code
+
+The server is the published npm package `@mauricio.wolff/mcp-obsidian`; nothing is vendored here. The
+folder exists so the connector has a **manifest**, and the manifest exists so a reader gets an explicit
+statement rather than an absence.
+
+That distinction is the whole point. The contract says *"a missing manifest means the connector is not
+listed"* — which would produce the right outcome here by accident, while leaving a reader unable to tell
+*"deliberately infrastructure"* from *"nobody has written the manifest yet."* Those need different
+responses: the first is finished, the second is a gap. An explicit `infrastructure: true` says which.
+
+## Register
+
+Handled for you. Documented here for manual repair only:
+
+```bash
+claude mcp add obsidian -- npx -y @mauricio.wolff/mcp-obsidian@latest {framework}/vault
+```
+
+`{framework}` is the **resolved** framework root. Never write a literal `~/aios` here — it is a symlink
+on some machines, so a hardcoded path documents something different from what works, and the mismatch is
+invisible wherever the clone and the symlink happen to agree.
+
+## If it fails
+
+Nothing breaks. Vault writes fall back to ordinary filesystem access; this bridge only makes them
+cleaner. Setup deliberately swallows a failure here rather than opening a first run on an error.

--- a/mcps/obsidian-mcp/connector.json
+++ b/mcps/obsidian-mcp/connector.json
@@ -1,0 +1,19 @@
+{
+  "id": "obsidian",
+  "service": "Obsidian vault bridge",
+  "value": "Lets the AIOS read and write your notes directly. Registered silently during setup — never a question, never a choice.",
+  "infrastructure": true,
+  "connect": "one-click",
+  "requires": [],
+  "register": {
+    "transport": "stdio",
+    "command": "npx",
+    "args": [
+      "-y",
+      "@mauricio.wolff/mcp-obsidian@latest",
+      "{framework}/vault"
+    ],
+    "env": {}
+  },
+  "docs": "README.md"
+}

--- a/mcps/pdf-generator-mcp/connector.json
+++ b/mcps/pdf-generator-mcp/connector.json
@@ -1,0 +1,19 @@
+{
+  "id": "pdf-generator",
+  "service": "PDF export",
+  "value": "Turn a document or web page into a clean PDF — for anything you need to send rather than share a link to.",
+  "infrastructure": false,
+  "connect": "one-click",
+  "requires": [
+    "{framework}/mcps/pdf-generator-mcp/.venv/bin/python"
+  ],
+  "register": {
+    "transport": "stdio",
+    "command": "{framework}/mcps/pdf-generator-mcp/.venv/bin/python",
+    "args": [
+      "{framework}/mcps/pdf-generator-mcp/server.py"
+    ],
+    "env": {}
+  },
+  "docs": "README.md"
+}

--- a/mcps/playwright-mcp/README.md
+++ b/mcps/playwright-mcp/README.md
@@ -10,6 +10,20 @@ Browser automation for the AI-OS. Auto-publish content, test web apps, capture s
 - Test web applications (verify UI behavior, debug rendering)
 - Scrape content with full JS rendering
 
+## Not a connector — there is nothing to register
+
+This folder lives under `mcps/` by history, but **it contains no MCP server**: no server code, no
+`FastMCP`, no stdio transport. Verified 2026-08-27 while auditing all bundled folders for the connector
+manifest.
+
+It is a Python toolkit, invoked directly — `.venv/bin/python cookie_import.py`, and Playwright itself
+driven from agent code. `connector.json` here carries `registers: false`, so the AIOS App neither lists
+it as a connector nor reads its missing registration as drift.
+
+An earlier audit recorded this folder as *"bundled but registered nowhere, no register command in the
+README"* and proposed authoring one. There is no server to point such a command at; writing one would
+produce a registration that fails at first use. The honest fix is this section.
+
 ## Example usage
 
 Ask Claude naturally — it drives the browser with your saved auth:

--- a/mcps/playwright-mcp/connector.json
+++ b/mcps/playwright-mcp/connector.json
@@ -1,0 +1,17 @@
+{
+  "id": "playwright",
+  "service": "Browser automation",
+  "value": "Drives a real browser for publishing, testing and screenshots — invoked directly as Python, not through a connector.",
+  "infrastructure": true,
+  "registers": false,
+  "delivery": "python",
+  "entrypoint": "{framework}/mcps/playwright-mcp/.venv/bin/python",
+  "setup": [
+    "bash mcps/setup.sh playwright-mcp",
+    "{framework}/mcps/playwright-mcp/.venv/bin/python {framework}/mcps/playwright-mcp/cookie_import.py"
+  ],
+  "connect": "guided",
+  "requires": [],
+  "docs": "README.md",
+  "_note": "NOT an MCP server. Verified 2026-08-27: no server code in this folder. `registers: false` means there is no registration to make and none to check for — a reader must not treat its absence as drift."
+}

--- a/mcps/slack-mcp/README.md
+++ b/mcps/slack-mcp/README.md
@@ -87,6 +87,24 @@ Operated by Revasser. Self-host support is best-effort; managed rollout and Clou
 
 **Runtime:** Node.js 20+
 
+### Register
+
+```bash
+claude mcp add slack -s user -- npx -y @jtalk22/slack-mcp
+```
+
+> **This command was missing from this README** until the connector-manifest audit (2026-08-27), even
+> though the server was live on the machine doing the audit — the working command existed only inside
+> `~/.claude.json`. It is now also in `connector.json`, which is what the AIOS App reads; this copy is
+> for a human reading the folder.
+>
+> **The registration takes no secret, and `env` is empty by design.** Credentials arrive out-of-band
+> through the `--setup` step below, which extracts them from your already-signed-in Chrome rather than
+> asking you to paste a token. So **"has a key" cannot be inferred from the registration** — an empty
+> `env` here means *"the secret lives elsewhere"*, not *"unconfigured"*. That is why this connector is
+> `connect: "guided"` rather than `one-click`: the command is fully known, but a human has to do the
+> auth step, and a card claiming one-click here would be lying.
+
 ```bash
 npx -y @jtalk22/slack-mcp --setup
 npx -y @jtalk22/slack-mcp@latest --version

--- a/mcps/slack-mcp/connector.json
+++ b/mcps/slack-mcp/connector.json
@@ -1,0 +1,26 @@
+{
+  "id": "slack",
+  "service": "Slack",
+  "value": "Your Slack conversations — so what needs your attention can be surfaced, and replies drafted, without opening the app.",
+  "infrastructure": false,
+  "connect": "guided",
+  "requires": [],
+  "register": {
+    "transport": "stdio",
+    "command": "npx",
+    "args": [
+      "-y",
+      "@jtalk22/slack-mcp"
+    ],
+    "env": {}
+  },
+  "docs": "README.md",
+  "guided": {
+    "why": "Credentials are extracted from your already-signed-in Chrome rather than typed, so no token is ever pasted or stored by the framework.",
+    "steps": [
+      "npx -y @jtalk22/slack-mcp --setup",
+      "npx -y @jtalk22/slack-mcp@latest --doctor   # verify"
+    ],
+    "note": "The registration itself needs no secret — `env` is empty by design. Do NOT infer 'has a key' from the registration (audit finding 4)."
+  }
+}

--- a/mcps/spotify-dj-mcp/connector.json
+++ b/mcps/spotify-dj-mcp/connector.json
@@ -1,0 +1,19 @@
+{
+  "id": "spotify-dj",
+  "service": "Spotify",
+  "value": "Playback control — start focus music without switching windows.",
+  "infrastructure": false,
+  "connect": "needs-key",
+  "requires": [
+    "{framework}/mcps/spotify-dj-mcp/.venv/bin/python"
+  ],
+  "register": {
+    "transport": "stdio",
+    "command": "{framework}/mcps/spotify-dj-mcp/.venv/bin/python",
+    "args": [
+      "{framework}/mcps/spotify-dj-mcp/server.py"
+    ],
+    "env": {}
+  },
+  "docs": "README.md"
+}

--- a/mcps/stitch-mcp/connector.json
+++ b/mcps/stitch-mcp/connector.json
@@ -1,0 +1,19 @@
+{
+  "id": "stitch",
+  "service": "Stitch (UI design)",
+  "value": "Generate interface designs from a description — screens and design systems without starting in a design tool.",
+  "infrastructure": false,
+  "connect": "one-click",
+  "requires": [],
+  "register": {
+    "transport": "stdio",
+    "command": "npx",
+    "args": [
+      "-y",
+      "@_davideast/stitch-mcp",
+      "proxy"
+    ],
+    "env": {}
+  },
+  "docs": "README.md"
+}

--- a/tests/aios-commit.test.sh
+++ b/tests/aios-commit.test.sh
@@ -166,6 +166,32 @@ grep -q 'index still lags HEAD' "$AC" && grep -q 'git diff --cached --name-only 
   && ok "post-sync verification + operator-facing NOTE are wired into the hook" \
   || no "the stale-index verification was removed — silent staleness can return"
 
+# The NOTE above reports the SYMPTOM (index lags HEAD for a committed path). It does
+# not report the CAUSE, because the sync used to hide its own failure behind
+# `2>/dev/null || true` — so "the add failed" and "the add worked" produced identical
+# output. On 2026-08-27 a stale index entry was found for a committed path and the
+# cause was unrecoverable; two hypotheses were tested and both falsified. Symptom and
+# cause are different reports and both are worth having: the NOTE tells the operator
+# what to clean, this tells whoever is debugging WHY it happened.
+#
+# Trigger is the ordinary `git mv` flow — the throwaway index is seeded from HEAD,
+# where the OLD name still exists, so pre-commit staging succeeds; post-commit HEAD
+# no longer carries it and the per-path sync matches nothing.
+echo "── aios-commit: the sync reports its own failure, not just the resulting staleness ──"
+R=$(mktemp -d)
+( cd "$R" && git init -q . && git config user.email t@t && git config user.name t \
+  && mkdir -p "00 - notes" && echo one > "00 - notes/old.md" && git add -A && git commit -qm init \
+  && git mv "00 - notes/old.md" "00 - notes/new.md" ) >/dev/null 2>&1
+OUT=$( cd "$R" && "$AC" --no-push -m "rename" -- "00 - notes/old.md" "00 - notes/new.md" 2>&1 )
+case "$OUT" in
+  *"post-commit index sync failed"*) ok "a failed post-commit index sync names itself" ;;
+  *) no "the index sync failed silently" "an unrecorded cause is why the 2026-08-27 staleness is unexplainable" ;;
+esac
+( cd "$R" && [ "$(git ls-tree -r HEAD --name-only | grep -c 'new.md')" = "1" ] ) \
+  && ok "the commit still lands despite a sync warning (non-fatal by design)" \
+  || no "a sync warning broke the commit" "cosmetic staleness must never fail work that is already committed"
+rm -rf "$R"
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Lock-failure CLASSIFICATION. `mkdir` fails for two unrelated reasons and the
 # loop used to treat both as contention: an unwritable $GIT_DIR (sandboxed Bash

--- a/tests/connector-manifests.test.sh
+++ b/tests/connector-manifests.test.sh
@@ -135,5 +135,60 @@ rm -rf "$T"
 [ "${hits:-0}" -ge 5 ] && ok "CONTROL FIRES: a deliberately broken manifest trips $hits criteria" \
   || no "CONTROL DID NOT FIRE (only ${hits:-0}) — section 2 proves nothing"
 
+
+echo "── 6. mcps/custom/ — validated if present, never required ──"
+# The App reads manifests from every folder under mcps/, custom/ included, and a
+# custom MCP with no manifest is not shown as broken — it is not shown at all. A
+# real one was found registered and working, invisible to the card, and it
+# surfaced only when the App started reporting unmanifested folders.
+#
+# But this suite CANNOT be the guard for that, and the reason is structural rather
+# than an oversight: mcps/custom/ is operator content that /aios:update never
+# touches, and tests/ is repo infrastructure deliberately never synced to a vault
+# (Tier 0). So canonical CI runs where there is no custom content, and the operator
+# who has custom content never runs canonical CI. Asserting a manifest EXISTS here
+# would fail on nothing and protect nobody.
+#
+# What this suite can honestly do is two things: validate a custom manifest if one
+# is ever present (a canonical example, or a contributor's fixture), and assert
+# that the DOCUMENTATION carries the rule — because documentation is the only
+# canonical surface that actually reaches the operator's machine.
+CUSTOM=$(ls -d mcps/custom/*/ 2>/dev/null | wc -l | tr -d ' ')
+CUSTOM_MANIFESTS=$(ls mcps/custom/*/connector.json 2>/dev/null | wc -l | tr -d ' ')
+if [ "${CUSTOM:-0}" -eq 0 ]; then
+  ok "no custom MCP folders in canonical — nothing to validate (expected)"
+else
+  bad_custom=$(python3 - <<'PY'
+import json,glob,os,re
+c=0
+for f in sorted(glob.glob("mcps/custom/*/connector.json")):
+    folder=os.path.basename(os.path.dirname(f))
+    try: d=json.load(open(f))
+    except Exception: c+=1; continue
+    if d.get("id") != folder[:-4] if folder.endswith("-mcp") else False: c+=1
+    if re.search(r'\bMCPs?\b', str(d.get("service","")), re.I): c+=1
+    c += len(re.findall(r'~/aios[^"]*', json.dumps(d)))
+    if d.get("connect") not in ("one-click","needs-key","guided"): c+=1
+print(c)
+PY
+)
+  [ "${bad_custom:-0}" -eq 0 ] \
+    && ok "$CUSTOM custom folder(s), $CUSTOM_MANIFESTS manifest(s), 0 violations" \
+    || no "$bad_custom violation(s) in a custom manifest" "same contract applies wherever a manifest lives"
+fi
+
+# The doc rule is the part that reaches an operator, so it is the part asserted.
+if grep -qiE 'connector\.json' mcps/custom/_index.md; then
+  ok "mcps/custom/_index.md tells an operator their MCP needs a manifest"
+else
+  no "the custom-MCP index does not mention connector.json" \
+     "the App will silently not list their MCP, and this suite never reaches their machine to say so"
+fi
+if awk '/^## Adding a new MCP/,0' mcps/_index.md | grep -qiE 'custom'; then
+  ok "the add-an-MCP checklist covers mcps/custom/ explicitly"
+else
+  no "the checklist does not mention custom/" "the case that most needs stating is the one nothing checks"
+fi
+
 printf '\nRESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/connector-manifests.test.sh
+++ b/tests/connector-manifests.test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# connector.json — the manifest contract (AI-122, Front A · C1-C5)
+#
+# The AIOS App reads mcps/*/connector.json to build its Connectors card and ships
+# NO copy of any register command. That is the whole contract: mcps/ is the single
+# source, the App is a reader. It makes these manifests load-bearing in a way the
+# usual "docs drift a bit" tolerance does not cover — a malformed or missing
+# manifest does not degrade the card, it removes a connector from existence.
+#
+# So the failure modes worth asserting are the ones that are SILENT:
+#   - a literal ~/aios in a path. That is a symlink on some machines, so the
+#     documented command differs from the working one — and it is invisible on
+#     every machine where the clone and the symlink agree, which is most of them.
+#   - an `id` that does not match the registered server name: a reader cannot pair
+#     manifest to registration, so a connected service reads as unconnected.
+#   - "MCP" in an operator-facing string: the word the whole change removes.
+#   - a folder with no server pretending it has one: the App would write a
+#     registration that fails at first use, which is the failure class AI-122 exists
+#     to remove rather than relocate.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; return 0; }
+
+echo "── 1. every bundled MCP folder carries a manifest ──"
+missing=""
+for d in mcps/*-mcp/; do
+  [ -d "$d" ] || continue
+  [ -f "${d}connector.json" ] || missing="$missing $(basename "$d")"
+done
+[ -z "$missing" ] && ok "all bundled folders have connector.json" \
+  || no "folders without a manifest:$missing" "the App does not list a connector whose manifest is absent — it vanishes silently"
+
+echo "── 2. the contract's own acceptance criteria ──"
+python3 - <<'PY'
+import json, glob, os, re, sys
+bad = []
+for f in sorted(glob.glob("mcps/*-mcp/connector.json")):
+    folder = os.path.basename(os.path.dirname(f))
+    want_id = folder[:-4]
+    try:
+        d = json.load(open(f))
+    except Exception as e:
+        bad.append(f"{folder}: unparseable JSON ({e})"); continue
+    blob = json.dumps(d)
+    if d.get("id") != want_id:
+        bad.append(f"{folder}: id {d.get('id')!r} must equal the registered server name {want_id!r}")
+    if re.search(r'\bMCPs?\b', str(d.get("service", "")), re.I):
+        bad.append(f"{folder}: service names the protocol: {d.get('service')!r}")
+    for m in re.findall(r'~/aios[^\"]*', blob):
+        bad.append(f"{folder}: literal ~/aios ({m[:50]}) — use {{framework}}")
+    if d.get("connect") not in ("one-click", "needs-key", "guided"):
+        bad.append(f"{folder}: connect={d.get('connect')!r} is not one of the three modes")
+    for k in ("service", "value", "docs"):
+        if not d.get(k): bad.append(f"{folder}: missing {k}")
+    docs = d.get("docs")
+    if docs and not os.path.isfile(os.path.join(os.path.dirname(f), docs)):
+        bad.append(f"{folder}: docs points at {docs}, which does not exist")
+    if d.get("registers", True):
+        if not d.get("register", {}).get("command"):
+            bad.append(f"{folder}: registers is true but there is no register.command")
+    else:
+        if not d.get("_note") and not d.get("delivery"):
+            bad.append(f"{folder}: registers:false must say how capability is delivered instead")
+for b in bad: print("  FAIL  " + b)
+pass
+PY
+n=$(python3 - <<'PY'
+import json,glob,os,re
+c=0
+for f in sorted(glob.glob("mcps/*-mcp/connector.json")):
+    folder=os.path.basename(os.path.dirname(f))
+    try: d=json.load(open(f))
+    except Exception: c+=1; continue
+    blob=json.dumps(d)
+    if d.get("id")!=folder[:-4]: c+=1
+    if re.search(r'\bMCPs?\b',str(d.get("service","")),re.I): c+=1
+    c+=len(re.findall(r'~/aios[^"]*',blob))
+    if d.get("connect") not in ("one-click","needs-key","guided"): c+=1
+    for k in ("service","value","docs"):
+        if not d.get(k): c+=1
+    docs=d.get("docs")
+    if docs and not os.path.isfile(os.path.join(os.path.dirname(f),docs)): c+=1
+    if d.get("registers",True):
+        if not d.get("register",{}).get("command"): c+=1
+    elif not d.get("_note") and not d.get("delivery"): c+=1
+print(c)
+PY
+)
+[ "$n" -eq 0 ] && ok "all manifests satisfy the contract (id · no \"MCP\" · {framework} · connect mode · docs exists)" \
+  || no "$n contract violation(s) — see FAIL lines above" ""
+
+echo "── 3. _index.md points at the manifests instead of holding commands ──"
+if grep -qE '^\s*claude mcp add (google-workspace|atlassian|github|slack|stitch|spotify-dj|nano-banana|pdf-generator)\b' mcps/_index.md; then
+  no "_index.md still holds a register command" "it declared itself the source of truth while carrying 1 of 11 — a section that HOLDS data drifts; one that POINTS cannot"
+else
+  ok "_index.md holds no register commands"
+fi
+grep -qF 'connector.json' mcps/_index.md \
+  && ok "_index.md names connector.json as the source" \
+  || no "_index.md does not point anywhere" "removing the commands without naming their replacement is worse than leaving them"
+
+echo "── 4. adding a new MCP requires a manifest ──"
+if awk '/^## Adding a new MCP/,0' mcps/_index.md | grep -qF 'connector.json'; then
+  ok "the add-an-MCP checklist requires connector.json"
+else
+  no "a new MCP can be added without a manifest" "it would be invisible to the App with nothing reporting why"
+fi
+
+echo "── 5. CONTROL — the criteria must be able to fail ──"
+T=$(mktemp -d); mkdir -p "$T/mcps/broken-mcp"
+cat > "$T/mcps/broken-mcp/connector.json" <<'J'
+{ "id": "wrong", "service": "Broken MCP", "value": "v", "connect": "sometimes",
+  "requires": ["~/aios/mcps/broken-mcp/x"], "register": {}, "docs": "NOPE.md" }
+J
+hits=$(cd "$T" && python3 - <<'PY'
+import json,glob,os,re
+c=0
+for f in sorted(glob.glob("mcps/*-mcp/connector.json")):
+    folder=os.path.basename(os.path.dirname(f)); d=json.load(open(f)); blob=json.dumps(d)
+    if d.get("id")!=folder[:-4]: c+=1
+    if re.search(r'\bMCPs?\b',str(d.get("service","")),re.I): c+=1
+    c+=len(re.findall(r'~/aios[^"]*',blob))
+    if d.get("connect") not in ("one-click","needs-key","guided"): c+=1
+    docs=d.get("docs")
+    if docs and not os.path.isfile(os.path.join(os.path.dirname(f),docs)): c+=1
+    if d.get("registers",True) and not d.get("register",{}).get("command"): c+=1
+print(c)
+PY
+)
+rm -rf "$T"
+[ "${hits:-0}" -ge 5 ] && ok "CONTROL FIRES: a deliberately broken manifest trips $hits criteria" \
+  || no "CONTROL DID NOT FIRE (only ${hits:-0}) — section 2 proves nothing"
+
+printf '\nRESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## The post-commit index sync reports its own failure

`aios-commit` ends by syncing the **shared** index for the paths it just committed (`git add --all`, no `GIT_INDEX_FILE` — deliberate, and documented as such). That sync hid its own failure behind `2>/dev/null || true`, so **a sync that did not happen was indistinguishable from one that did.**

### This is the cause, not the symptom — the hook already had the symptom

Line 326 already NOTEs *"your git index still lags HEAD for: `<paths>`"* and tells the operator how to clear it. **That stays.** They are different reports for different readers: the NOTE tells an operator what to clean; this tells whoever is debugging **why it happened**.

### Motivated by a real case, and by two theories that both turned out wrong

On 2026-08-27 a stale real-index entry was found for a committed path in a vault: HEAD carried one blob, the index carried the version from a commit **30 minutes earlier**, and `git status` had shown the file as modified ever since. It would have recorded a delivered document as undelivered on whoever committed next.

Two hypotheses were raised and **both were falsified by measurement**:

- *an Obsidian git plugin auto-staging* — no git plugin is installed in that vault (11 plugins, none git-related)
- *the spaced path (`00 - notes`) breaking the sync* — tested in a scratch repo; spaced paths sync correctly, HEAD blob == index blob, status clean

**The cause remains unknown, and it is unknown precisely because nothing recorded the failure at the moment it occurred.** That is the gap this closes. Neither disproven theory is recorded as a cause anywhere.

### Still non-fatal, deliberately

The commit has already succeeded by this point. Failing here would turn cosmetic index staleness into a hard error on work that is safely committed and pushed. **Non-fatal is not the same as unmentioned.**

### Reproduced, not assumed

Via the trigger the existing comment documents — the ordinary `git mv` flow. The throwaway index is seeded from `HEAD`, where the OLD name still resolves, so pre-commit staging succeeds; post-commit `HEAD` no longer carries it, so the per-path sync matches nothing:

```
aios-commit: WARNING — post-commit index sync failed for: 00 - notes/old.md
aios-commit:   git said: fatal: pathspec '00 - notes/old.md' did not match any files
aios-commit:   Your commit SUCCEEDED; this only means the real index still holds
aios-commit:   the old content for that path, so `git status` may show it as
aios-commit:   modified indefinitely. Fix: git restore --staged -- <path>
aios-commit: 3555c1338 — rename
```

The commit still lands (`HEAD` carries `new.md`).

**`tests/aios-commit.test.sh`: 28 → 30.** Control proven by restoring the swallow — the suite goes red. Passes on bash 5.x **and** bash 3.2 (macOS system bash). 20/20 suites.

`hash: 8d046d0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS
