### PR TITLE
docs(changelog): add #98's merge hash to the 2026-09-07 field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ## 2026-09-07 — Two readers of one file disagreed, and Windows operators could not run the hooks at all
 
-`hash: bbf60df · e81993c · ba2a010 · d3b4457` · [#83](https://github.com/The-AIOS/aios/pull/83) · [#84](https://github.com/The-AIOS/aios/pull/84) · [#85](https://github.com/The-AIOS/aios/pull/85) · [#91](https://github.com/The-AIOS/aios/pull/91) · [#89](https://github.com/The-AIOS/aios/pull/89) · [#92](https://github.com/The-AIOS/aios/pull/92) · [#94](https://github.com/The-AIOS/aios/pull/94) · [#96](https://github.com/The-AIOS/aios/pull/96) · [#98](https://github.com/The-AIOS/aios/pull/98)
+`hash: bbf60df · e81993c · ba2a010 · d3b4457 · c5482ed` · [#83](https://github.com/The-AIOS/aios/pull/83) · [#84](https://github.com/The-AIOS/aios/pull/84) · [#85](https://github.com/The-AIOS/aios/pull/85) · [#91](https://github.com/The-AIOS/aios/pull/91) · [#89](https://github.com/The-AIOS/aios/pull/89) · [#92](https://github.com/The-AIOS/aios/pull/92) · [#94](https://github.com/The-AIOS/aios/pull/94) · [#96](https://github.com/The-AIOS/aios/pull/96) · [#98](https://github.com/The-AIOS/aios/pull/98)
 
 > **What you can now do.** **Trust what `buffer-status.py` tells you** — if your `session-insights.md` uses top-level `- ` bullets rather than `### ` headings, it was reporting **`0/10` and `0/5`, "within contract", exit 0** on a buffer that was actually at its cap. And **run the framework's hooks and its own test suite on Windows**, where six of them previously died mid-report rather than printing a mangled character. Both were reported by operators running the framework on surfaces the maintainers do not use daily.
 


### PR DESCRIPTION
`c5482ed` (the #98 merge) was missing from the entry's `hash:` field.

Measured against a vault at `58a86f6`: all four existing hashes are ancestors of it, so `/aios:update`'s any-hash test returns fully-synced and the CLAUDE.md condensation subsection — plus **action item 5**, which tells a running session its loaded `CLAUDE.md` is stale and names the four behaviours that changed — would never be shown.

Action 5 is the one that changes how a live session behaves, so under-reporting this entry is the worst of the cases this convention exists to prevent.

Third instance of the same two-step today (#95, #97, this). `CONTRIBUTING.md` now states that the field takes a commit **reachable from `main`**, only obtainable after merge — which is why the follow-up commit is the shape of the fix rather than a lapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS