### PR TITLE
fix(changelog): the 2026-08-29 entry lost its hash line and inherited another entry's body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,26 +180,9 @@ A skill carrying the **order** a product gets built in, and the defaults that ar
 
 ## 2026-08-29 — An opt-out for automated wrappers, and a skill that was installed but unloadable
 
-> **What this delivers.** `FORTRESS.md` described a two-machine build costing about $600 and a weekend, and it was the **only** containment guidance the framework had — so the honest answer to *"how safe is my setup?"* was either *"buy a Mac mini"* or nothing. It now opens with a **six-rung ladder** you are already standing on, carries a **probe block** any session can run to tell you which rung, and finally documents the **agent bus** — the mechanism by which work actually crosses between machines.
+`hash: ef50c60 · 4f7121b · 4682f2c`
 
-- **Rung 0 — what you already have.** Vault local plus a private repo you own, MCP tokens on your own disk and revocable by deleting a folder, no telemetry, Bash sandboxed by default. A real rung, not a placeholder.
-- **Rung 1 — know what leaves.** An hour, nothing to install. *You cannot contain what you have not enumerated*, and this is the rung people skip because it produces no artifact.
-- **Rung 2 — scope what an agent can touch.** Permissions set deliberately · every API key out of your shell rc into `~/.config/aios-secrets/` · git hooks installed so a credential cannot be committed by accident. **This is the rung that pays.**
-- **Rung 3 — separate the risky work.** Worktrees; a second OS account for anything you would not want reading your keychain.
-- **Rung 4 — a cheap always-on box.** ~€5-10/month. The rung most people skip straight past and usually the right one: it buys the property that actually matters — *something that stays running when the laptop closes* — without hardware on your desk. Declare it rather than hand-configure it, so it is reproducible instead of a pet.
-- **Rung 5 — the two-machine fortress.** The rest of the document, unchanged.
-
-**The part worth reading even if you never climb:** most of the real risk reduction is **rungs 1 and 2, and neither costs money.** A second machine contains the blast radius of an agent that misbehaves; it does nothing about a key exported in a shell rc or a permission set nobody ever scoped. Buying hardware first is the satisfying move and the wrong order. The doc names the rung by **what is true, not what is aspired to** — an operator with a two-machine fortress and a key in `~/.zshrc` is on rung 1, because containment is the weakest link and not the priciest component.
-
-**Ask a session *"which containment rung am I on?"*** and it runs the doc's probe block. `/aios:housekeeping` re-checks on its normal cadence as **Bucket 28** — read-only, reporting *regressions* rather than a score, because containment degrades quietly: a key exported during a debugging session and never moved back, a hook that stopped being installed after a machine rebuild.
-
-**Five probes were wrong on a live machine, every one toward a *false reading*** — the direction that matters when the output is a safety claim. `command -v tailscale` misses a **GUI install** and reported *absent* on a machine that reaches its fortress over Tailscale daily. `ls ~/.config/aios-secrets/*.env` is **fatal under zsh**, which aborts on an unmatched glob *before* `ls` runs, so it died on exactly the machine it exists to describe. An unguarded call to the model rail printed a traceback on a vault that had not pulled it yet. `git worktree list` always prints the main tree, so a raw count of `1` marked a rung satisfied for everybody. And `pfctl` without sudo prints nothing — *not-readable*, never *no firewall*. All five are pinned by tests with controls.
-
-**And the agent bus is finally in the document.** Six defensive layers described the walls; nothing described the door. Agents coordinate across machines by **writing files** — `spawn`, `send` and `kill` are each a JSON file dropped into `~/.aios/spawn-inbox/`, fulfilled natively by whatever surface runs on the far machine. It is **pull-based**: the receiving machine opens no port and runs no listener, so it passes *through* the firewall posture rather than against it, and there is no broker to fail. The transport being a file makes the substrate pluggable by construction. **The design invariant, stated so it survives future edits: zero inbound surface** — if a design ever needs a listening port on the agent host, find another way. The section also says why a file bus rather than the built-in cross-session relay (no cloud transit, no plan gate, substrate-pluggable, no inbound anything), and states plainly what is missing: **a request file carries no authentication and no requester identity, so do not share a spawn-inbox** until requests are signed and verified.
-
-**Action required — none.** No new command: the ladder is documentation and the periodic check is a housekeeping bucket, which keeps the surface count flat. Running the probe block once is worth ten minutes.
-
-*This also closes a dangling reference: the model-routing doc shipped earlier today points at "the containment ladder" in `FORTRESS.md`, which did not yet contain one.*
+*Both fixes contributed by **José Medina** ([#59](https://github.com/The-AIOS/aios/pull/59)), running in a private fork before being offered.*
 
 ### `/close-session` can stop pushing, so your cron's own push is not raced
 

--- a/tests/update-changelog-scan.test.sh
+++ b/tests/update-changelog-scan.test.sh
@@ -102,5 +102,54 @@ else
   printf '       assertions (7-9) are the portable guard.\n'
 fi
 
+# ── every dated entry must carry a hash line ────────────────────────────────
+# /aios:update decides whether an entry is NEW by testing each of its hashes
+# against the operator's stored hash. An entry with NO hash field cannot be
+# tested at all — the scan degrades to matching by date + title, and an entry
+# that silently fails to register as new means its "Action required" is never
+# executed on any operator's machine. Under-reporting is the one failure a
+# changelog cannot afford.
+#
+# This fired for real on 2026-09-04: a rebase conflict resolution grafted one
+# entry's body onto another entry's header, displacing that entry's hash line.
+# Nothing failed, nothing looked wrong, and the entry became untestable. There
+# was no check for this — the guard is the fix.
+NOHASH=$(python3 - <<'PY'
+import re
+t = open('CHANGELOG.md', encoding='utf-8').read()
+bad = [m.group(1) for m in re.finditer(r'^## (\d{4}-\d{2}-\d{2}) — .+$', t, re.M)
+       if not re.search(r'`hash: [^`]+`', t[m.end():m.end()+400])]
+print(" ".join(bad))
+PY
+)
+if [ -z "$NOHASH" ]; then
+  PASS=$((PASS+1)); printf '  ok   12. every dated CHANGELOG entry carries a hash line\n'
+else
+  FAIL=$((FAIL+1)); printf '  FAIL 12. CHANGELOG entries with NO hash line: %s\n' "$NOHASH"
+  printf '       /aios:update cannot test these for sync state; their action items\n'
+  printf '       would never fire on an operator machine.\n'
+fi
+
+# Control: the check must be able to SEE a missing hash, or assertion 12 is
+# vacuous. Takes the fixture path as an ARGUMENT rather than cd-ing — a `cd`
+# inside a command substitution left one python invocation resolving the
+# relative filename in the wrong directory, which printed a traceback while the
+# assertion still passed. A test that emits a traceback reads as broken.
+CTRL_DIR=$(mktemp -d); printf '## 2026-01-01 — no hash here\n\nbody\n' > "$CTRL_DIR/CHANGELOG.md"
+CTRL=$(python3 - "$CTRL_DIR/CHANGELOG.md" <<'PY'
+import re, sys
+t = open(sys.argv[1], encoding='utf-8').read()
+bad = [m.group(1) for m in re.finditer(r'^## (\d{4}-\d{2}-\d{2}) — .+$', t, re.M)
+       if not re.search(r'`hash: [^`]+`', t[m.end():m.end()+400])]
+print(" ".join(bad))
+PY
+)
+rm -rf "$CTRL_DIR"
+if [ "$CTRL" = "2026-01-01" ]; then
+  PASS=$((PASS+1)); printf '  ok   13. control: the hash check DOES detect a missing hash\n'
+else
+  FAIL=$((FAIL+1)); printf '  FAIL 13. CONTROL FAILED — got [%s]; assertion 12 proves nothing\n' "$CTRL"
+fi
+
 printf '\n%d passed, %d failed, %d skipped\n' "$PASS" "$FAIL" "$SKIP"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
**Found by dogfooding `/aios:update`** against a live vault — the only reason it was found at all.

## What happened

Resolving a rebase conflict in `CHANGELOG.md`, *"keep both halves"* grafted the containment-ladder body onto the **2026-08-29** header — displacing that entry's `hash:` line and its contributor attribution, and leaving 22 lines of duplicated content where they did not belong.

The 2026-09-04 entry was **unaffected and complete**. The damage was entirely in the older entry the resolution ran past.

## Why this is not cosmetic

`/aios:update` decides whether an entry is **NEW** by testing each of its hashes against the operator's stored hash. An entry with **no hash field cannot be tested at all** — the scan degrades to date+title matching, and an entry that fails to register as new means its **`Action required` never executes on any operator's machine.**

Under-reporting is the one failure a changelog cannot afford.

Restored **verbatim from `44b4643`** — the operator's own stored hash — so the recovered text is the version that actually shipped rather than a reconstruction.

## The guard that did not exist

- **Assertion 12** — every `## YYYY-MM-DD` entry carries a `hash:` line.
- **Assertion 13** — its **control**: plants an entry with no hash in a fixture and requires the check to catch it, so 12 cannot pass vacuously.

Nothing failed when this shipped. No test covered it, `git diff` showed a plausible edit, and the markdown rendered fine. **A conflict resolution that produces valid-looking output is not evidence the content survived** — the second time that exact lesson has surfaced today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS