### PR TITLE
fix: optional close-session no-push for automated wrappers + karpathy-coding frontmatter

### DIFF
--- a/plugins/aios/commands/close-session.md
+++ b/plugins/aios/commands/close-session.md
@@ -126,9 +126,12 @@ Announce the detected mode: "Detected: **vault session** — writing to daily no
      --note "$HOME/aios/vault/01 - calendar/{YYYY-MM}/{YYYY-MM-DD}.md" \
      --before "## Close of Day" \
      -m "session: {HH:MM} {Topic}" \
-     --block-file /tmp/aios-session-block.$$.md
+     --block-file /tmp/aios-session-block.$$.md \
+     $([ "${CLAUDE_CLOSE_SESSION_NO_PUSH:-}" = "1" ] && echo --no-push)
    ```
    The helper takes a **per-file lock + merge-appends**: under the lock it re-reads the *latest* note and inserts the block before `## Close of Day` (or at the end if that marker is absent — omit `--before` then), then commits the note via `aios-commit`. So N sessions closing at once each land their block **in turn** — ordered, zero clobber, all visible immediately. (Then `rm` the temp block file.)
+
+   **`--no-push` fires when `$CLAUDE_CLOSE_SESSION_NO_PUSH=1` is set.** Set this before invoking `/close-session` from any automated wrapper (a cron, a scheduled agent) that already does its own controlled end-of-run push — a mid-run push from inside `/close-session` would otherwise race that push and land the vault in a half-committed state, out of order with it. Leave it unset for interactive use; the flag defaults to unset everywhere, so every push happens exactly as before unless an operator's own automation opts in.
 6. Update `session-insights.md` (observation buffer — not a log):
    - **Scan existing entries first:**
      - Does this session **reinforce** an Emerging insight? → move it to Reinforced with the new date

--- a/skills/aios/karpathy-coding/SKILL.md
+++ b/skills/aios/karpathy-coding/SKILL.md
@@ -1,4 +1,9 @@
-# CLAUDE.md
+---
+name: karpathy-coding
+description: Behavioral guidelines to reduce common LLM coding mistakes — think before coding, simplicity first, surgical changes, and goal-driven execution. Use when writing or editing code to avoid over-engineering, speculative abstractions, scope creep in diffs, and unverified changes.
+---
+
+# Karpathy Coding
 
 Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
 


### PR DESCRIPTION
## Summary
- `close-session.md`: setting `CLAUDE_CLOSE_SESSION_NO_PUSH=1` before invoking `/close-session` now suppresses its auto-push. Useful for any automated wrapper (a cron, a scheduled agent) that already does its own controlled end-of-run push — a mid-run push from inside `/close-session` would otherwise race that push and land the vault in a half-committed state, out of order with it. Unset (the default) behaves exactly as before, so interactive use is unaffected.
- `karpathy-coding/SKILL.md`: was missing YAML frontmatter entirely (`name`/`description`), so Claude Code registered it empty and the matcher never fired it. Added both fields so the skill actually loads and triggers.

Both fixes have been running without regressions in a private fork.

## Test plan
- [x] `close-session.md` diff verified to apply cleanly against current `main`
- [x] `karpathy-coding/SKILL.md` frontmatter matches the `name`/`description` convention used by other bundled skills