### PR TITLE
fix(buffer-status): a mixed buffer was told every entry was classified

### DIFF
--- a/hooks/buffer-status.py
+++ b/hooks/buffer-status.py
@@ -156,6 +156,20 @@ def build(sections, ecap, rcap):
                 f"on measured vaults ~80% of buffer intake is class:method, which exits by "
                 f"route/fold/drop rather than by waiting."
             )
+        elif any(e["class"] is None for e in em):
+            # MIXED: some classified, some not. The earlier version fell through to
+            # the all-classified message here and asserted "every entry is
+            # classified" while simultaneously reporting N unclassified entries in
+            # the next line — a self-contradicting report, and the same
+            # assert-a-cause-you-did-not-measure shape this file was written to
+            # avoid. Three states need three messages, not two.
+            unc = sum(1 for e in em if e["class"] is None)
+            actions.append(
+                f"Emerging is {len(em)}/{ecap} (over by {over}), and {unc} of them are still "
+                f"unclassified — the cause cannot be attributed yet. Classify those first; on "
+                f"measured vaults ~80% of buffer intake is class:method, which exits by "
+                f"route/fold/drop rather than by waiting."
+            )
         else:
             actions.append(
                 f"Emerging is {len(em)}/{ecap} (over by {over}). Every entry is classified and none "

--- a/tests/buffer-status.test.sh
+++ b/tests/buffer-status.test.sh
@@ -81,6 +81,30 @@ case "$out" in
   *) no "unclassified over-cap produced no recognisable diagnosis" "$out" ;;
 esac
 
+echo "── REGRESSION: a MIXED buffer does not claim everything is classified ──"
+# Three states need three messages. The first version had two, so a buffer with
+# SOME entries classified fell through to the all-classified branch and asserted
+# "every entry is classified" one line above reporting N unclassified. A report
+# that contradicts itself is the same assert-a-cause-you-did-not-measure shape
+# this whole file exists to reduce — caught by running it on a real buffer.
+{ echo "## Emerging"
+  i=0; while [ "$i" -lt 11 ]; do i=$((i+1)); echo "### old $i"; echo "body"; echo; done
+  echo "### classified one"; echo '`class: behavioural` · `route: patterns.md`'; echo "body"; } > "$T/mixed.md"
+out=$(python3 "$B" "$T/mixed.md")
+case "$out" in
+  *"Every entry is classified"*) no "claims every entry is classified while some are not" "self-contradicting report" ;;
+  *"still unclassified — the cause cannot be attributed"*) ok "mixed buffer refuses to attribute the cause" ;;
+  *) no "mixed buffer produced no recognisable diagnosis" "$(printf '%s' "$out" | tail -2)" ;;
+esac
+# Control: the all-classified branch must STILL be reachable, or the fix above
+# just made one message unreachable instead of correct.
+{ echo "## Emerging"
+  i=0; while [ "$i" -lt 12 ]; do i=$((i+1)); echo "### b $i"; echo '`class: behavioural` · `route: patterns.md`'; echo "body"; echo; done; } > "$T/allb.md"
+case "$(python3 "$B" "$T/allb.md")" in
+  *"Every entry is classified"*) ok "control: the all-classified branch is still reachable" ;;
+  *) no "CONTROL FAILED — the all-classified message is now unreachable" ;;
+esac
+
 echo "── REGRESSION: the pre-contract **Route to:** form counts as a route ──"
 { echo "## Emerging"; echo "### legacy entry"; echo "body"; echo '**Route to:** [[patterns]] (some reason)'; } > "$T/legacy.md"
 out=$(python3 "$B" "$T/legacy.md" --json)


### PR DESCRIPTION
Found by running it against a live vault mid-session-close. It printed, **one line apart**:

```
1. Emerging is 14/10 (over by 4). Every entry is classified and none is
   class:method, so the behavioural ones are genuinely the cause…
2. 18 entries carry no `class:` line…
```

Three states — **nothing** classified, **some** classified, **all** classified — had only **two** branches. The mixed case fell through to the all-classified message and asserted a fact it had not measured.

That is the same shape this file was written to reduce, **in the file itself**: a wrong specific cause directs the work, and here it pointed at behavioural entries when the real answer is *"you cannot attribute the cause until these are classified."*

The mixed branch now says exactly that, and names how many are unclassified.

**Tests:** a regression asserting a mixed buffer refuses to attribute the cause, plus a **control** asserting the all-classified branch is still reachable — otherwise the fix could have made one message correct by making the other unreachable, which the regression alone would not notice.

23 assertions (was 21). **29/29 suites pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS