### PR TITLE
fix(hooks): guard Windows stdout in every hook that prints non-ASCII, plus a lint

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1133,6 +1133,19 @@ jobs:
         # only considers .py/.sh.
         run: python3 tests/lint-claude-p.py
 
+      - name: every non-ASCII-printing hook guards Windows stdout
+        # Windows consoles are cp1252, so a print() carrying an em dash raises
+        # UnicodeEncodeError and the hook does NOT RUN — the failure is absence, not a
+        # mangled glyph. Measured: hooks/buffer-status.py scored 18 passed / 5 failed on
+        # Windows and 23 / 0 elsewhere, entirely from its own report line.
+        #
+        # The convention already existed in three hooks (pipeline-executor.py,
+        # route-insight.py, claude-identity/context-monitor.py) and was applied
+        # inconsistently to the rest, which is the shape a rule takes when nothing checks
+        # it. CI runs on ubuntu, so this class is invisible here by construction — the lint
+        # is the only thing standing between it and every Windows operator.
+        run: python3 tests/lint-windows-stdout.py
+
       - name: every tracked file passes the secret scanner
         # THE GAP THIS CLOSES. tests/secret-scan.test.sh proves the scanner behaves
         # correctly on FIXTURES. Nothing ran it across the tracked tree — so canonical

--- a/hooks/buffer-status.py
+++ b/hooks/buffer-status.py
@@ -51,6 +51,16 @@ import re
 import sys
 from datetime import date, datetime
 
+# Windows consoles default to cp1252, which cannot encode the em dashes and
+# symbols this script prints — so on Windows the report raised
+# UnicodeEncodeError and aborted instead of printing. Already guarded this way
+# in pipeline-executor.py, route-insight.py and claude-identity/context-monitor.py;
+# these callers were simply missed. Safe on macOS/Linux, where stdout is UTF-8.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+
 DEFAULT_PATH = os.path.expanduser(
     "~/aios/vault/00 - notes/context/observed/session-insights.md"
 )

--- a/hooks/claude-identity/_resume.py
+++ b/hooks/claude-identity/_resume.py
@@ -78,6 +78,16 @@ import json
 import os
 import subprocess
 import sys
+
+# Windows consoles default to cp1252, which cannot encode the em dashes and
+# symbols this script prints — so on Windows the report raised
+# UnicodeEncodeError and aborted instead of printing. Already guarded this way
+# in pipeline-executor.py, route-insight.py and claude-identity/context-monitor.py;
+# these callers were simply missed. Safe on macOS/Linux, where stdout is UTF-8.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 import time
 from glob import glob
 

--- a/hooks/markitdown-convert.py
+++ b/hooks/markitdown-convert.py
@@ -16,6 +16,16 @@ if os.path.exists(venv_path):
 
 from markitdown import MarkItDown
 
+# Windows consoles default to cp1252, which cannot encode the em dashes and
+# symbols this script prints — so on Windows the report raised
+# UnicodeEncodeError and aborted instead of printing. Already guarded this way
+# in pipeline-executor.py, route-insight.py and claude-identity/context-monitor.py;
+# these callers were simply missed. Safe on macOS/Linux, where stdout is UTF-8.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+
 def main():
     if len(sys.argv) < 2:
         print("Usage: markitdown-convert.py <input_file> [output_file]", file=sys.stderr)

--- a/hooks/openrouter.py
+++ b/hooks/openrouter.py
@@ -68,6 +68,16 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+# Windows consoles default to cp1252, which cannot encode the em dashes and
+# symbols this script prints — so on Windows the report raised
+# UnicodeEncodeError and aborted instead of printing. Already guarded this way
+# in pipeline-executor.py, route-insight.py and claude-identity/context-monitor.py;
+# these callers were simply missed. Safe on macOS/Linux, where stdout is UTF-8.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+
 SECRETS_DIR = Path.home() / ".config" / "aios-secrets"
 
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"

--- a/hooks/transcribe.py
+++ b/hooks/transcribe.py
@@ -45,6 +45,16 @@ import subprocess
 import sys
 import tempfile
 
+# Windows consoles default to cp1252, which cannot encode the em dashes and
+# symbols this script prints — so on Windows the report raised
+# UnicodeEncodeError and aborted instead of printing. Already guarded this way
+# in pipeline-executor.py, route-insight.py and claude-identity/context-monitor.py;
+# these callers were simply missed. Safe on macOS/Linux, where stdout is UTF-8.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+
 DEFAULT_MODEL = "mlx-community/whisper-large-v3-turbo"
 HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))  # this file lives in hooks/ (canonical); venv is hooks/.venv
 VENV_DIR = os.path.join(HOOKS_DIR, ".venv")

--- a/hooks/video-watch.py
+++ b/hooks/video-watch.py
@@ -66,6 +66,16 @@ import subprocess
 import sys
 import tempfile
 
+# Windows consoles default to cp1252, which cannot encode the em dashes and
+# symbols this script prints — so on Windows the report raised
+# UnicodeEncodeError and aborted instead of printing. Already guarded this way
+# in pipeline-executor.py, route-insight.py and claude-identity/context-monitor.py;
+# these callers were simply missed. Safe on macOS/Linux, where stdout is UTF-8.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+
 HOOKS = os.path.dirname(os.path.abspath(__file__))
 OCR_SWIFT = os.path.join(HOOKS, "ocr-image.swift")
 YT_TRANSCRIPT = os.path.join(HOOKS, "custom", "youtube-transcript.py")

--- a/tests/lint-windows-stdout.py
+++ b/tests/lint-windows-stdout.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Every hook that PRINTS non-ASCII must guard Windows stdout.
+
+Windows consoles default to cp1252. A `print()` carrying an em dash, an arrow or
+an emoji raises UnicodeEncodeError there and aborts the script — so on Windows the
+failure is not a mangled character, it is the tool not running. The framework's
+own prose style uses em dashes liberally, which makes this a standing trap rather
+than an edge case: `hooks/buffer-status.py` scored 18 passed / 5 failed on Windows
+purely from its report line, while passing 23 / 0 everywhere else.
+
+Three hooks already carried the guard (`pipeline-executor.py`, `route-insight.py`,
+`claude-identity/context-monitor.py`), so the convention existed and was simply
+applied inconsistently. A rule that lives only in three files is folklore; this is
+the check that makes it a contract.
+
+Exit 0 = clean · 1 = a hook prints non-ASCII without the guard.
+"""
+import io
+import os
+import re
+import sys
+
+# This linter ECHOES the offending source lines, which are non-ASCII by
+# definition — so without the very guard it enforces, it crashes on cp1252
+# while reporting the defect. Found by mutating a hook to see the red line.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+PRINTS = re.compile(r"print\(|sys\.std(?:out|err)\.write")
+
+
+def prints_non_ascii(src):
+    """Lines that emit output AND carry a byte no cp1252 console can encode."""
+    hits = []
+    for n, line in enumerate(src.splitlines(), 1):
+        if PRINTS.search(line) and any(ord(c) > 127 for c in line):
+            hits.append((n, line.strip()[:88]))
+    return hits
+
+
+def main():
+    bad = []
+    for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, "hooks")):
+        dirnames[:] = [d for d in dirnames if d not in {"__pycache__", ".venv", "custom"}]
+        for fn in sorted(filenames):
+            if not fn.endswith(".py"):
+                continue
+            p = os.path.join(dirpath, fn)
+            src = io.open(p, encoding="utf-8").read()
+            hits = prints_non_ascii(src)
+            if not hits:
+                continue
+            if "reconfigure(encoding=" in src:
+                continue
+            rel = os.path.relpath(p, ROOT).replace(os.sep, "/")
+            bad.append((rel, hits))
+
+    if not bad:
+        print("lint-windows-stdout: clean — every non-ASCII-printing hook guards Windows stdout")
+        return 0
+
+    print("lint-windows-stdout: these hooks print non-ASCII with no Windows stdout guard.")
+    print("On a cp1252 console each raises UnicodeEncodeError and the tool does not run.\n")
+    for rel, hits in bad:
+        print(f"  {rel}")
+        for n, line in hits[:3]:
+            print(f"    {n}: {line}")
+        if len(hits) > 3:
+            print(f"    ... and {len(hits) - 3} more")
+    print("\nAdd, after the imports (the form already used by pipeline-executor.py):\n")
+    print('    if sys.platform == "win32":')
+    print('        sys.stdout.reconfigure(encoding="utf-8")')
+    print('        sys.stderr.reconfigure(encoding="utf-8")')
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The defect

Windows consoles default to **cp1252**. A `print()` carrying an em dash, an arrow or an emoji raises `UnicodeEncodeError` there — so the failure is not a mangled glyph, it is **the hook not running**. The framework's prose style uses em dashes liberally, which makes this a standing trap rather than an edge case.

Measured on Windows with `tests/buffer-status.test.sh`:

| | result |
|---|---|
| `upstream/main` on Windows | **18 passed, 5 failed** |
| same tree, `PYTHONIOENCODING=utf-8` | **23 passed, 0 failed** |

All five failures are the same crash inside the tool's own report line — no logic defect. A Windows operator cannot run the framework's own suite, and any hook in this set dies mid-report rather than degrading.

## Why this is a consistency fix, not a new convention

The guard **already exists** in three hooks and was simply applied inconsistently:

- `hooks/pipeline-executor.py` — *"Fix Windows encoding — cp1252 doesn't support emojis in output"*
- `hooks/route-insight.py`
- `hooks/claude-identity/context-monitor.py`

Six hooks that print non-ASCII did not have it: `buffer-status`, `claude-identity/_resume`, `markitdown-convert`, `openrouter`, `transcribe`, `video-watch`. Same idiom, placed after the imports.

## The lint

A rule living in three files is folklore, and **CI runs on ubuntu, so this class is invisible here by construction** — the lint is the only thing standing between it and every Windows operator.

`tests/lint-windows-stdout.py` flags any hook under `hooks/` (excluding `custom/`) that emits non-ASCII without the guard, and prints the exact form to add. Wired into the `primitives` job, so it inherits that job's `if: github.event.repository.fork != true` — runs on contributor PRs, skips in an operator fork.

**Verified by mutation, not by observing it pass.** Removing the guard from one hook turns it red and names the file and offending lines; restoring it returns green.

That mutation also exposed the linter **reproducing the very bug it detects** — it echoes the offending source lines, which are non-ASCII by definition, so it crashed on cp1252 *while reporting the defect*. It now carries the guard it enforces.

## Note

This touches `hooks/buffer-status.py`, as does the bullet-entry fix in the companion PR. The two edits sit in different regions (import block vs. `parse()`), so they are independent and merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSYsCZsWA8hA6VxHHJUiXu