### PR TITLE
feat(statusline): account label reads operator alias from USER.md

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1133,6 +1133,16 @@ jobs:
         # only considers .py/.sh.
         run: python3 tests/lint-claude-p.py
 
+      - name: the statusline account chip falls back safely
+        # This renders on EVERY prompt, so a raise in the alias lookup is not a wrong
+        # label — it is a broken statusline. The suite spends most of its effort on
+        # absent/malformed USER.md, and asserts the no-alias case explicitly, because
+        # that is the property keeping every existing vault rendering as before.
+        # Contributed in #83; the self-locate and doc-placement assertions were added
+        # on merge — USER.md is Tier-2 and never syncs, so a convention documented
+        # only there would reach fresh clones and no existing operator.
+        run: bash tests/statusline-account-alias.test.sh
+
       - name: every non-ASCII-printing hook guards Windows stdout
         # Windows consoles are cp1252, so a print() carrying an em dash raises
         # UnicodeEncodeError and the hook does NOT RUN — the failure is absence, not a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,21 @@ This is a **consistency fix, not a new convention** — three hooks already carr
 
 ---
 
+### The statusline account chip can carry a name you choose
+
+`👤` and the `🔄 from→to` swap banner showed the email's **local-part**. Two accounts can legitimately share one — the same person on two providers, or a single Google address behind two separate Anthropic accounts — and then both chips render **identically**, leaving the usage percentages as the only way to tell which account you are on.
+
+Declare an alias per line in `USER.md` → `## Anthropic accounts` and the chip uses it:
+
+```markdown
+1. `you@example.com` — primary
+2. `you@example.com.alt` — overflow · alias **overflow**
+```
+
+**Omit it and nothing changes** — that account keeps its local-part, so every existing vault renders exactly as before. The convention is documented in `hooks/claude-identity/README.md`, which is where the accounts section's format already lives.
+
+*Merged with three additions the contribution could not have anticipated. The default `USER.md` path now derives from the file's own location rather than hardcoding `~/aios` — CI forbids that in `.py` because it depends on the operator's symlink existing, and the shell sibling that does it is exempt only because the rule covers `.py`/`.js`/`.ts`, which is an asymmetry rather than a licence. The convention moved out of the parser into a **Tier-1** doc: `USER.md` is Tier-2 and never syncs, so documenting it only there would have reached fresh clones and no existing operator — a convention living in one parser is folklore. And a suite now covers the fallback path, because this code renders on every prompt, so a raise there is a broken statusline rather than a wrong label.*
+
 ### What you need to do — checks first, then act
 
 > **To the session reading this during `/aios:update`: run the checks and act on what they return.** Both are read-only. Report *"already satisfied — no action"* when a check comes back clean.
@@ -96,6 +111,18 @@ python3 ~/aios/hooks/buffer-status.py --json > /dev/null && echo ok
 
 - `ok` → the guard is in place; nothing further.
 - A `UnicodeEncodeError` → the update did not land the hook files. Re-run `/aios:update` and report that it did not apply, rather than working around it with `PYTHONIOENCODING`.
+
+**3 · Optional — name the accounts if two of them share a local-part.** *(Session: check, then offer. Do not edit `USER.md` unprompted; it is the operator's file.)*
+
+```bash
+# Section-scoped on purpose: an unscoped grep reads numbered lists from every
+# other section of USER.md and reports phantom collisions.
+awk '/^## Anthropic accounts/{f=1;next} f&&/^## /{exit} f' ~/aios/USER.md 2>/dev/null \
+  | grep -oE '^[0-9]+\. `[^`]+`' | sed -E 's/.*`(.*)@.*/\1/' | sort | uniq -d
+```
+
+- **No output** → every account has a distinct local-part. **Say nothing**; the chip is already unambiguous.
+- **A local-part printed twice or more** → those accounts render identically in the statusline. Offer: *"you can add `alias **short-name**` to those lines in `USER.md` → `## Anthropic accounts` and the chip will use it — want me to?"* Format and reasoning: `hooks/claude-identity/README.md`.
 
 **Nothing else.** No restart, no re-registration, no config change.
 

--- a/hooks/claude-identity/README.md
+++ b/hooks/claude-identity/README.md
@@ -92,9 +92,15 @@ Paths below assume the vault is at `~/aios`. If you cloned elsewhere, either sym
 ## Anthropic accounts (quota management)
 
 > `hooks/claude-identity/claude-identity.sh` parses the numbered list below as rotation slots. Order defines rotation. The parser requires backticks around each email — `N. \`email\``.
-
+>
+> **Optional per line: `alias **short-name**`.** The statusline's `👤` chip and the
+> `🔄 from→to` swap banner render this instead of the email's local-part. Worth setting
+> when two accounts **share a local-part** — the same person on two providers, or one
+> Google address behind two separate Anthropic accounts — because the bare local-part
+> then renders both identically and the usage percentages become the only way to tell
+> them apart. Omit it and that account keeps its local-part, exactly as before.
 1. `{email_1}` — primary
-2. `{email_2}` — overflow
+2. `{email_2}` — overflow · alias **{short_name_2}**
 {...etc for N accounts}
 ```
 

--- a/hooks/claude-identity/context-monitor.py
+++ b/hooks/claude-identity/context-monitor.py
@@ -510,18 +510,68 @@ def get_rate_limit_display(rate_limits):
     return f" \033[90m|{reset} ⚡ " + f" \033[90m·{reset} ".join(parts)
 
 
+_ACCOUNT_ALIASES = None
+
+
+def _account_aliases():
+    """Operator-declared short names for Anthropic accounts, read from
+    USER.md → `## Anthropic accounts`. Convention, per numbered line:
+
+        1. `someone@example.com` — alias **work** · any other prose
+
+    Returns {email: alias}. Optional: a line without `alias **x**` simply
+    has no entry and falls back to the email's local-part. This exists
+    because two accounts can share a local-part (same person, two
+    providers), which made the bare local-part ambiguous in the bar."""
+    global _ACCOUNT_ALIASES
+    if _ACCOUNT_ALIASES is not None:
+        return _ACCOUNT_ALIASES
+    aliases = {}
+    try:
+        user_md = os.environ.get("USER_MD_PATH") or os.path.expanduser("~/aios/USER.md")
+        in_sec = False
+        with open(user_md, encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("## Anthropic accounts"):
+                    in_sec = True
+                    continue
+                if in_sec and line.startswith("## "):
+                    break
+                if not in_sec:
+                    continue
+                m = re.match(r"\s*\d+\.\s*`([^`]+)`(.*)$", line)
+                if not m:
+                    continue
+                email, rest = m.group(1), m.group(2)
+                a = re.search(r"alias\s+\*\*([^*]+)\*\*", rest)
+                if a:
+                    aliases[email] = a.group(1).strip()
+    except Exception:
+        pass
+    _ACCOUNT_ALIASES = aliases
+    return aliases
+
+
+def _account_label(email):
+    """Alias from USER.md if declared, else the local-part (before @)."""
+    if not email:
+        return "?"
+    return _account_aliases().get(email) or email.split("@")[0]
+
+
 def get_account_display():
-    """Show the active Anthropic account's local-part (before @) so you can
-    tell at a glance whether you're on j@ or cc@ after an auto-swap.
-    Cheap — reads ~/.claude.json once per statusline refresh."""
+    """Show the active Anthropic account so you can tell at a glance which
+    one you're on after an auto-swap. Uses the operator's alias from USER.md
+    when declared (two accounts can share a local-part), else the local-part.
+    Cheap — reads ~/.claude.json once per statusline refresh; USER.md once
+    per process."""
     try:
         with open(os.path.expanduser("~/.claude.json")) as f:
             d = json.load(f)
         email = d.get("oauthAccount", {}).get("emailAddress", "")
         if not email:
             return ""
-        label = email.split("@")[0]
-        # Green by default — colored red if we couldn't match an Anthropic account
+        label = _account_label(email)
         return f" \033[90m|\033[0m \033[36m👤 {label}\033[0m"
     except Exception:
         return ""
@@ -553,8 +603,8 @@ def get_swap_banner():
         age = int(time.time() - ts)
         if age < 0 or age > SWAP_BANNER_TTL_SECS:
             return ""
-        from_local = (m.get("from") or "?").split("@")[0]
-        to_local = (m.get("to") or "?").split("@")[0]
+        from_local = _account_label(m.get("from"))
+        to_local = _account_label(m.get("to"))
         return (
             f"\033[31;1m🔄 {from_local}→{to_local}\033[0m "
             f"\033[90m|\033[0m "

--- a/hooks/claude-identity/context-monitor.py
+++ b/hooks/claude-identity/context-monitor.py
@@ -8,6 +8,7 @@ cumulative monthly cost tracking, and people-equivalent productivity metric.
 import json
 import sys
 import os
+from pathlib import Path
 import re
 import subprocess
 import time
@@ -528,7 +529,13 @@ def _account_aliases():
         return _ACCOUNT_ALIASES
     aliases = {}
     try:
-        user_md = os.environ.get("USER_MD_PATH") or os.path.expanduser("~/aios/USER.md")
+        # SELF-LOCATE, do not hardcode ~/aios. This file lives at
+        # hooks/claude-identity/, so the repo root is two parents up. Hardcoding
+        # `~/aios` depends on the operator's symlink existing, and the shell
+        # sibling that does it (claude-identity.sh) is exempt only because the CI
+        # rule covers .py/.js/.ts and not .sh — an asymmetry, not a licence.
+        default_user_md = Path(__file__).resolve().parents[2] / "USER.md"
+        user_md = os.environ.get("USER_MD_PATH") or str(default_user_md)
         in_sec = False
         with open(user_md, encoding="utf-8") as f:
             for line in f:

--- a/tests/statusline-account-alias.test.sh
+++ b/tests/statusline-account-alias.test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# The statusline account chip renders the operator's alias, and falls back safely
+#
+# WHY THIS EXISTS
+# The `👤` chip and the `🔄 from→to` swap banner used to show the email's
+# local-part. Two accounts can legitimately SHARE a local-part — the same person
+# on two providers, or one Google address behind two separate Anthropic accounts
+# — and then both render identically, leaving the usage percentages as the only
+# way to tell which one you are on. Contributed in #83.
+#
+# THE PROPERTY THAT MATTERS MOST IS THE FALLBACK. This code runs on every prompt
+# render, so a raise here is not a wrong label, it is a broken statusline. The
+# tests below therefore spend more effort on absent/malformed USER.md than on the
+# happy path, and the no-alias case is asserted explicitly because that is what
+# keeps every existing vault rendering exactly as it did before.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+MOD=hooks/claude-identity/context-monitor.py
+
+label(){ # label <USER_MD_PATH|-> <email>
+  local up="$1" em="$2"
+  if [ "$up" = "-" ]; then env -u USER_MD_PATH python3 - "$MOD" "$em" <<'PY'
+import importlib.util, sys
+spec=importlib.util.spec_from_file_location("cm", sys.argv[1]); m=importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m); print(m._account_label(sys.argv[2] or None))
+PY
+  else USER_MD_PATH="$up" python3 - "$MOD" "$em" <<'PY'
+import importlib.util, sys
+spec=importlib.util.spec_from_file_location("cm", sys.argv[1]); m=importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m); print(m._account_label(sys.argv[2] or None))
+PY
+  fi; }
+
+cat > "$T/USER.md" <<'MD'
+# USER
+
+## Anthropic accounts (quota management)
+
+> parser notes live here
+
+1. `same@gmail.com` — primary, MacBook
+2. `same@gmail.com.alt` — overflow · alias **overflow**
+3. `other@example.com` — third · alias **third slot**
+
+## Next section
+1. `notanaccount@example.com` — must NOT be picked up
+MD
+
+echo "── the alias renders, and only for lines that declare one ──"
+[ "$(label "$T/USER.md" 'same@gmail.com.alt')" = "overflow" ] && ok "declared alias wins" || no "alias not used" "got [$(label "$T/USER.md" 'same@gmail.com.alt')]"
+[ "$(label "$T/USER.md" 'other@example.com')" = "third slot" ] && ok "multi-word alias survives" || no "multi-word alias mangled"
+# THE BACK-COMPAT CONTROL: without it this change could silently relabel every
+# existing vault, which is the one outcome nobody would notice until it confused them.
+[ "$(label "$T/USER.md" 'same@gmail.com')" = "same" ] && ok "control: no alias declared → local-part, unchanged behaviour" \
+  || no "CONTROL FAILED — an undeclared account no longer renders its local-part"
+[ "$(label "$T/USER.md" 'stranger@nowhere.com')" = "stranger" ] && ok "account absent from USER.md → local-part" || no "unknown account mislabelled"
+
+echo "── the section boundary is respected ──"
+[ "$(label "$T/USER.md" 'notanaccount@example.com')" = "notanaccount" ] \
+  && ok "a numbered line in a LATER section is not read as an account" \
+  || no "parser ran past its section" "an unrelated numbered list would poison the chip"
+
+echo "── it never raises: this renders on every prompt ──"
+[ "$(label "$T/nonexistent.md" 'a@b.com')" = "a" ] && ok "missing USER.md → local-part, no raise" || no "missing USER.md broke the label"
+printf 'garbage without a section\n\x00\xff binary-ish\n' > "$T/junk.md"
+[ "$(label "$T/junk.md" 'a@b.com')" = "a" ] && ok "malformed USER.md → local-part, no raise" || no "malformed USER.md broke the label"
+[ "$(label "$T/USER.md" '')" = "?" ] && ok "empty email → '?' rather than a crash" || no "empty email not handled"
+
+echo "── it self-locates rather than hardcoding the install path ──"
+grep -q 'parents\[2\]' "$MOD" && ok "derives the repo root from __file__" \
+  || no "no self-locating default" "hardcoding ~/aios depends on the operator's symlink; CI forbids it in .py"
+sed 's/#.*//' "$MOD" | grep -q 'expanduser("~/aios' \
+  && no "still hardcodes ~/aios in executable text" "Migration drift will fail" \
+  || ok "no hardcoded ~/aios outside comments"
+
+echo "── the convention is documented where operators receive it ──"
+# USER.md is Tier-2 and NEVER syncs, so documenting only there would reach fresh
+# clones and no existing operator. The component README is Tier-1 and does sync.
+grep -q 'alias \*\*' hooks/claude-identity/README.md \
+  && ok "documented in hooks/claude-identity/README.md (Tier-1, syncs)" \
+  || no "convention undocumented" "a convention living only in its parser is folklore"
+
+echo
+echo "── $PASS passed, $FAIL failed ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

The `👤` account chip in the statusline (and the `🔄 from→to` swap banner) showed the email's local-part. When an operator has two accounts that share a local-part (same person, two providers), the chip is ambiguous: both render identically, and the only way to tell them apart is the usage percentages.

This reads an optional operator alias from `USER.md` → `## Anthropic accounts`, per numbered line:

```
1. `someone@example.com` — alias **work** · any other prose
```

`{email: alias}` is parsed once per process. No alias on a line → that account keeps the local-part, so existing vaults render exactly as before. `USER_MD_PATH` is honored like in `claude-identity.sh`.

## Why not hardcode

Operator vocabulary stays in `USER.md`; the renderer only knows the convention. Same decoupling the identity wrapper already uses for the account list itself.

## Tested

- Alias resolution for three declared accounts, fallback to local-part for an undeclared one, `?` for empty.
- Full statusline render with a synthetic payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)