### PR TITLE
docs(changelog): two merges shipped with no entry, and the lint operators never receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ## 2026-09-04 — Four ladders: which writing tells to keep, which Claude to spend, how contained you are, and what to build first
 
-`hash: 25d4a9f`
+`hash: 25d4a9f · 6a6b815 · 7f3b96d · 5c11809 · 8cb3c3e · 0094e48 · {HASH}`
 
 > **The shape of the day.** Four things shipped that are all the same move: replacing a judgement call you were making by feel with **a rung you can locate yourself on**. Which AI-writing tells to keep. Which Claude model to spend. How contained your machine actually is. What to build first in a product. Each one used to be answered by instinct; each now has a ladder and, where it is measurable, a script that measures it.
 >
@@ -173,6 +173,31 @@ Both shipped in `v0.6.0` and are fixed in `v0.6.1`. Neither needs anything from 
 
 Both are the same lesson: **a conflict resolution that produces valid-looking output is not evidence the content survived.**
 
+### Headless `claude -p` calls must name the tools they may use
+
+> **What this delivers.** A rule, a CI lint, and `/aios:housekeeping` **Bucket 29** — because a headless `claude -p` with no `--allowedTools` will use whatever the machine permits, and in a routine fleet a headless call spawning another headless call is the normal topology, so a rogue one does not look anomalous.
+
+**Reported by an operator** who audited their own fleet after a published RCE against Claude Code arising from a *"summarise this website"* request. The load-bearing part is the vendor's own response: **auto mode is a convenience feature backed by a best-effort classifier, not a security boundary** — the real boundary is OS isolation and egress control. The call shape that matters is any that puts *fetched text* into a prompt: a page title, an email body, a transcript.
+
+**Three of the four obvious fixes do not work.** Recorded so nobody re-invents them:
+
+- **`--allowedTools ""`** is swallowed — the flag is variadic, and with the prompt after it, the prompt is eaten.
+- **`--permission-mode manual` does not block.** Bash still runs. This is the one that reads like the safe setting.
+- **`--disallowedTools Bash`** is a denylist — `Write`, `Edit` and `Agent` survive it.
+- **What holds:** an allowlist naming the tools the job needs (or one that does not exist, when it needs none), plus `--strict-mcp-config` — **and an explicit `--permission-mode`.** Measured on a machine whose `settings.json` sets `permissions.defaultMode: "auto"`, the allowlist alone **created a file** and reported `permission_denials: []`; adding `--permission-mode default` blocked it. **A machine-level auto mode silently outranks the flag.**
+
+**You cannot verify any of this by asking the agent what tools it has.** Under a restrictive allowlist it still lists `Bash` and `Write`, because it is describing its *schema* rather than its permissions. **Only an absent side effect is evidence** — did a file appear, did the command run.
+
+**Canonical was clean when the report arrived, and broke four days later.** The model-id verification probe shipped earlier in this same entry is a headless call with no allowlist, printed in a doc telling operators to run it. Its prompt is a fixed literal so the risk is nil — but a doc showing the unguarded form teaches the unguarded form, which is the strongest available argument for a check rather than a rule. Both sites now carry the guard, and the guarded probe was re-verified to still distinguish a real model id from a bogus one.
+
+**Action required — worth ten minutes if you write your own hooks.** Canonical's lint lives in `tests/`, which is **Tier 0 and never reaches your vault**, so it protects canonical and not you. Your half is **Bucket 29**, which runs on the next `/aios:housekeeping` and scans your own `hooks/custom/`, `skills/custom/`, `plugins/custom/` and routine scripts. It is **report-only** — it will never edit a hook, because adding a tool restriction can break a working automation and only you know what each call legitimately needs.
+
+### `buffer-status.py` told a partly-classified buffer that everything was classified
+
+Small, and worth naming because of where it happened. The tool printed, one line apart: *"Every entry is classified and none is class:method…"* and *"18 entries carry no `class:` line…"* Both cannot be true. Three states — nothing classified, **some** classified, all classified — had only two branches, so the mixed case asserted a cause it had never measured and pointed the operator at behavioural entries when the honest answer was *"the cause cannot be attributed until these are classified."*
+
+That is the same wrong-specific-cause shape this tool exists to reduce, occurring inside it. Fixed, with a regression test **and** a control asserting the all-classified branch is still reachable — otherwise the fix could have made one message correct by making the other unreachable.
+
 ### What you need to do — the whole day in one list
 
 **`/aios:update` handles almost all of it** — it lands the files, registers the new skills into `~/.claude/skills`, and re-runs the wrapper installer. Three things it cannot do for you:
@@ -185,6 +210,8 @@ Both are the same lesson: **a conflict resolution that produces valid-looking ou
 
 - **Ask a session *"which containment rung am I on?"***. It runs read-only probes and reports with evidence. It never touches `~/.ssh/`, your keychain, or system security settings, and shows a diff before going near a shell rc.
 - **If you keep your own scorer** under `hooks/custom/` or `skills/custom/` that asks a Claude model to grade Claude-authored prose, that is worth a look by hand. Bucket 27 will find it on the next housekeeping run and offer you the two options.
+
+**If you write your own hooks that call `claude -p`**, the next `/aios:housekeeping` will scan them (Bucket 29) and report any that name no tools. Report-only; it never edits a hook.
 
 **If you keep a personal writing protocol or pre-publish checklist**, adding `voice-gate` as a step before your existing voice pass is the one manual edit worth making — it filters mechanically so your own pass spends its attention on judgment.
 

--- a/plugins/aios/commands/housekeeping.md
+++ b/plugins/aios/commands/housekeeping.md
@@ -9,7 +9,7 @@ allowed-tools: mcp__obsidian__*, Read, Grep, Glob, Bash
 
 # /housekeeping — Vault Housekeeping
 
-Periodic care of the vault as it grows. Produces a review packet across **every bucket enumerated in Phase 1** — link repairs, index refresh, project merges, archival, carry cleanup, task dedup, table trim, INTENT.md drift, antifragile cleanup, permissions audit, plugin-cache verification, antifragile compact, USER.md drift, missed reports, antifragile→USER.md graduation, radar health, CLAUDE.md+USER.md health, upstream freshness, observed-context lifecycle, skill-registration verification, file placement drift, agent-output gate health, truth-surface drift, memory-pressure channeling, spawned-output placement, antifragile fix-verification, same-family judge, containment rung drift — with proposals the user approves before anything is applied. Writes a log of what was proposed, approved, and applied.
+Periodic care of the vault as it grows. Produces a review packet across **every bucket enumerated in Phase 1** — link repairs, index refresh, project merges, archival, carry cleanup, task dedup, table trim, INTENT.md drift, antifragile cleanup, permissions audit, plugin-cache verification, antifragile compact, USER.md drift, missed reports, antifragile→USER.md graduation, radar health, CLAUDE.md+USER.md health, upstream freshness, observed-context lifecycle, skill-registration verification, file placement drift, agent-output gate health, truth-surface drift, memory-pressure channeling, spawned-output placement, antifragile fix-verification, same-family judge, containment rung drift, headless-call tool allowlists — with proposals the user approves before anything is applied. Writes a log of what was proposed, approved, and applied.
 
 **When to run:** monthly as a rhythm, or whenever the vault feels heavy (lots of carries, too many active projects, stale snapshots). `/today` will suggest it when triggers fire.
 
@@ -785,6 +785,27 @@ It runs for months without complaining, which is why it needs a periodic sweep r
 **State COVERAGE, every run, even at zero findings:** *"Containment: rung **{N}** · **{P}** probes run · **{U}** could not run ({which}) · **{R}** regressions since {date}."* **A probe that could not run is excluded from the verdict and named** — a rung claimed on the strength of a probe that never executed is worse than no verdict, and five of these probes have historically failed toward a *false pass*.
 
 **Don't propose:** editing a shell rc, installing anything, or touching security settings (read-only) · a finding for a rung the operator has deliberately declined · buying hardware · re-deriving the probes into this file.
+
+#### Bucket 29: Headless `claude -p` without a tool allowlist (NEW — REPORT-ONLY, never edits)
+
+**The gap.** A headless `claude -p` with no `--allowedTools` will use whatever the machine permits. Canonical's own invocations are guarded by a CI lint — but **`tests/` is Tier 0 and never reaches an operator vault**, so that lint protects canonical and does nothing for the operator's own `hooks/custom/`, `skills/custom/`, routines and scripts. This bucket is the operator-side half. (Proposed by the operator who reported the finding, who put it in *their* housekeeping first; canonical initially placed it only in CI, which was the right call for canonical and the wrong one for everyone else.)
+
+**Why it matters more than it looks.** A published RCE against Claude Code came from a *"summarise this website"* request. The vendor's response is the load-bearing part: **auto mode is a convenience feature backed by a best-effort classifier, not a security boundary** — the real boundary is OS isolation and egress control. In a routine fleet, a headless call spawning another headless call is the normal topology, so a rogue one does not look anomalous. Any call that puts *fetched text* into a prompt — a page title, an email body, a transcript — is the shape that matters.
+
+> **READ-ONLY.** Never edit a hook to add flags. Adding a tool restriction can break a working automation, and only the operator knows what each call legitimately needs.
+
+**How to check.** Scan the operator's own `.py` / `.sh` under `hooks/custom/`, `skills/custom/`, `plugins/custom/`, and any routine scripts, for a statement that **invokes** `claude -p` without `--allowedTools`. Two disciplines make this quiet rather than noisy:
+
+- **Join line continuations and strip comments FIRST.** A first version of canonical's lint was wrong five times out of five — two hits were continuation lines whose `--allowedTools` sat on the *next* line, three were log strings that merely mention `claude -p` in prose.
+- **The invocation shape is language-specific.** In shell it is a command line; in Python it is an argv list (`[claude, "-p", …]`). A bare `claude -p` inside a Python string is documentation, never a call.
+
+**Report as:** *"`{file}:{line}` invokes `claude -p` with no `--allowedTools`. If any text in that prompt comes from outside the vault (a fetched page, an email, a transcript), it is worth an allowlist. Three of the four obvious fixes do not work — see `MODEL-ROUTING.md` § Verify an id before you trust it."*
+
+**Carry the three traps into the report**, because an operator who reaches for the obvious fix will pick a broken one: `--allowedTools ""` is swallowed (the flag is variadic and eats a following prompt) · `--permission-mode manual` does **not** block · `--disallowedTools` is a denylist, so `Write`, `Edit` and `Agent` survive it. The form that holds is an allowlist naming the tools the job needs — or one that does not exist, when it needs none — plus `--strict-mcp-config` **and an explicit `--permission-mode`**, because a machine-level `permissions.defaultMode: "auto"` silently outranks the allowlist.
+
+**State COVERAGE, every run:** *"Headless calls: **{N}** invocations found across **{F}** operator files · **{G}** already name their tools · **{R}** reported."*
+
+**Don't propose:** editing a hook (read-only) · flagging a call whose prompt is entirely vault-local and fixed · flagging prose or log lines that mention `claude -p` · verifying a fix by asking the agent what tools it has — under a restrictive allowlist it still lists `Bash` and `Write`, because it is describing its **schema**, not its permissions. **Only an absent side effect is evidence.**
 
 ### Phase 2 — Present the packet
 


### PR DESCRIPTION
**Caught by reading canonical's log:** two commits sat past the `v0.6.1` tag with raw file changes and **nothing in the CHANGELOG**. An operator syncing next would have received a security-relevant guard and a behaviour fix with no explanation of either.

## Also: the day-entry hash field was stale

It still named only the **first** merge (`25d4a9f`) while **five more** had landed under the same date.

`/aios:update` decides whether an entry is new by testing its hashes. With only the first listed, **an operator synced at that hash reads the entry as fully seen and never sees the later subsections** — including their `Action required`. That is precisely the under-reporting failure the multi-hash convention exists to prevent, and it was live.

## The bigger gap, found while writing the entry

`tests/lint-claude-p.py` lives in `tests/`, which is **Tier 0 and never syncs to an operator vault.**

So the lint protects canonical and does **nothing** for anyone's own `hooks/custom/`, `skills/custom/` or routine scripts — which is where the reported risk actually lives. The reporter had originally put their check in `/aios:housekeeping`; canonical moved it to CI on the argument that a build check is read by everyone who opens a PR. **That is right for canonical and wrong for operators, and the two are not alternatives.**

Both now:
- **CI** — canonical regression protection
- **Bucket 29** — operator surfaces, **report-only** (adding a tool restriction can break a working automation, and only the operator knows what each call needs)

Bucket 29 carries the three non-working fixes into its report so nobody reaches for a broken one — including that a machine-level `permissions.defaultMode: "auto"` **silently outranks the allowlist**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS