### PR TITLE
docs(changelog): fill the 2026-09-04 entry hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 ## 2026-09-04 — Four ladders: which writing tells to keep, which Claude to spend, how contained you are, and what to build first
 
-`hash: {HASH}`
+`hash: 25d4a9f`
 
 > **The shape of the day.** Four things shipped that are all the same move: replacing a judgement call you were making by feel with **a rung you can locate yourself on**. Which AI-writing tells to keep. Which Claude model to spend. How contained your machine actually is. What to build first in a product. Each one used to be answered by instinct; each now has a ladder and, where it is measurable, a script that measures it.
 >


### PR DESCRIPTION
The consolidated `2026-09-04` entry shipped with a `{HASH}` placeholder.

`/aios:update` reads that field to show an operator **only what is new since their stored hash**, so a placeholder there is a real defect rather than cosmetic — it matches no commit, and the entry could be shown or skipped wrongly.

Filled with `25d4a9f` (the merge of #69, the last commit in the day's work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS