### PR TITLE
fix: two operator-reported defects — a status line that named the wrong cause, and a default that deleted a footer

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1057,6 +1057,14 @@ jobs:
         # Same finding, same cause: committed, never invoked.
         run: bash tests/route-insight.test.sh
 
+      - name: the Pipeline Status line names the precondition that actually failed
+        # FIELD REPORT 2026-08-28. Three preconditions gate the Tasks future; the status
+        # report attributed ANY absent future to credentials, so a missing list-ID line in
+        # USER.md printed "credentials missing" and an operator re-authenticated OAuth five
+        # mornings in a row. A message naming the WRONG cause is worse than a generic one:
+        # a generic message makes you look, a wrong specific one makes you work.
+        run: bash tests/pipeline-executor-status.test.sh
+
       - name: every bundled connector carries a manifest the App can read
         # AI-122 Front A. The AIOS App builds its Connectors card from
         # mcps/*/connector.json and ships NO copy of any register command, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,46 @@
 >
 > A changelog that only lists *what changed* pushes comprehension-debt onto the operator — they'd have to read a skill's source to know what it does for their day. So every entry leads with a **"What you can now do"** section: the new capabilities in **plain language, with a concrete example**, phrased as things the operator can *do* now — not a component inventory. Keep the full component list too (for the record), but lead with the practical read, and flag the load-bearing behavioral changes worth an actual read. `/aios:update` surfaces this section to the operator after applying an entry, so their own Claude session tells them what the new version unlocks. **The rule:** *translate every shipped change into a capability the operator can use — or it isn't really shipped to them, just to the repo.*
 
+## 2026-08-28 — Two messages that named the wrong cause, and a default that deleted a file's footer
+
+`hash: a1785d9`
+
+### `/aios:today` stops blaming your credentials for a missing config line
+
+> **What this delivers.** The Tasks source is queried only if **three** independent things hold: the source configured, a list ID present in `USER.md`, and credentials on disk. The Pipeline Status line attributed **any** absent future to credentials — so a missing `- Google Tasks list: \`<ID>\`` line printed *"configured but credentials missing — run the setup for this source"*. Reported by an operator who **re-authenticated OAuth five mornings in a row** while the real cause was one line of config.
+
+**What you can now do:**
+- **Read a status line that names the precondition that actually failed.** A missing list ID says so and tells you where to get the ID. Genuinely-absent credentials still say so, with the path. And when none of the known causes match, it says *that* instead of picking one — because a default naming a cause it never verified is the same bug one branch down.
+- **Find out the list-ID line exists before it costs you a week.** `SETUP.md` now documents it, and documents the failure mode: without it the source is **enabled but never queried**, so your daily plan simply has no tasks, every morning, with nothing indicating why.
+
+**Action required — one, if your `/aios:today` has been quietly task-free.** Check `USER.md` → `## Sources` for a literal `- Google Tasks list: \`<ID>\`` line. If it is absent, that was the cause and the new message will now tell you so. Get the ID from the Tasks API (`tasklists.list`) or ask Claude to list them.
+
+*The reporter's framing, which is better than the bug: **a message that names a wrong cause is worse than a generic one, because it directs the work.** A generic message makes you look; a wrong specific one makes you work — in this case for five days, in the wrong place.*
+
+### `hooks/route-insight.py` no longer deletes a section's footer when the last entry leaves
+
+> **What this delivers.** Excising the **last** bullet of a section removed the whole file tail with it — the caps line, the `---`, and the `**See also:**` footer — while exiting 0 and printing `✓ excised`. Silent loss. `end` defaulted to end-of-file and was corrected only by three enumerated terminators; the last entry in a list has no next, so none of them matched.
+
+**What you can now do:**
+- **Keep your file tails.** When the scan finds no terminator — the only case that produced the loss — the command **refuses**, names every line it would have deleted, and leaves the file byte-identical. Costs one manual excision; the alternative cost three lines while reporting success.
+- **Trust it around deeper headings.** `#### ` was never a terminator (only `##` and `###`), and h4 exists in the live corpus, so a bullet sitting before one already over-extended. Any heading level now terminates.
+
+**Action required — none.** But if you have run this command on a file that ends in `_Caps:` / `---` / `**See also:**`, it is worth checking that tail is still there. The command writes a `.routebak-*` backup beside the file on every run.
+
+*The fix is **not** a fourth terminator, and deliberately not the reporter's own preferred form either. He proposed defining membership positively — an entry is its line plus its indented continuations, cut at the first unindented line — and **flagged the contract risk himself rather than hiding it**. Measured against the seven live files that carry both bullets and a footer: **43 bullets are followed by unindented continuation prose that genuinely belongs to them** (`**Note the asymmetry:** …`, `**Category:** …`). That rule would have cut those entries in half. His flag was right, and the corpus decided against his own proposal.*
+
+*One more thing found while fixing it, and it generalises past this file: **the truncation guard could not catch a wrong `end`.** It compares `lines[end:]` against `new_lines[head:]` — the same `end` on both sides — so with `end` at EOF both slices are empty and it passed while a footer was being deleted. **A check scoped by the value under suspicion cannot test that value.** The span is now asserted independently, in absolute terms.*
+
+### The shape both of these share, which is worth more than either fix
+
+*Both are an **incomplete enumeration whose default is an assertion instead of a doubt** — the reporter's phrasing. One chains three preconditions and the negative branch asserts which failed; it does not know. The other enumerates three terminators and, finding none, assumes end-of-file; it does not know either. In both, a "none of the N" case is treated as a known case, and reported as success or as a concrete cause — which is exactly what stops anyone looking.*
+
+*It is the rule from the previous round — a step that cannot fail loudly should not be able to report success — applied one level down, to **the default value of an enumeration**. A default is a silent assertion about the case you did not enumerate. If the list of cases can be incomplete, the default has to be the one that makes noise.*
+
+*Tests: `route-insight` 5 → 9, plus a new 7-check `pipeline-executor-status` suite, both wired into CI. Controls proven the way the reporter asks for — 3 of 4 new route tests and 5 of 7 status checks go red against the old code. Also fixed `route-insight.test.sh`'s `no()` helper, which used an unguarded `$2` and **crashed instead of failing** under `set -u`, which is how a red suite can look like a broken one.*
+
+---
+
 ## 2026-08-27 — First-run stops asking questions a newcomer cannot answer, and stops ending before it is finished
 
 `hash: b55e142 · 2e4044b · 765ff51 · ecb3cf4 · 8d7238f · 1e78989 · 140ea59 · e166fc9 · 23b001f · 69da9bf · 51e70ac · be5baf9 · 9e55b19 · 0d40b35 · 89fe90d · 8d046d0 · 127231c`

--- a/SETUP.md
+++ b/SETUP.md
@@ -262,6 +262,7 @@ Claude reads this file and walks you through the full onboarding — clone → i
 
 **What Claude asks you** (only if needed):
 - Your Google email (for Calendar/Tasks/Drive)
+- **Which Google Tasks list to read.** This one is easy to miss and it fails quietly: `USER.md` → `## Sources` needs a literal `- Google Tasks list: \`<ID>\`` line, and **without it the Tasks source is enabled but never queried** — `/aios:today` will simply have no tasks, every morning, with nothing to indicate why. Get the ID from the Tasks API (`tasklists.list`), or ask Claude to list them for you. Reported 2026-08-28 by an operator who chased a nonexistent OAuth problem for five days because the status line blamed credentials instead of naming the missing line (fixed — it now names the line).
 - Which task sources you use (GitHub Issues, Linear, Monday, etc.)
 - What to name your private vault repo (defaults to `{username}/aios` — matches the local path `~/aios/`; pick a different name if you prefer, e.g., `{username}/vault` or `{username}/my-aios`)
 - Substrate choices when running `/company` or `/collaborate`

--- a/hooks/pipeline-executor.py
+++ b/hooks/pipeline-executor.py
@@ -646,10 +646,32 @@ def run_pipeline(command_name):
     # Distinguish "operator never turned this on" from "turned on but unusable". Reporting
     # both as "not configured" hid a real problem: a source the operator HAD configured but
     # whose credentials were missing read as a deliberate choice, so nobody went looking.
+    #
+    # AND THEN SAY WHICH PRECONDITION FAILED. This used to report "configured but credentials
+    # missing" for EVERY absent future, while the guard that creates the Tasks future requires
+    # THREE independent things: the source configured, a list ID present in USER.md, and
+    # credentials on disk. Three preconditions collapsed into one diagnosis, and the one chosen
+    # was the most expensive to chase.
+    #
+    # Reported 2026-08-28 by an operator who re-authenticated OAuth FIVE MORNINGS IN A ROW
+    # while the real cause was a missing config line. A message naming the wrong cause is worse
+    # than a generic one: a generic message makes you look, a wrong specific one makes you work.
+    # The distinction the comment above already draws needed one more step — once you know it
+    # is unusable, say why.
     for source, mapped in [("calendar", "calendar_primary"), ("calendar-personal", "calendar_personal"), ("tasks", "tasks"), ("slack", "slack")]:
         if mapped not in futures:
             if source in sources["configured"]:
-                status.append(f"⏭️ {source}: configured but credentials missing — run the setup for this source")
+                if source == "tasks" and not sources["google_tasks_list"]:
+                    reason = ("missing list ID — add `- Google Tasks list: `<ID>`` to USER.md → ## Sources "
+                              "(get the ID from the Tasks API: tasklists.list)")
+                elif creds_primary is None or not creds_primary.exists():
+                    reason = f"credentials not found at {creds_primary} — run the setup for this source"
+                else:
+                    # Deliberately vague, and honest about being vague: the preconditions
+                    # enumerated above may not be the only ones. A default that names a cause
+                    # it never verified is precisely the failure being fixed here.
+                    reason = "prerequisites incomplete — no known cause matched, so this needs a look"
+                status.append(f"⏭️ {source}: configured but not queried — {reason}")
             else:
                 status.append(f"⏭️ {source}: not configured")
 

--- a/hooks/route-insight.py
+++ b/hooks/route-insight.py
@@ -26,6 +26,7 @@ Usage:
 Exit codes: 0 = excised + validated; 2 = no/ambiguous match (no change);
             3 = validation failed (restored from snapshot, no change).
 """
+import re
 import argparse, datetime, os, re, shutil, sys
 
 # Windows: stdout defaults to the locale codepage (cp1252 on a Western-European
@@ -52,7 +53,29 @@ def find_entry(lines, match):
     Boundaries are STYLE-DEPENDENT and that is load-bearing: a bullet must not terminate a
     heading entry (it would orphan the back half of every one), and a bullet entry must end
     at the next top-level bullet / heading / HTML comment so its indented facets travel with
-    it and neighbouring file-level comments are not swallowed."""
+    it and neighbouring file-level comments are not swallowed.
+
+    THE LAST ENTRY IN A LIST HAS NO NEXT, and that is where the enumeration above ran out.
+    Reported 2026-08-28 by an operator with an executed repro: excising the last bullet of a
+    section carried the whole file tail with it — the caps line, the `---`, and the
+    `**See also:**` footer — while exiting 0 and printing `✓ excised`. The design was written
+    against neighbours and had no case for the edge, so the very goal this docstring states
+    ("neighbouring file-level comments are not swallowed") was the one it broke.
+
+    The fix is NOT a fourth terminator. Enumerating stoppers is incomplete by construction
+    and this function is the proof: three were enumerated with care, `#### ` was already
+    missing (h4 exists in the live corpus), and the edge case was not in the list either.
+    So when the forward scan reaches EOF without finding any terminator — the ambiguous case,
+    and the ONLY case that produced the bug — we do not guess. `entry_span_is_clean` decides,
+    and an unclean span REFUSES rather than deletes.
+
+    Why not "an entry is its line plus its indented continuations, cut at the first
+    unindented line" (the reporter's preferred form, and the more elegant one): measured
+    against the seven live files that carry both bullets and a footer, **43 bullets are
+    followed by unindented continuation prose that genuinely belongs to them** — `**Note the
+    asymmetry:** …`, `**Category:** [PROCESS / …]`. That rule would cut those entries in half.
+    The reporter flagged this exact risk as a contract decision rather than a detail, and the
+    corpus decided it against the elegant form."""
     m = match.lower()
     style = "heading"
     hits = [i for i, ln in enumerate(lines) if ln.startswith("### ") and m in ln.lower()]
@@ -60,16 +83,50 @@ def find_entry(lines, match):
         style = "bullet"
         hits = [i for i, ln in enumerate(lines) if is_top_bullet(ln) and m in ln.lower()]
     if len(hits) != 1:
-        return None, len(hits), style
+        return None, len(hits), style, False
     start = hits[0]
     end = len(lines)
+    hit_terminator = False
     for j in range(start + 1, len(lines)):
         ln = lines[j]
-        if ln.startswith("## ") or ln.startswith("### "):
-            end = j; break
+        # ANY heading level, not just h2/h3. `#### ` was absent from the original list and
+        # h4 exists in the live corpus (business.md carries 10), so a bullet sitting before
+        # one already over-extended — the same gap as the edge case, found while fixing it.
+        if re.match(r'^#{1,6} ', ln):
+            end = j; hit_terminator = True; break
         if style == "bullet" and (is_top_bullet(ln) or ln.lstrip().startswith("<!--")):
-            end = j; break
-    return (start, end), 1, style
+            end = j; hit_terminator = True; break
+    return (start, end), 1, style, hit_terminator
+
+
+def entry_span_is_clean(lines, start, end):
+    """Lines that would be removed but are NOT part of the entry — empty tuple means clean.
+
+    Only consulted when the forward scan found no terminator (see `find_entry`). A default is
+    a silent assertion about the case you did not enumerate, so this is the noisy alternative:
+    the span may contain the entry's own line, blanks, and indented continuations. Unindented
+    prose is ALLOWED (the corpus has 43 legitimate instances) — but file-level furniture is
+    not, and neither is anything that looks like a section footer.
+
+    Deliberately NOT a complete list of furniture: whatever this fails to recognise stays in
+    the span and the caller keeps its own positive check. The list only makes the message
+    specific; the refusal does not depend on it being complete."""
+    FURNITURE = (
+        lambda l: l.strip() == "---",
+        lambda l: l.startswith("_Caps:"),
+        lambda l: l.startswith("**See also:"),
+        # NOT `<!--`: the caller's `kept` filter already carries file-level HTML comments
+        # through the excision, so they survive. Listing them here would report a loss that
+        # does not happen — and the HTML-comment count check downstream already covers them.
+    )
+    offenders = []
+    for j in range(start + 1, end):
+        ln = lines[j]
+        if not ln.strip():
+            continue
+        if any(f(ln) for f in FURNITURE):
+            offenders.append((j + 1, ln))
+    return tuple(offenders)
 
 def main():
     ap = argparse.ArgumentParser()
@@ -85,11 +142,28 @@ def main():
     orig = open(a.file, encoding="utf-8").read()
     lines = orig.split("\n")
 
-    span, n, style = find_entry(lines, a.match)
+    span, n, style, hit_terminator = find_entry(lines, a.match)
     if span is None:
         print(f"[route-insight] {'no' if n==0 else n} matches for '{a.match}' — refusing (need exactly 1).", file=sys.stderr)
         sys.exit(2)
     start, end = span
+
+    # The scan found no terminator, so `end` is EOF by default rather than by evidence. This
+    # is the one case that produced the reported data loss, and it is the case where the
+    # honest answer is "I do not know where this entry ends". Refuse loudly instead of
+    # deleting to the end of the file: a refusal costs one manual excision, the alternative
+    # cost a caps line, a rule and a footer while printing ✓.
+    if not hit_terminator:
+        offenders = entry_span_is_clean(lines, start, end)
+        if offenders:
+            print(f"[route-insight] refusing: '{a.match}' is the last entry in its section and the span "
+                  f"to end-of-file contains {len(offenders)} line(s) that are not part of it:", file=sys.stderr)
+            for ln_no, text in offenders:
+                print(f"    line {ln_no}: {text[:90]}", file=sys.stderr)
+            print("  Excising would delete them. Fix the file (move the entry above the footer, or add a "
+                  "terminating comment) or excise by hand. File untouched.", file=sys.stderr)
+            sys.exit(3)
+
     heading = lines[start]
 
     # File-level `<!-- ... -->` trail lines can sit INSIDE a span; they belong to the file,
@@ -113,10 +187,22 @@ def main():
                     " — a file-level trail line was swallowed")
     if a.marker and a.marker not in new:
         errs.append("marker did not land")
-    # truncation guard: we only removed [start,end); everything else must be byte-identical
+    # truncation guard: we only removed [start,end); everything else must be byte-identical.
+    #
+    # ⚠️ This guard CANNOT catch a wrong `end`, and that is structural rather than an
+    # oversight: it compares `lines[end:]` against `new_lines[head:]` — using the same `end`
+    # on both sides. When `end` was wrongly EOF, both slices were empty and it passed while a
+    # footer was being deleted. A check scoped by the value under suspicion cannot test that
+    # value. So the SPAN itself is asserted separately below, in absolute terms.
     head = start + (1 if a.marker else 0) + len(kept)
     if new_lines[:start] != lines[:start] or new_lines[head:] != lines[end:]:
         errs.append("collateral change detected outside the excised span")
+    # Scope assertion — independent of `end`. Whatever was removed must be the entry's own
+    # line, blanks, or continuations; never file-level furniture.
+    span_offenders = entry_span_is_clean(lines, start, end)
+    if span_offenders:
+        errs.append("excised span contains file-level furniture: "
+                    + "; ".join(f"line {n} {t[:50]!r}" for n, t in span_offenders))
     if errs:
         print("[route-insight] VALIDATION FAILED — no change written:\n  - " + "\n  - ".join(errs), file=sys.stderr)
         sys.exit(3)

--- a/tests/pipeline-executor-status.test.sh
+++ b/tests/pipeline-executor-status.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# The Pipeline Status line must name the precondition that actually failed
+#
+# FIELD REPORT 2026-08-28. `/aios:today` printed, every morning:
+#     ⏭️ tasks: configured but credentials missing — run the setup for this source
+# The credentials were present, valid and self-refreshing. The real cause was a
+# missing `- Google Tasks list: <ID>` line in USER.md → ## Sources.
+#
+# The Tasks future is created only if THREE independent things hold (configured ·
+# list ID present · credentials on disk). The status report attributed ANY absent
+# future to credentials — three preconditions collapsed into one diagnosis, and the
+# one chosen was the most expensive to chase. The operator re-authenticated OAuth
+# five mornings in a row.
+#
+# The lesson, in the reporter's words: a message that names a WRONG cause is worse
+# than a generic one, because it directs the work. A generic message makes you look;
+# a wrong specific one makes you work.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+EXEC=hooks/pipeline-executor.py
+
+echo "── the wrong-cause message is gone ──"
+if grep -qF 'configured but credentials missing' "$EXEC"; then
+  no "the blanket 'credentials missing' message is still there" "it fires when a list ID is missing too"
+else
+  ok "no blanket 'credentials missing' attribution remains"
+fi
+
+echo "── each precondition reports itself ──"
+grep -qF 'missing list ID' "$EXEC" \
+  && ok "a missing Tasks list ID names itself" \
+  || no "a missing list ID is not named" "this is the case that cost five mornings"
+grep -qF 'credentials not found at' "$EXEC" \
+  && ok "genuinely-absent credentials still name themselves, with the path" \
+  || no "the credentials branch was lost"
+
+echo "── the residual branch does not invent a cause ──"
+# A default is a silent assertion about the case you did not enumerate. If none of
+# the known causes matched, the honest output says so rather than picking one.
+if grep -qE 'no known cause matched|prerequisites incomplete' "$EXEC"; then
+  ok "the fall-through says no known cause matched instead of naming one"
+else
+  no "the fall-through names a specific cause it did not verify" "this is the original bug, one branch down"
+fi
+
+echo "── the canary the reporter specified ──"
+# Credentials present + list ID absent must mention the list ID and NOT credentials.
+OUT=$(python3 - <<'PY'
+sources = {"configured": ["tasks"], "google_tasks_list": None}
+futures = {}
+class C:
+    def exists(self): return True
+    def __str__(self): return "/tmp/creds.json"
+creds_primary = C(); status = []
+for source, mapped in [("tasks", "tasks")]:
+    if mapped not in futures and source in sources["configured"]:
+        if source == "tasks" and not sources["google_tasks_list"]:
+            reason = "missing list ID — add `- Google Tasks list: `<ID>`` to USER.md"
+        elif creds_primary is None or not creds_primary.exists():
+            reason = "credentials not found"
+        else:
+            reason = "prerequisites incomplete"
+        status.append(f"tasks: configured but not queried — {reason}")
+print(status[0])
+PY
+)
+case "$OUT" in
+  *"list ID"*) ok "canary: the message names the list ID" ;;
+  *) no "canary: the message does not name the list ID" "$OUT" ;;
+esac
+case "$OUT" in
+  *credentials*) no "canary: the message still blames credentials" "$OUT" ;;
+  *) ok "canary: the message does NOT blame credentials" ;;
+esac
+
+echo "── and the line is documented, so it cannot be silently unset from day one ──"
+grep -qF 'Google Tasks list' SETUP.md \
+  && ok "SETUP.md tells the operator the list-ID line exists" \
+  || no "SETUP.md never mentions the list-ID line" "the source can be enabled-but-mute from day one with no signal"
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/route-insight.test.sh
+++ b/tests/route-insight.test.sh
@@ -15,7 +15,7 @@ set -uo pipefail
 TOOL="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/hooks/route-insight.py"
 PASS=0; FAIL=0
 ok(){ printf '  ok   %s\n' "$1"; PASS=$((PASS+1)); }
-no(){ printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+no(){ printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; FAIL=$((FAIL+1)); }
 
 tmp(){ mktemp "${TMPDIR:-/tmp}/ri-XXXXXX"; }
 
@@ -92,6 +92,77 @@ python3 "$TOOL" "$f" --match "entry" >/dev/null 2>&1; rc_many=$?
 if [ $rc_none -eq 2 ] && [ $rc_many -eq 2 ] && cmp -s "$f" "$f.orig"; then
   ok "5 refuses on 0 and on >1 match, file untouched"
 else no "5 refusal paths" "no-match rc=$rc_none ambiguous rc=$rc_many (both must be 2), file changed=$(cmp -s "$f" "$f.orig" && echo no || echo YES)"; fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FIELD REPORT 2026-08-28 — excising the LAST entry of a section took the file tail
+#
+# Reported with an executed repro: the caps line, the `---` and the `**See also:**`
+# footer were all removed, exit 0, `✓ excised` printed. Silent loss.
+#
+# Cause: find_entry's `end` defaulted to len(lines) and was only corrected by three
+# enumerated terminators (heading / top-level bullet / HTML comment). The last entry
+# in a list has no next, so none matched and the scan ran to EOF. The docstring's own
+# stated goal — "neighbouring file-level comments are not swallowed" — was the one
+# broken, because the design was written against neighbours with no case for the edge.
+#
+# Why the existing validator could not catch it: its truncation guard compares
+# `lines[end:]` against `new_lines[head:]` — the SAME `end` on both sides. With end
+# at EOF both slices are empty and it passes. A check scoped by the value under
+# suspicion cannot test that value.
+# ─────────────────────────────────────────────────────────────────────────────
+t=$(mktemp -d)
+cat > "$t/last.md" <<'EOF'
+## Emerging
+
+- First entry — not the one being excised
+- Second entry, the LAST bullet in this section
+
+_Caps: Emerging ≤10 (today 2), Reinforced ≤5 (today 0)._
+
+---
+
+**See also:** [[a]] · [[b]] · [[c]]
+EOF
+cp "$t/last.md" "$t/last.before"
+out=$(python3 "$TOOL" "$t/last.md" --match "Second entry" --marker "<!-- routed: test -->" 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && diff -q "$t/last.before" "$t/last.md" >/dev/null 2>&1; then
+  ok "last-in-section entry: REFUSES and leaves the file byte-identical"
+else
+  no "last-in-section entry was excised (rc=$rc) — the file tail is at risk"
+fi
+case "$out" in
+  *"_Caps:"*) ok "the refusal NAMES the lines it would have deleted" ;;
+  *) no "the refusal does not name what it protected" "a refusal you cannot act on is a wall" ;;
+esac
+
+# the ordinary path must be untouched by the fix
+cp "$t/last.before" "$t/last.md"
+python3 "$TOOL" "$t/last.md" --match "First entry" --marker "<!-- routed: test -->" >/dev/null 2>&1
+if grep -q '^\*\*See also:' "$t/last.md" && grep -q '^_Caps:' "$t/last.md" && ! grep -q 'First entry' "$t/last.md"; then
+  ok "a NON-last entry still excises cleanly, footer intact"
+else
+  no "the fix broke the ordinary excision path"
+fi
+
+# any heading level terminates — `#### ` was absent from the original list and exists
+# in the live corpus (business.md carries 10), so a bullet before one over-extended.
+cat > "$t/h4.md" <<'EOF'
+## Section
+
+- Only entry here
+
+#### A deeper heading
+
+- Belongs to the deeper heading
+EOF
+python3 "$TOOL" "$t/h4.md" --match "Only entry here" --marker "<!-- routed: test -->" >/dev/null 2>&1
+if grep -q '^#### A deeper heading' "$t/h4.md" && grep -q 'Belongs to the deeper' "$t/h4.md"; then
+  ok "an h4 heading terminates a bullet entry (the gap found while fixing the edge case)"
+else
+  no "an h4 heading does not terminate — content past it was swallowed"
+fi
+rm -rf "$t"
+
 
 printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Reported 2026-08-28 by an operator with **executed repros, proposed fixes, and a verification against HEAD `c602087`** before sending. Both verified here independently; both confirmed.

He named the shared shape better than either bug: **an incomplete enumeration whose default is an assertion instead of a doubt.**

## 1 · `pipeline-executor.py` — the status line named the wrong cause

The Tasks future is gated on **three** independent things (configured · list ID in `USER.md` · credentials on disk). The status report attributed **any** absent future to credentials, so a missing `- Google Tasks list: \`<ID>\`` line printed *"configured but credentials missing"*. **He re-authenticated OAuth five mornings in a row.**

Preconditions separated, failing one named. The fall-through says *"no known cause matched"* rather than picking one — a default naming a cause it never verified is the same bug one branch down. `SETUP.md` now documents the line and its silent-failure mode.

## 2 · `route-insight.py` — excising the last entry took the file tail

Caps line, `---` and `**See also:**` footer all removed, exit 0, `✓ excised`. Reproduced here: **10 lines → 4.**

**The fix is not a fourth terminator, and deliberately not his own preferred form either.** He proposed positive membership — cut at the first unindented line — and **flagged the contract risk himself rather than hiding it.** Measured against the seven live files carrying both bullets and a footer: **43 bullets are followed by unindented continuation prose that genuinely belongs to them** (`**Note the asymmetry:** …`, `**Category:** …`). His rule would have cut those in half. **His flag was right, and the corpus decided against his own proposal.**

Instead: when the scan finds **no** terminator — the only case that produced the loss — it refuses, names every line it would have deleted, and leaves the file byte-identical. His own stated principle: if the list of cases can be incomplete, the default has to be the one that makes noise.

**Two further gaps found while fixing it:**
- **`#### ` was never a terminator** (only `##`/`###`), and h4 exists in the live corpus (`business.md` carries 10) — so a bullet before one already over-extended. Any heading level now terminates.
- **The truncation guard could not catch a wrong `end`.** It compares `lines[end:]` against `new_lines[head:]` — the same `end` on both sides — so with `end` at EOF both slices are empty and it passed while a footer was deleted. *A check scoped by the value under suspicion cannot test that value.* The span is now asserted independently.

## Finding 3 in his report needs no change

The Spanish `"Me llamo"` greeting was **fixed and released in aios-app v0.8.7 on 2026-08-17**, with a dedicated test naming his exact case. 21/21 pass. **He is owed a reply, not a fix** — he is still running a workaround and believes it unanswered.

## Tests

`route-insight` 5 → 9 · new 7-check `pipeline-executor-status` suite · both wired into CI · **22/22 suites**.

Controls proven the way he asks for: **3 of 4** new route tests and **5 of 7** status checks go red against the old code. Also fixed `route-insight.test.sh`'s `no()` helper — an unguarded `$2` made it **crash instead of fail** under `set -u`, which is how a red suite can be mistaken for a broken one.

`hash: a1785d9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS