### PR TITLE
docs(changelog): fill the 2026-09-07 entry hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ## 2026-09-07 — Two readers of one file disagreed, and Windows operators could not run the hooks at all
 
-`hash: {HASH}` · [#84](https://github.com/The-AIOS/aios/pull/84) · [#85](https://github.com/The-AIOS/aios/pull/85)
+`hash: bbf60df` · [#84](https://github.com/The-AIOS/aios/pull/84) · [#85](https://github.com/The-AIOS/aios/pull/85)
 
 > **What you can now do.** **Trust what `buffer-status.py` tells you** — if your `session-insights.md` uses top-level `- ` bullets rather than `### ` headings, it was reporting **`0/10` and `0/5`, "within contract", exit 0** on a buffer that was actually at its cap. And **run the framework's hooks and its own test suite on Windows**, where six of them previously died mid-report rather than printing a mangled character. Both were reported by operators running the framework on surfaces the maintainers do not use daily.
 


### PR DESCRIPTION
The entry shipped with a `{HASH}` placeholder. `/aios:update` tests that field to decide an entry is new — a placeholder matches no commit, so the entry could be shown or skipped wrongly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS