### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "aios",
-      "displayName": "AIOS — Daily Ritual & Strategic OS",
-      "version": "0.5.0",
-      "description": "AIOS framework commands — daily ritual, strategic reviews, insight mining, accountability, multi-company mounting",
+      "displayName": "AIOS \u2014 Daily Ritual & Strategic OS",
+      "version": "0.6.0",
+      "description": "AIOS framework commands \u2014 daily ritual, strategic reviews, insight mining, accountability, multi-company mounting",
       "author": {
         "name": "Chuy Cepeda",
         "email": "chuy@sovra.io"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 >
 > Entries here are **date-keyed**. Releases are **tagged in git** with full notes, and published as GitHub Releases. A release contains every entry dated up to and including its tag date, back to the previous release:
 >
-> - **Unreleased** — entries dated after `2026-08-12`
+> - **Unreleased** — entries dated after `2026-09-04`
+> - **[v0.6.0](https://github.com/The-AIOS/aios/releases/tag/v0.6.0)** — tagged `2026-09-04` — covers `2026-08-13` → `2026-09-04`
 > - **[v0.5.0](https://github.com/The-AIOS/aios/releases/tag/v0.5.0)** — tagged `2026-08-12` — covers `2026-07-26` → `2026-08-12`
 > - **[v0.4.0](https://github.com/The-AIOS/aios/releases/tag/v0.4.0)** — tagged `2026-07-25` — covers `2026-05-26` → `2026-07-25`
 > - **[v0.2.0](https://github.com/The-AIOS/aios/releases/tag/v0.2.0)** — tagged `2026-05-25` — covers `2026-05-24` → `2026-05-25`

--- a/plugins/aios/.claude-plugin/plugin.json
+++ b/plugins/aios/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aios",
-  "version": "0.5.0",
-  "description": "AIOS framework commands — daily ritual, strategic reviews, insight mining, accountability, multi-company mounting",
+  "version": "0.6.0",
+  "description": "AIOS framework commands \u2014 daily ritual, strategic reviews, insight mining, accountability, multi-company mounting",
   "author": {
     "name": "Chuy Cepeda",
     "email": "chuy@sovra.io"


### PR DESCRIPTION
Ten CHANGELOG entries since `v0.5.0` (2026-08-12).

**Minor bump** — new capabilities, nothing removed, and **every existing flag resolves to what it always did** (`--tier mechanical` and `--tier judgment` are byte-identical).

- `plugins/aios/.claude-plugin/plugin.json` → `0.6.0`
- CHANGELOG releases table gains the `v0.6.0` row covering `2026-08-13` → `2026-09-04`

Tag and GitHub Release follow this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS