### PR TITLE
fix(security-engineer): a canonical file the secret scanner rejects blocks every operator's sync

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1113,6 +1113,32 @@ jobs:
         # unparseable file reporting a healthy zero is the defect class this reduces.
         run: bash tests/buffer-status.test.sh
 
+      - name: every tracked file passes the secret scanner
+        # THE GAP THIS CLOSES. tests/secret-scan.test.sh proves the scanner behaves
+        # correctly on FIXTURES. Nothing ran it across the tracked tree — so canonical
+        # could (and did) ship a file the scanner rejects, and the failure appeared
+        # only on an operator's machine, at the worst possible moment: aios-commit
+        # refuses the commit, so the framework sync applies but cannot be committed.
+        #
+        # Found 2026-09-04 by dogfooding /aios:update on a live vault. The offender was
+        # the security-engineer agent DOCUMENTING credential patterns to grep for,
+        # including a literal PEM private-key header. Canonical developers never hit it
+        # because a checkout without the git hooks installed never runs this scanner;
+        # every operator using aios-commit does. That asymmetry is the whole bug.
+        run: |
+          set -e
+          FAIL=""
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            bash hooks/git/secret-scan.sh "$f" >/dev/null 2>&1 || FAIL="$FAIL $f"
+          done < <(git ls-files)
+          if [ -n "$FAIL" ]; then
+            echo "::error::Tracked file(s) rejected by hooks/git/secret-scan.sh — every operator would be unable to commit a sync that touches them:$FAIL"
+            echo "Describe the credential marker instead of reproducing it verbatim."
+            exit 1
+          fi
+          echo "OK: every tracked file passes the secret scanner"
+
       - name: the model-routing ladder agrees across both wrappers
         # The tier -> model map is implemented TWICE (a bash case, a PowerShell switch)
         # and nothing but this suite connects them. A fix applied to one and not the

--- a/agents/aios/engineering/security-engineer.md
+++ b/agents/aios/engineering/security-engineer.md
@@ -125,7 +125,7 @@ The rule: **secrets must never appear in source code, CI logs, or local files ou
 - **CI/CD masking** — ensure CI providers mask secret values in logs; don't echo them, don't pass via `set -x`
 
 *Detection in code review:*
-Grep patterns for hardcoded credentials: `sk_live_`, `AKIA[0-9A-Z]{16}`, `ghp_[a-zA-Z0-9]{36}`, `xoxb-`, `eyJ` (base64-prefixed JWTs), `-----BEGIN PRIVATE KEY-----`. Run on every PR (Semgrep rule + GitHub Push Protection).
+Grep patterns for hardcoded credentials: `sk_live_`, `AKIA[0-9A-Z]{16}`, `ghp_[a-zA-Z0-9]{36}`, `xoxb-`, `eyJ` (base64-prefixed JWTs), the PEM private-key header (`-----BEGIN`…`PRIVATE KEY-----`). Run on every PR (Semgrep rule + GitHub Push Protection).
 
 **5. Threat Mitigation Mapping**
 


### PR DESCRIPTION
**Found by dogfooding `/aios:update` on a live vault** — and it would have hit **every operator upgrading to v0.6.0**.

## The bug

`agents/aios/engineering/security-engineer.md` documents credential patterns for a security engineer to grep for, and **reproduced a literal PEM private-key header** among them. `hooks/git/secret-scan.sh` matches exactly that pattern. So:

1. `/aios:update` applies the file — **it changed this release**
2. Step 7 commits the sync via `aios-commit`
3. `aios-commit`'s secret scan **refuses the commit**
4. the operator's vault is **applied-but-uncommittable**, with an error naming a "secret" that is a documentation example

## Why canonical CI never caught it

`tests/secret-scan.test.sh` proves the scanner behaves correctly **on fixtures**. Nothing ran the scanner across the **tracked tree**.

And a canonical checkout **without the git hooks installed never invokes it at all** — so the people most likely to add such a line are the people structurally least likely to hit it. **That asymmetry is the whole bug:** the check existed, pointed at the wrong thing, and its blind spot was exactly the population it was protecting.

## The fix

- **Describe the marker instead of reproducing it.** A security agent's reader knows the PEM header; the literal string is what makes the file uncommittable, and it carries no information the description lacks.
- **New CI step: every tracked file must pass `hooks/git/secret-scan.sh`.** Verified the scanner still flags a planted marker, so the step **can actually fail**.

Exactly one tracked file was affected; the tree is clean after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS