### PR TITLE
docs(changelog): add #100's merge hash to the 2026-09-07 field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ## 2026-09-07 — Two readers of one file disagreed, and Windows operators could not run the hooks at all
 
-`hash: bbf60df · e81993c · ba2a010 · d3b4457 · c5482ed` · [#83](https://github.com/The-AIOS/aios/pull/83) · [#84](https://github.com/The-AIOS/aios/pull/84) · [#85](https://github.com/The-AIOS/aios/pull/85) · [#91](https://github.com/The-AIOS/aios/pull/91) · [#89](https://github.com/The-AIOS/aios/pull/89) · [#92](https://github.com/The-AIOS/aios/pull/92) · [#94](https://github.com/The-AIOS/aios/pull/94) · [#96](https://github.com/The-AIOS/aios/pull/96) · [#98](https://github.com/The-AIOS/aios/pull/98)
+`hash: bbf60df · e81993c · ba2a010 · d3b4457 · c5482ed · 282c47d` · [#83](https://github.com/The-AIOS/aios/pull/83) · [#84](https://github.com/The-AIOS/aios/pull/84) · [#85](https://github.com/The-AIOS/aios/pull/85) · [#91](https://github.com/The-AIOS/aios/pull/91) · [#89](https://github.com/The-AIOS/aios/pull/89) · [#92](https://github.com/The-AIOS/aios/pull/92) · [#94](https://github.com/The-AIOS/aios/pull/94) · [#96](https://github.com/The-AIOS/aios/pull/96) · [#98](https://github.com/The-AIOS/aios/pull/98) · [#100](https://github.com/The-AIOS/aios/pull/100)
 
 > **What you can now do.** **Trust what `buffer-status.py` tells you** — if your `session-insights.md` uses top-level `- ` bullets rather than `### ` headings, it was reporting **`0/10` and `0/5`, "within contract", exit 0** on a buffer that was actually at its cap. And **run the framework's hooks and its own test suite on Windows**, where six of them previously died mid-report rather than printing a mangled character. Both were reported by operators running the framework on surfaces the maintainers do not use daily.
 


### PR DESCRIPTION
`282c47d` (the #100 merge) plus the #100 PR link. Without the hash the entry reads fully-synced for anyone at `fdaa48c`, so the tier-dial and unclaimed-request subsection would never be shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS