### PR TITLE
fix(model-routing): the shipped claude -p probe named no tools, and add a lint

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1113,6 +1113,26 @@ jobs:
         # unparseable file reporting a healthy zero is the defect class this reduces.
         run: bash tests/buffer-status.test.sh
 
+      - name: every shipped `claude -p` invocation names its tools
+        # Reported by an operator 2026-08-31 after auditing their own fleet, prompted by a
+        # published RCE against Claude Code from a "summarise this website" request. The
+        # vendor's own response is the part that matters: auto mode is a convenience feature
+        # backed by a best-effort classifier, NOT a security boundary. A headless `claude -p`
+        # spawning another headless `claude -p` is the normal topology for a routine fleet,
+        # so a rogue one looks ordinary.
+        #
+        # Canonical was clean when they checked. This guard is so it STAYS clean — an
+        # allowlist is a flag now and a fleet-wide retrofit later.
+        #
+        # SCOPED TO EXECUTABLE FILES AND TO STATEMENTS, NOT TEXT. The first version grepped
+        # line-by-line across all tracked files and produced five false positives out of
+        # five: two were continuation lines whose --allowedTools sat on the NEXT line, and
+        # three were log strings in video-watch.py that merely MENTION `claude -p`. A guard
+        # that flags the prose describing a call is the same measuring-the-wrong-thing shape
+        # this repo keeps hitting, so this one joins continuations, strips comments, and
+        # only considers .py/.sh.
+        run: python3 tests/lint-claude-p.py
+
       - name: every tracked file passes the secret scanner
         # THE GAP THIS CLOSES. tests/secret-scan.test.sh proves the scanner behaves
         # correctly on FIXTURES. Nothing ran it across the tracked tree — so canonical

--- a/MODEL-ROUTING.md
+++ b/MODEL-ROUTING.md
@@ -52,10 +52,20 @@ Model ids churn. An id AIOS does not recognise **does not fail loudly** — Clau
 means *"the spawn worked"* is worthless as evidence on its own. The check that can actually fail:
 
 ```bash
-claude -p --model "$ID" --output-format json 'ok' 2>&1 | head -c 200
+# Prompt FIRST, then flags — `--allowedTools` is variadic and will swallow a
+# prompt that follows it. Both guard flags are required, and so is the explicit
+# permission mode: see the note below.
+claude -p 'ok' --model "$ID" --output-format json \
+  --allowedTools NoSuchTool --strict-mcp-config --permission-mode default 2>&1 | head -c 200
 # real id  → JSON with non-zero total_cost_usd and non-zero input tokens
 # bad id   → the literal string  [claude-code:unrecognized_model]
 ```
+
+> **Why a probe that only says `ok` carries an allowlist.** Reported by an operator, 2026-08-31, after auditing their own fleet. Any shipped `claude -p` invocation should name the tools it actually needs — this one needs none — because the cost of adding it is a flag and the cost of retrofitting it across a fleet is a weekend. Three of the four obvious ways to do this **do not work**: `--allowedTools ""` is swallowed by the variadic flag · `--permission-mode manual` does **not** block (Bash still runs) · `--disallowedTools Bash` is a denylist, so `Write`, `Edit` and `Agent` survive it. The allowlist naming a tool that does not exist, plus `--strict-mcp-config`, is the form that holds.
+>
+> **And it holds only if you also pass `--permission-mode` explicitly.** Measured 2026-09-04 on a machine whose `~/.claude/settings.json` sets `permissions.defaultMode: "auto"`: the allowlist form alone **created a file**, with `permission_denials: []`. Adding `--permission-mode default` (or `plan`) blocked it. A machine-level auto mode silently outranks the flag — which is consistent with the vendor's own position that auto mode is a convenience feature backed by a best-effort classifier, **not a security boundary**.
+>
+> **You cannot verify any of this by asking the agent what tools it has.** Under a restrictive allowlist it still lists `Bash` and `Write`, because it is describing its *schema* rather than its *permissions*. **Only an absent side effect is evidence** — did a file appear, did the command run. Every claim in this note was measured that way.
 
 Note what `modelUsage` in that JSON is **not**: it echoes the id you *requested*, so a bogus id
 appears there verbatim and looks confirmed. Cost and token counts are the discriminating signal.

--- a/hooks/claude-identity/install-wrappers.sh
+++ b/hooks/claude-identity/install-wrappers.sh
@@ -351,7 +351,12 @@ spawn() {
   # Code does not recognise does NOT error into the void — it prints
   # [claude-code:unrecognized_model] and then bills zero tokens, so "the spawn
   # worked" is not evidence. The check that can fail:
-  #   claude -p --model "$ID" --output-format json 'ok' 2>&1 | head -c 200
+  #   claude -p 'ok' --model "$ID" --output-format json \\
+  #     --allowedTools NoSuchTool --strict-mcp-config --permission-mode default
+  # (prompt FIRST — --allowedTools is variadic and swallows a following prompt.
+  #  Both guard flags AND the explicit permission-mode are needed: a machine-level
+  #  permissions.defaultMode of "auto" silently outranks the allowlist. See
+  #  MODEL-ROUTING.md § Verify an id before you trust it.)
   # (`modelUsage` in that JSON echoes the id you ASKED for, so a bogus id looks
   # confirmed there — cost and token counts are the discriminating signal.)
   #

--- a/tests/lint-claude-p.py
+++ b/tests/lint-claude-p.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Assert every shipped `claude -p` invocation names the tools it may use.
+
+WHY
+    A headless `claude -p` with no tool allowlist will use whatever its machine
+    permits. Reported by an operator after a published RCE against Claude Code
+    from a "summarise this website" request; the vendor's own reply is the load-
+    bearing part — auto mode is a convenience feature backed by a best-effort
+    classifier, NOT a security boundary. In a routine fleet a headless call
+    spawning another headless call is the normal topology, so a rogue one does
+    not look anomalous.
+
+WHAT IT CHECKS, AND WHY IT IS NARROW
+    Only `.py` and `.sh` under version control — the files that actually EXECUTE.
+    Markdown is documentation; a doc that shows an unguarded call is a docs bug,
+    not a live risk, and flagging it produced nothing but noise.
+
+    Within those, it joins backslash continuations and strips comments FIRST,
+    then looks for a statement that invokes `claude -p`. The first version of
+    this check grepped line-by-line across every tracked file and was wrong five
+    times out of five: two hits were continuation lines whose `--allowedTools`
+    sat on the following line, and three were log strings that merely mention
+    `claude -p`. A guard that flags the prose describing a call is measuring
+    text, not behaviour.
+
+THE THREE GUARDS THAT DO NOT WORK (so nobody re-invents them)
+    --allowedTools ""          swallowed — the flag is variadic, and with the
+                               prompt after it, the prompt is eaten
+    --permission-mode manual   does NOT block; Bash still runs
+    --disallowedTools Bash     a denylist: Write, Edit and Agent survive it
+
+    The form that holds is an allowlist naming a tool the job needs (or one that
+    does not exist, when it needs none) plus --strict-mcp-config — AND an
+    explicit --permission-mode, because a machine-level permissions.defaultMode
+    of "auto" silently outranks the allowlist. Measured 2026-09-04: without the
+    mode flag the call created a file and reported permission_denials: [].
+
+    None of this is verifiable by asking the agent what tools it has — under a
+    restrictive allowlist it still lists Bash and Write, because it is describing
+    its schema rather than its permissions. Only an absent side effect is
+    evidence.
+"""
+import re
+import subprocess
+import sys
+
+SKIP_PREFIXES = ("skills/anthropic/", "skills/superpowers/", "tests/lint-claude-p.py")
+
+
+def statements(text, is_python):
+    """Yield (line_no, statement) with continuations joined and comments stripped."""
+    out, buf, start = [], "", 0
+    for i, raw in enumerate(text.splitlines(), 1):
+        line = raw
+        # Strip comments. In Python a '#' inside a string is not a comment, so only
+        # strip when the '#' is the first non-space character — conservative on
+        # purpose: under-stripping risks a false positive, never a false pass.
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            line = ""
+        if not buf:
+            start = i
+        buf += " " + line.rstrip("\\")
+        if line.rstrip().endswith("\\"):
+            continue
+        out.append((start, buf.strip()))
+        buf = ""
+    if buf.strip():
+        out.append((start, buf.strip()))
+    return out
+
+
+def main():
+    files = subprocess.run(["git", "ls-files", "*.py", "*.sh"],
+                           capture_output=True, text=True).stdout.split()
+    bad = []
+    for f in files:
+        if any(f.startswith(p) for p in SKIP_PREFIXES):
+            continue
+        try:
+            text = open(f, encoding="utf-8", errors="replace").read()
+        except OSError:
+            continue
+        if "claude" not in text:
+            continue
+        for lineno, st in statements(text, f.endswith(".py")):
+            # The invocation SHAPE differs by language, and using the shell shape on
+            # Python is what produced three false positives: a bare `claude -p` inside
+            # a log string is prose, and Python code never invokes a binary that way.
+            if f.endswith(".py"):
+                # A subprocess argv list: [claude, "-p", …] or ["claude", "-p", …]
+                shell_call = None
+                py_call = re.search(r'\[\s*["\']?claude["\']?\s*,\s*["\']-p["\']', st)
+            else:
+                shell_call = re.search(r"(^|[^\w-])claude\s+-p\s+\S", st)
+                py_call = None
+            if not (shell_call or py_call):
+                continue
+            if "allowedTools" in st:
+                continue
+            bad.append(f"{f}:{lineno}: {st[:110]}")
+    if bad:
+        print("::error::A shipped `claude -p` invocation does not name its tools:")
+        for b in bad:
+            print("  " + b)
+        print("Add --allowedTools sized to the job (a nonexistent tool name when it needs none),")
+        print("plus --strict-mcp-config and an explicit --permission-mode.")
+        print("Prompt FIRST: --allowedTools is variadic and swallows a prompt that follows it.")
+        return 1
+    print(f"OK: every shipped claude -p invocation names its tools ({len(files)} executable files scanned)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Reported by an operator 2026-08-31, prompted by a [published RCE against Claude Code](https://embracethered.com/blog/posts/2026/breaking-claude-code-opus-5-and-automode/) from a *"summarise this website"* request.

The vendor's own reply is the load-bearing part: **auto mode is a convenience feature backed by a best-effort classifier, not a security boundary** — the real boundary is OS isolation and egress control. In a routine fleet a headless `claude -p` spawning another headless `claude -p` is the normal topology, so a rogue one does not look anomalous.

**They checked canonical and found it clean.** Then canonical shipped an unguarded one the same week: the model-id verification probe added in `v0.6.0`. Its prompt is a fixed literal so the injection risk is nil — but **a doc that tells operators to run an unguarded call teaches the unguarded form.** Both sites now carry the guard.

## Three of the four obvious guards do not work

Documented so nobody re-invents them:

| attempt | result |
|---|---|
| `--allowedTools ""` | **swallowed** — the flag is variadic and eats a following prompt |
| `--permission-mode manual` | **does not block** — Bash still runs |
| `--disallowedTools Bash` | denylist — `Write`, `Edit`, `Agent` survive |
| allowlist naming a nonexistent tool + `--strict-mcp-config` | **holds** |

## A correction to that finding, measured here

**The allowlist form holds only with an explicit `--permission-mode`.** On a machine whose `settings.json` sets `permissions.defaultMode: "auto"`, the allowlist form **created a file** and reported `permission_denials: []`. Adding `--permission-mode default` (or `plan`) blocked it.

A machine-level auto mode **silently outranks the flag** — which is the vendor's own point about auto mode not being a boundary, arriving from the other direction.

Verified the guarded probe **still discriminates** a real model id from a bogus one, so the guard did not cost the probe its job.

## The lint

`tests/lint-claude-p.py`. The **first version was wrong five times out of five** — two hits were continuation lines whose `--allowedTools` sat on the next line, three were log strings that merely *mention* `claude -p`. It now joins continuations, strips comments, scopes to `.py`/`.sh`, and uses a **language-specific invocation shape** (a Python argv list vs a shell command line). Verified against planted unguarded calls in both languages.

**None of this is verifiable by asking the agent what tools it has** — under a restrictive allowlist it still lists `Bash` and `Write`, because it describes its *schema*, not its *permissions*. Only an absent side effect is evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS