### PR TITLE
fix(buffer-status): count bullet entries — the framework's two buffer readers disagreed about what an entry is

### DIFF
--- a/hooks/buffer-status.py
+++ b/hooks/buffer-status.py
@@ -83,6 +83,51 @@ LEGACY_ROUTE = re.compile(r"^\s*\*\*Route to:\*\*\s*(.+)$", re.M | re.I)
 VALID_CLASSES = {"behavioural", "method"}
 
 
+# An entry is a `### ` heading OR a top-level `- ` bullet. This is not a new
+# convention: `route-insight.py` — the tool that EXCISES entries from this same
+# file — resolves both styles and documents why (indented `  - ` lines are body,
+# not entries; unindented continuation prose after a bullet legitimately belongs
+# to it, measured at 43 live instances). Counting only `### ` here meant the two
+# tools disagreed about what an entry is, and the reader silently lost.
+TOP_BULLET = re.compile(r"^- \S")
+ANY_HEADING = re.compile(r"^#{1,6} ")
+
+
+def _entry_chunks(body):
+    """Entry text blocks of ONE style, heading first then bullet.
+
+    Boundaries are style-dependent, exactly as in `route-insight.py`: a bullet
+    entry ends at the next top-level bullet, ANY heading level, or an HTML
+    comment (the `<!-- ROUTED ... -->` tombstones are file furniture, never
+    entries), so its indented facets travel with it.
+    """
+    lines = body.split('\n')
+    starts = [i for i, l in enumerate(lines) if l.startswith("### ")]
+    style = "heading"
+    if not starts:
+        style = "bullet"
+        starts = [i for i, l in enumerate(lines) if TOP_BULLET.match(l)]
+    chunks = []
+    for start in starts:
+        end = len(lines)
+        for j in range(start + 1, len(lines)):
+            ln = lines[j]
+            if ANY_HEADING.match(ln):
+                end = j
+                break
+            if style == "bullet" and (TOP_BULLET.match(ln) or ln.lstrip().startswith("<!--")):
+                end = j
+                break
+        chunks.append('\n'.join(lines[start:end]))
+    return chunks
+
+
+# A section body is "substantive" if it carries prose outside HTML comments — a
+# stage holding only routed-entry tombstones is legitimately empty.
+def _has_substance(body):
+    return len(re.sub(r"<!--.*?-->", "", body, flags=re.S).strip()) >= 80
+
+
 def parse(text):
     """-> {section: [entry, ...]}. Raises ValueError when it cannot measure."""
     if not text.strip():
@@ -102,8 +147,9 @@ def parse(text):
         if key is None:
             continue
         entries = []
-        for chunk in re.split(r"^###\s+", body, flags=re.M)[1:]:
-            title, _, rest = chunk.partition("\n")
+        for chunk in _entry_chunks(body):
+            first, _, rest = chunk.partition('\n')
+            title = re.sub(r"^(?:#{1,6} |- )", "", first)
             fields = {k.lower(): v for k, v in FIELD.findall(rest[:600])}
             if "route" not in fields:
                 m = LEGACY_ROUTE.search(rest)
@@ -119,6 +165,15 @@ def parse(text):
                 }
             )
         sections[key] = entries
+        # Neither style matched a section that plainly holds content: the shape
+        # is one this parser does not know. Reporting 0 there is the false-clean
+        # zero `main()` promises never to print, so refuse loudly instead.
+        if not entries and _has_substance(body):
+            raise ValueError(
+                f"section `## {name}` holds content but yielded no entries in "
+                "either supported style (`### ` heading or top-level `- ` "
+                "bullet) — cannot measure; not reporting an empty buffer"
+            )
     if not sections:
         raise ValueError(
             "found `## ` sections but none named Emerging or Reinforced — "

--- a/tests/buffer-status.test.sh
+++ b/tests/buffer-status.test.sh
@@ -130,6 +130,54 @@ printf '## Something Else\n\n### x\nbody\n' > "$T/wrongsec.md"
 rc4=$(python3 "$B" "$T/wrongsec.md" >/dev/null 2>&1; echo $?)
 [ "$rc4" = "2" ] && ok "sections present but neither stage named → exit 2" || no "wrong-section file → exit $rc4, expected 2"
 
+echo '-- entries may be BULLETS, not only ### headings --'
+# `route-insight.py` — the tool that EXCISES entries from this same file — resolves
+# BOTH styles and documents why. This parser counted only `### `, so the framework's
+# two readers of session-insights.md disagreed about what an entry is, and this one
+# lost silently: a live vault holding 5 Reinforced anchors and 9 Emerging entries
+# reported `0/5`, `0/10`, `~0 tokens`, "Within contract", exit 0. Every guard above
+# passes on that file (non-empty, `## ` sections present, both stages named), which
+# is why nothing caught it.
+{ echo "# Session Insights"; echo; echo "## Emerging"; echo
+  echo "- **(2026-09-01)** first bullet entry"
+  echo '  `class: method` · `first-seen: 2026-09-01` · `route: antifragile.md`'
+  echo "  - an indented facet, which is BODY and must not count as an entry"
+  echo "  > a blockquote facet, likewise"
+  echo "- **(2026-09-02)** second bullet entry"
+  echo '  `class: behavioural` · `first-seen: 2026-09-02` · `route: patterns.md`'
+  echo "unindented continuation prose that belongs to the entry above"
+  echo
+  echo "<!-- ROUTED 2026-08-01: a tombstone is furniture, never an entry. -->"
+  echo; echo "## Reinforced"; echo
+  echo "- **An anchor.** Body."
+  echo '  `class: behavioural` · `first-seen: 2026-06-12` · `route: patterns.md`'
+} > "$T/bul.md"
+out=$(python3 "$B" "$T/bul.md" --json); rc=$?
+be=$(printf '%s' "$out" | python3 -c 'import sys,json;print(json.load(sys.stdin)["emerging"])')
+br=$(printf '%s' "$out" | python3 -c 'import sys,json;print(json.load(sys.stdin)["reinforced"])')
+bm=$(printf '%s' "$out" | python3 -c 'import sys,json;print(json.load(sys.stdin)["method_awaiting_disposition"])')
+bu=$(printf '%s' "$out" | python3 -c 'import sys,json;print(json.load(sys.stdin)["unclassified"])')
+[ "$be" = "2" ] && ok "counted 2 bullet Emerging entries" || no "counted $be bullet Emerging, expected 2" "indented facets or the tombstone were counted as entries"
+[ "$br" = "1" ] && ok "counted 1 bullet Reinforced entry" || no "counted $br bullet Reinforced, expected 1"
+[ "$bm" = "1" ] && ok "class: fields parse inside a bullet entry" || no "method count $bm, expected 1" "the class line sits on the bullet's indented continuation"
+[ "$bu" = "0" ] && ok "no bullet entry is misread as unclassified" || no "$bu unclassified, expected 0"
+# Control: the heading style must still work, or the change above just swapped one
+# blind spot for another.
+mk "$T/hd.md" 2 1
+he=$(python3 "$B" "$T/hd.md" --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["emerging"])')
+[ "$he" = "3" ] && ok "control: heading-style entries still counted" || no "CONTROL FAILED — heading style now counts $he, expected 3"
+# Control: a stage holding ONLY tombstones is legitimately empty, not a parse failure.
+{ echo "## Reinforced"; echo; echo "## Emerging"; echo
+  echo "<!-- ROUTED 2026-08-24: graduated to patterns.md; removed from buffer. -->"
+} > "$T/tomb.md"
+rct=$(python3 "$B" "$T/tomb.md" >/dev/null 2>&1; echo $?)
+[ "$rct" = "0" ] && ok "control: a genuinely empty buffer still measures clean" || no "CONTROL FAILED — empty-but-valid buffer → exit $rct, expected 0"
+# A shape matching NEITHER style must refuse, not report zero.
+{ echo "## Emerging"; echo; echo "some prose that is neither a heading nor a top-level bullet,"
+  echo "long enough to be unmistakably substantive content in this stage."; } > "$T/neither.md"
+rcn=$(python3 "$B" "$T/neither.md" >/dev/null 2>&1; echo $?)
+[ "$rcn" = "2" ] && ok "an unknown entry shape refuses (exit 2), never reports 0" || no "unknown shape → exit $rcn, expected 2"
+
 echo "── an unrecognised class is surfaced ──"
 { echo "## Emerging"; echo "### weird"; echo '`class: sytem` · `route: x.md`'; echo body; } > "$T/badclass.md"
 case "$(python3 "$B" "$T/badclass.md")" in


### PR DESCRIPTION
## The defect

`hooks/buffer-status.py` splits buffer entries on `^### ` only. But `hooks/route-insight.py` — the tool that **excises** entries from that same `session-insights.md` — resolves **both** `### ` headings and top-level `- ` bullets, with a documented, corpus-measured contract for each:

- indented `  - ` lines are body, not entries
- unindented continuation prose after a bullet legitimately belongs to it (*"measured against the seven live files… 43 bullets are followed by unindented continuation prose that genuinely belongs to them"*)
- a bullet entry ends at the next top-level bullet, any heading level, or an HTML comment

So the framework ships **two readers of one file that disagree about what an entry is**, and the measuring one loses silently.

## What that produced on a live vault

A buffer holding **5 Reinforced anchors and 9 Emerging entries** reported:

```
Emerging   0/10
Reinforced 0/5
  reading the buffer in full costs ~0 tokens

Within contract — nothing to dispose.
```

exit `0`. The buffer was in fact **at** the Reinforced cap, one off the Emerging cap, and ~7,900 tokens to read in full.

Every guard upstream of the split passes on that file — non-empty, `## ` sections present, both stages named — which is why nothing caught it. And `main()` annotates its own ValueError path *"Loud, and exit 2. Never a healthy-looking zero."* This is that exact defect class occurring inside the tool built to reduce it.

Worth noting for triage: the tool is called by `/close-day`, so on any bullet-form buffer the close ritual has been reading a clean bill of health.

## The fix

`_entry_chunks()` resolves heading style first, then bullet, **mirroring `route-insight.py`'s boundary rules** so the two tools cannot drift apart again. Entries are no longer produced by a regex split on the delimiter, so a `class:` line sitting on a bullet's indented continuation parses exactly like one under a heading.

A backstop is kept for the case the original code got wrong for a different reason: a stage holding substantive prose that matches **neither** style now refuses (exit 2) rather than reporting zero. Substance is measured outside HTML comments, so a stage holding only `<!-- ROUTED … -->` tombstones stays legitimately empty and still exits 0.

## Tests

`23 → 30 passed, 0 failed`. Seven assertions in `tests/buffer-status.test.sh`:

- bullet entries counted in both stages
- indented facets, blockquote facets and tombstones **not** counted
- `class:` fields parse inside a bullet entry
- **control** — `### ` heading entries still counted (without it, the change could swap one blind spot for another)
- **control** — a tombstone-only stage still measures clean at exit 0
- an unknown entry shape refuses with exit 2

## Not addressed here

While running this suite on Windows: **5 assertions fail regardless of this change** (`upstream/main` scores 18 passed / 5 failed) because cp1252 stdout cannot encode the em dashes and `⚠` in the report. Three hooks already guard this with `sys.stdout.reconfigure`; `buffer-status.py` does not. Filed as a separate PR — it touches this file's import block, a different region, so merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYsCZsWA8hA6VxHHJUiXu