### PR TITLE
fix(close-session): the no-push opt-out reaches every push site, and is AIOS_-namespaced

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1057,6 +1057,17 @@ jobs:
         # Same finding, same cause: committed, never invoked.
         run: bash tests/route-insight.test.sh
 
+      - name: the close-session no-push opt-out reaches every push site
+        # Contributed in #59 to stop an automated wrapper's own end-of-run push racing
+        # the one inside /close-session — a real, unattended failure: aios-commit
+        # releases its lock BEFORE pushing, and a rejected push does not self-heal, it
+        # asks a human to pull/rebase. The contribution covered 1 of 3 push sites, which
+        # is worse than covering none: the wrapper's author sets the variable, believes
+        # the race is handled, and still hits it at the next site. This asserts sites and
+        # guards AGREE, so a fourth push site added later fails the build instead of
+        # silently escaping the flag.
+        run: bash tests/close-session-nopush.test.sh
+
       - name: the Pipeline Status line names the precondition that actually failed
         # FIELD REPORT 2026-08-28. Three preconditions gate the Tasks future; the status
         # report attributed ANY absent future to credentials, so a missing list-ID line in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,41 @@
 >
 > A changelog that only lists *what changed* pushes comprehension-debt onto the operator — they'd have to read a skill's source to know what it does for their day. So every entry leads with a **"What you can now do"** section: the new capabilities in **plain language, with a concrete example**, phrased as things the operator can *do* now — not a component inventory. Keep the full component list too (for the record), but lead with the practical read, and flag the load-bearing behavioral changes worth an actual read. `/aios:update` surfaces this section to the operator after applying an entry, so their own Claude session tells them what the new version unlocks. **The rule:** *translate every shipped change into a capability the operator can use — or it isn't really shipped to them, just to the repo.*
 
