### PR TITLE
fix(pipeline-executor): the first account block wins, not the last

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -111,6 +111,19 @@ jobs:
           bash tests/source-detector.test.sh
           echo "OK: template prose does not vote on the operator's configuration"
 
+      - name: The first account block wins; a later one cannot overwrite it
+        run: |
+          set -e
+          # parse_sources() walked every line with no notion of which block it was in, so
+          # the LAST match won. "### Google accounts" ships a *Primary:* block and
+          # operators add further ones (a destination-only address, an old account), any
+          # of which silently replaced an address already read correctly. Every
+          # credentials path is built from that value, so /today reported Calendar and
+          # Tasks as "configured but credentials missing" while the OAuth token was valid.
+          # Tests 1, 1b and 2 fail against the pre-fix parser, so this cannot pass vacuously.
+          bash tests/pipeline-executor-config.test.sh
+          echo "OK: a later account block cannot overwrite the primary"
+
       - name: Changelog scan handles multi-hash entries; layer pathspec is an array
         run: |
           set -e

--- a/hooks/pipeline-executor.py
+++ b/hooks/pipeline-executor.py
@@ -237,6 +237,28 @@ def parse_sources():
     if "### Dev projects" in content:
         config["configured"].add("dev-projects")
 
+    # FIRST operator line wins for these identity fields, not the last one.
+    #
+    # These four are single-valued, but the scan below is a plain walk over every line
+    # with no notion of which block it is in — so before this guard the LAST match won.
+    # The template ships "### Google accounts" as a *Primary:* block followed by an
+    # optional second block, and operators routinely add a further one: a
+    # destination-only address, an old account, one explicitly annotated as not
+    # connected via MCP. Any of those that names its address as "- Google email: `…`"
+    # silently overwrote the primary that had already been read correctly.
+    #
+    # The consequence is invisible where it happens and misleading where it surfaces:
+    # every downstream credentials lookup builds its path from this value
+    # (GOOGLE_CREDS_DIR_PRIMARY / f"{email}.json"), so it resolves to a file that does
+    # not exist and /today reports Calendar and Tasks as "configured but credentials
+    # missing" — while the primary account's OAuth token is valid the whole time. The
+    # operator is sent to re-authenticate a connector that was never broken.
+    #
+    # First-wins rather than a block sentinel on purpose: keying on a literal label
+    # ("*Secondary:*") only covers the labels we thought to enumerate, and the second
+    # block is operator-written prose that can say anything. Ordering is the one thing
+    # the template does guarantee — the primary account is declared first.
+    _scalar_parsed = set()
     for line in content.split("\n"):
         for pattern, key in [
             (r'- Google Tasks list: `(.+?)`', "google_tasks_list"),
@@ -244,9 +266,12 @@ def parse_sources():
             (r'- Google email \(Personal\): `(.+?)`', "google_email_personal"),
             (r'- Timezone: `(.+?)`', "timezone"),
         ]:
+            if key in _scalar_parsed:
+                continue
             m = re.match(pattern, line)
             if m:
                 config[key] = m.group(1)
+                _scalar_parsed.add(key)
 
         # Parse channels to monitor
         m = re.match(r'- \*\*Channels to monitor:\*\* (.+)', line)

--- a/tests/pipeline-executor-config.test.sh
+++ b/tests/pipeline-executor-config.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Regression suite for USER.md config-value parsing (hooks/pipeline-executor.py →
+# parse_sources()).
+#
+# Sibling of source-detector.test.sh, which covers whether a source is ON. This file
+# covers the VALUES parsed once it is on — the account addresses, tasks list and
+# timezone that every downstream lookup is built from.
+#
+# TEST 1 IS THE CANARY: a USER.md whose "### Google accounts" carries a second block
+# naming another address must still report the PRIMARY one. It fails against the pre-fix
+# code, which walked every line and let the LAST match win — so a second block silently
+# replaced an address that had already been read correctly, and every credentials path
+# derived from it (GOOGLE_CREDS_DIR_PRIMARY / f"{email}.json") pointed at a file that
+# does not exist. /today then reported Calendar and Tasks as "configured but credentials
+# missing" while the primary account's OAuth token was valid throughout.
+
+set -u
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+have(){ [ "$1" = "$2" ] && ok "$3" || { no "$3"; printf '       expected %s, got %s\n' "$2" "$1"; }; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EXEC="$ROOT/hooks/pipeline-executor.py"
+[ -f "$EXEC" ] || { echo "cannot find hooks/pipeline-executor.py"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+printf 'USER.md config-value parsing\n'
+
+# Load the SHIPPED module and point it at a fixture USER.md, so the test exercises the
+# real parse_sources() rather than a copy that can drift away from it.
+field(){ # $1 = USER.md content, $2 = config key  →  prints the parsed value
+  printf '%s' "$1" > "$TMP/USER.md"
+  python3 - "$EXEC" "$TMP/USER.md" "$2" <<'PY'
+import importlib.util, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("pipeline_executor", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+mod.SOURCES_PATH = Path(sys.argv[2])
+print(mod.parse_sources()[sys.argv[3]])
+PY
+}
+
+# ---------------------------------------------------------------------------
+# TEST 1 — THE CANARY. A second account block must not overwrite the primary.
+# ---------------------------------------------------------------------------
+TWO_BLOCKS='## Sources
+
+### Google accounts
+
+*Primary:*
+- Google email: `primary@example.com`
+- Google Tasks list: `list-primary`
+
+*Secondary:*
+- Google email: `secondary@example.com`
+- Google Tasks list: `list-secondary`
+'
+have "$(field "$TWO_BLOCKS" google_email_primary)" "primary@example.com" \
+  "1. canary: a second block does not overwrite the primary email"
+have "$(field "$TWO_BLOCKS" google_tasks_list)" "list-primary" \
+  "1b. canary: nor the primary tasks list"
+
+# ---------------------------------------------------------------------------
+# TEST 2 — label-agnostic. The guard must not depend on the word "Secondary".
+# ---------------------------------------------------------------------------
+ODD_LABEL='## Sources
+
+### Google accounts
+
+- Google email: `primary@example.com`
+
+*Old account (not connected via MCP):*
+- Google email: `retired@example.com`
+'
+have "$(field "$ODD_LABEL" google_email_primary)" "primary@example.com" \
+  "2. any later block loses, whatever the operator called it"
+
+# ---------------------------------------------------------------------------
+# TEST 3 — no regression on the single-block case the template ships.
+# ---------------------------------------------------------------------------
+ONE_BLOCK='## Sources
+
+### General
+- Timezone: `America/Mexico_City`
+
+### Google accounts
+
+*Primary:*
+- Google email: `only@example.com`
+- Google Tasks list: `only-list`
+
+*Personal (optional):*
+- Google email (Personal): `personal@example.com`
+'
+have "$(field "$ONE_BLOCK" google_email_primary)" "only@example.com" "3. single block still parses"
+have "$(field "$ONE_BLOCK" google_tasks_list)"    "only-list"         "3b. tasks list still parses"
+have "$(field "$ONE_BLOCK" timezone)"             "America/Mexico_City" "3c. timezone still parses"
+
+# ---------------------------------------------------------------------------
+# TEST 4 — the personal address has its own key and is unaffected by the guard.
+# ---------------------------------------------------------------------------
+have "$(field "$ONE_BLOCK" google_email_personal)" "personal@example.com" \
+  "4. the (Personal) line still fills its own field"
+
+# A second block naming a plain address must not leak into the personal field either.
+have "$(field "$TWO_BLOCKS" google_email_personal)" "None" \
+  "4b. a second plain address does not become the personal account"
+
+# ---------------------------------------------------------------------------
+# TEST 5 — the shipped template's EXAMPLE-ONLY lines declare nothing.
+# ---------------------------------------------------------------------------
+TEMPLATE='## Sources
+
+### Google accounts
+
+*EXAMPLE ONLY (Claude: ignore these) — replace with yours:*
+
+*Primary:*
+- *Google email: `you@company.com`*
+- *Google Tasks list: `your-list-id`*
+'
+have "$(field "$TEMPLATE" google_email_primary)" "None" \
+  "5. a template-only USER.md parses no address"
+
+# ---------------------------------------------------------------------------
+# TEST 6 — a missing USER.md still returns defaults rather than raising.
+# ---------------------------------------------------------------------------
+MISSING="$(python3 - "$EXEC" "$TMP/absent-USER.md" 2>/dev/null <<'PY'
+import importlib.util, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("pipeline_executor", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+mod.SOURCES_PATH = Path(sys.argv[2])
+print(mod.parse_sources()["timezone"])
+PY
+)"
+have "$MISSING" "UTC" "6. a missing USER.md falls back to the UTC default"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What breaks

`parse_sources()` walks every line of `USER.md` with no notion of which block it is in. For the four single-valued identity fields, the **last** match wins:

```python
for line in content.split("\n"):
    for pattern, key in [
        (r'- Google Tasks list: `(.+?)`', "google_tasks_list"),
        (r'- Google email: `(.+?)`',      "google_email_primary"),
        ...
    ]:
        m = re.match(pattern, line)
        if m:
            config[key] = m.group(1)     # ← overwrites a value already read correctly
```

`### Google accounts` ships as a `*Primary:*` block, and operators routinely add a further one — a destination-only address, a retired account, one explicitly annotated as *not connected via MCP*. Any of those that names its address as `- Google email: \`…\`` silently replaces the primary.

## Why it is expensive

The failure is invisible where it happens and misleading where it surfaces. Every credentials lookup builds its path from this value (`GOOGLE_CREDS_DIR_PRIMARY / f"{email}.json"`), so it resolves to a file that does not exist and `/today` reports:

```
⏭️ tasks: configured but credentials missing — run the setup for this source
```

…while the primary account's OAuth token is valid the entire time. The operator is sent to re-authenticate a connector that was never broken.

That is the **same user-visible line** `tests/pipeline-executor-status.test.sh` was written for ("The operator re-authenticated OAuth five mornings in a row"), reached by a different cause. That fix made the status line name the right precondition; this one removes another way of reaching the wrong state in the first place.

## The fix

First-wins for the four scalar fields — once a key is parsed, a later line cannot replace it.

**Why not a block sentinel.** The obvious fix is to track `*Secondary:*` and skip inside it. That only covers the labels we thought to enumerate, and the second block is operator-written prose that can say anything (`*Old account:*`, `*Not connected:*`, `*Billing only:*`). Ordering is the one thing the template actually guarantees: the primary account is declared first. So the guard is label-agnostic — test 2 covers a block that never says "Secondary".

The `*EXAMPLE ONLY*` lines the template ships are italic (`- *Google email: …*`), so `re.match` never matched them and first-wins cannot hand the example the win. Test 5 pins that.

## Evidence

`tests/pipeline-executor-config.test.sh` loads the **shipped** module and points `SOURCES_PATH` at fixture files, so it exercises `parse_sources()` itself rather than a copy that can drift — the same principle as `source-detector.test.sh`, by import rather than regex extraction, since these values come from the function as a whole.

Against the pre-fix parser:

```
  FAIL 1. canary: a second block does not overwrite the primary email
       expected primary@example.com, got secondary@example.com
  FAIL 1b. canary: nor the primary tasks list
       expected list-primary, got list-secondary
  FAIL 2. any later block loses, whatever the operator called it
       expected primary@example.com, got retired@example.com
7 passed, 3 failed
```

After:

```
10 passed, 0 failed
```

The canary fails against `main`, so the suite cannot pass vacuously. Wired into `validate.yml` next to the source-detector step; the "every `tests/*.sh` is referenced by a workflow" guard passes.

Run live in a real vault before proposing: the value was being overwritten there, and `/today` recovered its Calendar and Tasks futures once the parse was correct.

## Two upstream questions

1. **Should the value loop also route through `_operator_lines()`?** `_mentions_enabled` already does, and the value loop not doing so is an inconsistency. I left it out deliberately — none of these four patterns matches a template line today, so it fixes no currently-reachable class and would widen the diff speculatively. It is defence in depth against a future template that writes a non-italic example. Happy to add it if you want the two scans symmetrical.

2. **No `CHANGELOG.md` entry in this PR.** The checklist asks for one, but every `hash:` must resolve in canonical git and a contributor cannot know the merge hash — and the recent practice (#59) is that the entry lands as a separate maintainer commit afterwards. Say the word and I will add one in whatever form you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhepP9P5QWkS7qGayN9XjN