+## 2026-08-29 — An opt-out for automated wrappers, and a skill that was installed but unloadable
+
+`hash: ef50c60 · 4f7121b · 4682f2c`
+
+*Both fixes contributed by **José Medina** ([#59](https://github.com/The-AIOS/aios/pull/59)), running in a private fork before being offered.*
+
+### `/close-session` can stop pushing, so your cron's own push is not raced
+
+> **What this delivers.** If you run `/close-session` from an automated wrapper — a cron, a scheduled agent — that already does its own controlled end-of-run push, set **`AIOS_CLOSE_SESSION_NO_PUSH=1`** before invoking it and no push happens from inside the command. Unset (the default) behaves exactly as before, so interactive use is untouched.
+
+**What you can now do:**
+- **Stop a race that does not recover on its own.** `aios-commit` releases its lock **before** pushing — deliberately, so a slow network call never makes other sessions wait — which means two pushes genuinely race. And a rejected push does **not** self-heal: it prints *"the remote has diverged. Pull/rebase, then push"* and stops. That is exactly right for a human at a terminal and useless inside a cron, where nobody reads it and the vault sits committed-but-unpushed until someone happens to notice.
+- **Set it once and have it hold for the whole run.** The command pushes from **three** places — the note block, the observed-context commit, and Mode B's report commit — and one variable now covers all three.
+
+**Action required — none unless you automate `/close-session`.** If you do, set `AIOS_CLOSE_SESSION_NO_PUSH=1` in that wrapper and let it own the push.
+
+*Two notes on what changed between the contribution and what shipped, both recorded because the reasoning outlives the change.*
+
+*The contribution guarded **one** of the three push sites. That is worse than guarding none: the wrapper's author sets the variable, believes the race is handled, and still hits it at the next site — where the symptom no longer looks connected to the thing they configured. This is **not** a criticism of the work: the three-site structure is not visible from the region of the file being edited, which is exactly why the completion ships with a test that counts **both** sites and guards and requires them to agree. Asserting "there are three guards" would pass while a fourth unguarded site was added, and that additive case is the one nothing in review catches.*
+
+*The flag was renamed from `CLAUDE_CLOSE_SESSION_NO_PUSH` to **`AIOS_CLOSE_SESSION_NO_PUSH`**. `CLAUDE_*` is Claude Code's own namespace (`CLAUDE_CODE_SESSION_ID`, `CLAUDE_CONFIG_DIR`); framework switches are `AIOS_*` (`AIOS_UPDATE_REINVOKED`, `AIOS_STAR_ASK`). There is precedent for framework variables under `CLAUDE_`, so this is a convention choice rather than a defect — made **now**, because an environment variable becomes a contract the moment someone's automation depends on it, and nothing did yet. If you already piloted the original name, update it.*
+
+### The `karpathy-coding` skill was installed and unloadable
+
+> **What this delivers.** `skills/aios/karpathy-coding/SKILL.md` had **no YAML frontmatter at all** — no `name`, no `description` — so Claude Code registered it empty and the matcher could never fire it. Its H1 read `# CLAUDE.md`, which is the tell: it was pasted from a CLAUDE.md and never converted into a skill.
+
+**What you can now do:**
+- **Actually get the skill you already had.** It was the only one of **25** bundled `aios` skills missing frontmatter, and the symlink into `~/.claude/skills` existed the whole time — so it looked installed while being unreachable. `name` and `description` are now present and it triggers.
+
+**Action required — one, and only if you want it immediately.** The skill loads on a **restart**: a `SKILL.md` whose frontmatter changed mid-session is not re-read until the session restarts. Nothing else to do; the symlink was already in place.
+
+*The shape worth keeping from this one: **installed and working are different states, and only one of them is visible.** A registered symlink pointing at a file the loader silently rejects reports as present in every check anyone would think to run. The same class as an agent declaring a skill it never receives — no error, just quietly less capability than the inventory claims.*
+
+---
+
 ## 2026-08-29 — Four documents agreed about Stitch and all four were wrong, and an installer that reported success after doing nothing
 
 `hash: 653aeac`

--- a/plugins/aios/commands/close-session.md
+++ b/plugins/aios/commands/close-session.md
@@ -127,11 +127,17 @@ Announce the detected mode: "Detected: **vault session** — writing to daily no
      --before "## Close of Day" \
      -m "session: {HH:MM} {Topic}" \
      --block-file /tmp/aios-session-block.$$.md \
-     $([ "${CLAUDE_CLOSE_SESSION_NO_PUSH:-}" = "1" ] && echo --no-push)
+     $([ "${AIOS_CLOSE_SESSION_NO_PUSH:-}" = "1" ] && echo --no-push)
    ```
    The helper takes a **per-file lock + merge-appends**: under the lock it re-reads the *latest* note and inserts the block before `## Close of Day` (or at the end if that marker is absent — omit `--before` then), then commits the note via `aios-commit`. So N sessions closing at once each land their block **in turn** — ordered, zero clobber, all visible immediately. (Then `rm` the temp block file.)
 
-   **`--no-push` fires when `$CLAUDE_CLOSE_SESSION_NO_PUSH=1` is set.** Set this before invoking `/close-session` from any automated wrapper (a cron, a scheduled agent) that already does its own controlled end-of-run push — a mid-run push from inside `/close-session` would otherwise race that push and land the vault in a half-committed state, out of order with it. Leave it unset for interactive use; the flag defaults to unset everywhere, so every push happens exactly as before unless an operator's own automation opts in.
+   > ### `AIOS_CLOSE_SESSION_NO_PUSH=1` — set it once, it covers EVERY push this command makes
+   >
+   > Set this before invoking `/close-session` from any automated wrapper (a cron, a scheduled agent) that already does its own controlled end-of-run push. Leave it unset for interactive use: the flag defaults to unset everywhere, so every push happens exactly as before unless an operator's own automation opts in.
+   >
+   > **Why it is worth a flag at all.** `aios-commit` releases its lock *before* pushing (deliberately — a slow network call must not make peers wait), so two pushes genuinely race. And a rejected push does **not** self-heal: it prints *"the remote has diverged. Pull/rebase, then push"* and stops, which is correct for a human at a terminal and useless inside a cron, where nobody reads it. The vault then sits committed-but-unpushed until someone notices.
+   >
+   > **This command pushes from THREE places, and the flag must reach all three** — step 5's `aios-note-append`, step 10's `aios-commit` (Mode A), and Mode B's report commit. Covering only one is worse than covering none: the wrapper's author sets the variable, believes the race is handled, and still hits it at the next site. The three-site count is asserted by `tests/close-session-nopush.test.sh`, so a fourth push site added later fails the build rather than silently escaping the flag.
 6. Update `session-insights.md` (observation buffer — not a log):
    - **Scan existing entries first:**
      - Does this session **reinforce** an Emerging insight? → move it to Reinforced with the new date
@@ -177,9 +183,11 @@ Announce the detected mode: "Detected: **vault session** — writing to daily no
 
 10. **Commit any observed-context you touched via `aios-commit`** (the note block was already committed by `aios-note-append` in step 5). **NEVER `git add -A`** — in a concurrently-written vault it sweeps other sessions' + the human's in-flight files into your commit (scrambled attribution). Commit only the paths you changed:
    ```bash
-   ~/aios/hooks/aios-commit -m "session: {date} {topic}" -- \
+   ~/aios/hooks/aios-commit -m "session: {date} {topic}" \
+     $([ "${AIOS_CLOSE_SESSION_NO_PUSH:-}" = "1" ] && echo --no-push) -- \
      "vault/00 - notes/context/observed/session-insights.md" {any other files you edited}
    ```
+   **The `--no-push` opt-out applies here too** — this is the command's second push site, and a wrapper that set the flag for step 5 expects it to hold for the whole run (see the box at step 5).
    `aios-commit` stages ONLY the given paths via a throwaway index (working tree untouched), self-scans for secrets, and pushes with defer-on-offline. It is the one sanctioned commit path — it replaces `git add -A` everywhere.
 
 ### Session block format (Mode A)
@@ -245,7 +253,7 @@ If yes → write the pages (with `[[wiki-links]]`, proper frontmatter, source at
 1. Determine the project name from the repo (read `package.json` name, or `CLAUDE.md` title, or folder name)
 2. **Date rule:** If the current time is between midnight and 7:00 AM, ask the user which date the report belongs to — late-night sessions usually belong to the previous day. After 7:00 AM, use today's date.
 3. Infer session content from the conversation
-4. Write the report to **`~/aios/.claude/session-report-{YYYY-MM-DD}-{project}-{session}.md`** — `{project}` is a filesystem-safe slug of the repo name (from step 1), `{session}` is `$CLAUDE_AGENT_NAME` (fallback: a short session-id or pid if unset). **Both suffixes are load-bearing at a shared dir:** `{project}` keeps two *different* repos' sessions from colliding in the one harvest dir, and `{session}` keeps a Close-all broadcast's N workers in the *same* repo from clobbering each other. Write it to `~/aios/.claude/` **even though the session runs in another repo** — that's the whole point: one dir close-day always scans, no registration needed. (`~/aios/.claude/` is fully gitignored, so the report never leaks into any repo's git.) Then commit your session's own scoped work via `~/aios/hooks/aios-commit -m "..." -- <paths>` (never `git add -A`).
+4. Write the report to **`~/aios/.claude/session-report-{YYYY-MM-DD}-{project}-{session}.md`** — `{project}` is a filesystem-safe slug of the repo name (from step 1), `{session}` is `$CLAUDE_AGENT_NAME` (fallback: a short session-id or pid if unset). **Both suffixes are load-bearing at a shared dir:** `{project}` keeps two *different* repos' sessions from colliding in the one harvest dir, and `{session}` keeps a Close-all broadcast's N workers in the *same* repo from clobbering each other. Write it to `~/aios/.claude/` **even though the session runs in another repo** — that's the whole point: one dir close-day always scans, no registration needed. (`~/aios/.claude/` is fully gitignored, so the report never leaks into any repo's git.) Then commit your session's own scoped work via `~/aios/hooks/aios-commit -m "..." $([ "${AIOS_CLOSE_SESSION_NO_PUSH:-}" = "1" ] && echo --no-push) -- <paths>` (never `git add -A`). **The `--no-push` opt-out applies here too** — Mode B is the third and last push site, and an automated wrapper is *more* likely to run in this mode than in Mode A, not less.
 5. Confirm: "Session report written to `~/aios/.claude/session-report-{date}-{project}-{session}.md`. `/close-day` will pick it up tonight."
 
 ### Session report format (Mode B)

--- a/tests/close-session-nopush.test.sh
+++ b/tests/close-session-nopush.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# AIOS_CLOSE_SESSION_NO_PUSH must reach EVERY push /close-session makes
+#
+# Contributed 2026-08-29 (PR #59) to stop an automated wrapper's own end-of-run
+# push racing the one inside /close-session. The problem is real and unattended:
+# aios-commit releases its lock BEFORE pushing (deliberately — a slow network call
+# must not make peers wait), so two pushes race; and a rejected push does NOT
+# self-heal, it prints "the remote has diverged. Pull/rebase, then push" and stops.
+# Correct for a human at a terminal, useless inside a cron.
+#
+# The contribution covered ONE of three push sites. That is worse than covering
+# none: the wrapper's author sets the variable, believes the race is handled, and
+# still hits it at the next site — with a symptom that now looks unrelated to the
+# thing they configured. This suite exists so the count cannot drift again.
+#
+# The failure mode it guards is ADDITIVE: someone adds a fourth push site later,
+# with no reason to know the flag exists. Nothing in review would catch that. A
+# count assertion does.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+F=plugins/aios/commands/close-session.md
+
+echo "── every push site is guarded ──"
+# A push site = an invocation of a helper that pushes. Count them, then count the
+# guards, and require the two to agree. Counting BOTH sides is the point: asserting
+# only "there are 3 guards" would pass while a 4th unguarded site was added.
+# Exclude the `allowed-tools:` frontmatter line: it DECLARES the helpers as permitted
+# tools, it does not invoke them. Counting it made this assertion report 4 sites for 3
+# guards and fail on a file that was already correct — a guard that cannot tell a
+# declaration from a call fires on every honest edit, and then gets muted.
+SITES=$(grep -E '~/aios/hooks/aios-(commit|note-append)' "$F" | grep -cv '^allowed-tools:')
+GUARDS=$(grep -c 'AIOS_CLOSE_SESSION_NO_PUSH:-' "$F")
+printf '     push-helper invocations: %s · flag guards: %s\n' "$SITES" "$GUARDS"
+if [ "$SITES" -eq "$GUARDS" ]; then
+  ok "every push-helper invocation carries the opt-out ($GUARDS/$SITES)"
+else
+  no "push sites and guards disagree ($GUARDS guards for $SITES sites)" \
+     "an unguarded site means a wrapper that set the flag still races there — and the symptom will look unrelated to what they configured"
+fi
+
+echo "── the three known sites specifically ──"
+grep -qE 'aios-note-append' "$F" && grep -A6 'aios-note-append' "$F" | grep -q 'AIOS_CLOSE_SESSION_NO_PUSH' \
+  && ok "site 1: step 5 aios-note-append (Mode A note block)" \
+  || no "site 1 unguarded" "the block commit pushes"
+grep -A3 'aios-commit -m "session: {date} {topic}"' "$F" | grep -q 'AIOS_CLOSE_SESSION_NO_PUSH' \
+  && ok "site 2: step 10 aios-commit (Mode A observed context)" \
+  || no "site 2 unguarded" "this is the one the original contribution missed"
+grep -q 'own scoped work via .*AIOS_CLOSE_SESSION_NO_PUSH' "$F" \
+  && ok "site 3: Mode B report commit" \
+  || no "site 3 unguarded" "an automated wrapper is MORE likely to be in Mode B than Mode A"
+
+echo "── the flag lives in the framework's namespace ──"
+# CLAUDE_* is Claude Code's own namespace (CLAUDE_CODE_SESSION_ID, CLAUDE_CONFIG_DIR).
+# Framework-owned switches are AIOS_* (AIOS_UPDATE_REINVOKED, AIOS_STAR_ASK, AIOS_HUMAN).
+# Renamed while nothing depended on it yet — an env var is a contract the moment it ships.
+grep -q 'CLAUDE_CLOSE_SESSION_NO_PUSH' "$F" \
+  && no "the flag is still in the CLAUDE_* namespace" "framework switches are AIOS_*" \
+  || ok "the flag is AIOS_-prefixed, not CLAUDE_-prefixed"
+
+echo "── the default is unchanged behaviour ──"
+# Unset must add NO argument at all — not an empty string, which would reach the
+# helper as a stray empty pathspec.
+for sh in bash zsh sh; do
+  command -v "$sh" >/dev/null 2>&1 || continue
+  n=$("$sh" -c 'set -- x $([ "${AIOS_CLOSE_SESSION_NO_PUSH:-}" = "1" ] && echo --no-push); echo $#')
+  y=$("$sh" -c 'AIOS_CLOSE_SESSION_NO_PUSH=1; set -- x $([ "${AIOS_CLOSE_SESSION_NO_PUSH:-}" = "1" ] && echo --no-push); echo $#')
+  if [ "$n" = "1" ] && [ "$y" = "2" ]; then
+    ok "$sh: unset adds nothing, =1 adds exactly --no-push"
+  else
+    no "$sh: expansion is wrong (unset=$n args, set=$y args)" "an empty unquoted expansion would become a stray empty pathspec"
+  fi
+done
+
+echo "── the helpers actually accept the flag ──"
+grep -q -- '--no-push' hooks/aios-note-append \
+  && ok "aios-note-append accepts --no-push" \
+  || no "aios-note-append does not accept --no-push" "the guard would pass an unknown flag"
+grep -q -- '--no-push' hooks/aios-commit \
+  && ok "aios-commit accepts --no-push" \
+  || no "aios-commit does not accept --no-push"
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Completes **#59** (@medinagarciajose), merged just before this. The contribution found a **real, unattended** failure and built the right mechanism; this finishes the coverage and standardises the name while nothing depends on it yet.

## The problem is worse than the PR argued — verified

`aios-commit` **releases its lock before pushing** (`hooks/aios-commit:336`, deliberately: a slow network call must not make peers wait), so two pushes genuinely race. And a rejected push does **not** self-heal — it prints *"the remote has diverged. Pull/rebase, then push"* and stops. Exactly right for a human at a terminal; useless inside a cron, where nobody reads it and the vault sits committed-but-unpushed.

## 1 · Three push sites, one was guarded

| site | what | before | now |
|---|---|---|---|
| step 5 | `aios-note-append` (Mode A note block) | ✅ | ✅ |
| step 10 | `aios-commit` (Mode A observed context) | ❌ | ✅ |
| Mode B | `aios-commit` (report commit) | ❌ | ✅ |

**Covering one is worse than covering none:** the wrapper's author sets the variable, believes the race is handled, and still hits it at the next site — where the symptom no longer looks connected to what they configured.

**Not a criticism of the contribution.** The three-site structure isn't visible from the region of the file being edited. That's precisely why this ships with a test rather than a correction.

## 2 · `CLAUDE_` → `AIOS_`

`CLAUDE_*` is Claude Code's own namespace (`CLAUDE_CODE_SESSION_ID`, `CLAUDE_CONFIG_DIR`); framework switches are `AIOS_*` (`AIOS_UPDATE_REINVOKED`, `AIOS_STAR_ASK`, `AIOS_HUMAN`). There **is** precedent for framework vars under `CLAUDE_` (`CLAUDE_AUTOSWAP_RESPAWN`), so this is a convention choice, not a defect — done **now** because an env var becomes a contract the moment someone's automation depends on it, and nothing does yet.

## 3 · The test counts *both* sides

`tests/close-session-nopush.test.sh` asserts push sites and guards **agree**. Asserting *"there are 3 guards"* would pass while a 4th unguarded site was added — and that additive case is the one nothing in review catches, because whoever adds it has no reason to know the flag exists.

Expansion verified in **bash, zsh and sh**: unset adds *no argument at all*, not an empty one that would reach the helper as a stray empty pathspec. The contributor's expansion form was correct as written and is unchanged.

**Its own first version counted the `allowed-tools:` frontmatter line as a push site** — 4 sites for 3 guards, failing a file that was already correct. A guard that cannot tell a declaration from a call fires on every honest edit and then gets muted. Excluded, with the reason recorded in the test.

**24/24 suites.** Control proven: removing one guard fails both the count and the specific-site assertion.

`hash: 4682f2c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS