### PR TITLE
fix(compass): restore the commit the squash-merge dropped — main was red

### DIFF
--- a/plugins/aios/commands/close-day.md
+++ b/plugins/aios/commands/close-day.md
@@ -722,6 +722,12 @@ cd ~/aios && ~/aios/hooks/aios-commit --vault -m "Close day {date}"
 
 Everything else this command surfaces **completes** — ships, carries, streaks, keys. This is the one place the framework can offer the other kind of read, and the whole design rests on **not offering it too early**. Full method: the **`finding-your-why`** skill.
 
+**And check WHEN this close is running, because a once-only offer must not be spent at the wrong moment.** `/today` fires `Skill(aios:close-day)` automatically when it finds the previous note unclosed — so an operator who habitually skips close-day only ever reaches this command through that catch-up path, in the morning, days late, while trying to start their day. That is the opposite of the reflective moment this offer needs, and the offer happens **once**: landing it there burns it.
+
+So the offer additionally requires a **timely** close — the note being closed is today's or yesterday's. On a multi-day catch-up, **skip the offer silently and leave the state untouched** (do not record a decline; nothing was offered). It will fire at the next close that runs on its own day.
+
+> **Stated limitation, because silence must not hide it:** an operator who *never* closes on time never crosses this condition, so they never receive the offer. That is the deliberate trade — a compass offered in the middle of a rushed morning catch-up is worse than no compass, and an operator who has not closed a day in a fortnight is not in a state where this would land. If several consecutive closes have all been catch-ups, say **one** plain line at the end of the run — *"worth a proper close-day one evening this week; there's something I'd like to show you that needs the quiet slot"* — and nothing more. That is a scheduling nudge, not the offer, and it carries none of the offer's content.
+
 **Check the state before anything else. In State 0 this section produces no output of any kind** — no prompt, no placeholder, no "consider setting a purpose" nudge. Silence is the correct behaviour, not a gap.
 
 - **`growth.md` has a `## Compass` WITH CONTENT under it** → **State 2.** Probe it with `awk '/^## Compass/{f=1;next} f&&/^## /{exit} f&&NF{print "present";exit}'` — **never `grep -c`**, which prints `0` *and* exits non-zero on no-match, so a `|| echo 0` fallback emits two values and the comparison silently yields the wrong state. Nothing to offer. The verdict line already answers the second question (above), and `/today` carries the goal→value clause. Skip this section.

--- a/tests/compass-layer.test.sh
+++ b/tests/compass-layer.test.sh
@@ -264,12 +264,18 @@ echo "-- 15. the state probe is not the grep -c trap --"
 # result to "0" gets false and concludes a compass exists when none does — the gate
 # inverted, silently, on every fresh vault. Same shape as antifragile #101: a fallback that
 # makes "it found nothing" and "it failed" indistinguishable.
+# Scoped to what a session would RUN — inside a bash code fence — never the whole file.
+# Both files legitimately DISCUSS the trap in prose (the changelog explains why the probe
+# changed; close-day warns the next author off it), and the first version of this check
+# fired on those explanations: the guard-matches-its-own-documentation defect, reproduced
+# in a check written the same day to prevent a different one. Extract the fence, then look.
 for f in "$CLOSE" CHANGELOG.md; do
   b=$(basename "$f")
-  if grep -qE "grep -c '\^## Compass'" "$f" 2>/dev/null; then
-    no "$b probes the compass with grep -c" "grep -c prints 0 and exits non-zero; a || fallback then emits two values and the state comparison silently yields the wrong answer"
+  fenced=$(awk '/^```bash/{f=1;next} /^```/{f=0} f' "$f" 2>/dev/null)
+  if printf '%s' "$fenced" | grep -q "grep -c '\^## Compass'"; then
+    no "$b RUNS a grep -c compass probe" "grep -c prints 0 and exits non-zero; a || fallback then emits two values and the state comparison silently yields the wrong answer"
   else
-    ok "$b does not use the grep -c probe"
+    ok "$b runs no grep -c probe (prose may discuss it)"
   fi
 done
 grep -qF 'never `grep -c`' "$CLOSE" && ok "close-day names the trap so it is not reintroduced" || no "close-day does not warn against grep -c" "the next author reaches for it first; the warning is the guard"
@@ -293,6 +299,21 @@ echo "-- 16. the method says the tells are READ, not grepped --"
 grep -qiE 'READ, not grepped|not evidence of absence' "$SKILL" \
   && ok "the skill warns that an empty search is not absent evidence" \
   || no "the skill implies the tells are searchable" "a session will grep first, find nothing, and wrongly stay in State 0 on a vault full of evidence"
+
+echo "-- 17. the once-only offer is not spent on a late catch-up close --"
+# Operator-reported: some people avoid /close-day and only reach it when the next /today
+# notices the previous day was never closed — which fires Skill(aios:close-day) in the
+# MORNING, days late. That is the opposite of the reflective moment a once-only offer
+# needs, and landing it there burns it permanently.
+grep -qiE 'timely.{0,30}close|catch-up|catch up' "$CLOSE" \
+  && ok "close-day distinguishes a timely close from a catch-up" \
+  || no "close-day makes the offer on any close" "/today auto-fires close-day for a skipped day; the offer would arrive mid-morning, days late, once, and be spent"
+grep -qiE 'do not record a decline|nothing was offered' "$CLOSE" \
+  && ok "a skipped offer does not record a decline" "nothing was offered, so nothing was refused — recording one would silence it for 90 days" \
+  || no "a deferred offer may be mistaken for a decline"
+grep -qiE 'never receive the offer|never crosses this condition' "$CLOSE" \
+  && ok "the limitation is stated rather than hidden by the silence" \
+  || no "the never-closes case is silently unreachable" "a condition that can never be met must say so, or it reads as a working feature that simply never fires"
 
 echo
 echo "-- $PASS passed, $FAIL failed --"


### PR DESCRIPTION
**`main` is currently red.** #104 merged the PR's *cached* head rather than the branch tip: GitHub's PR record sat at `2cbadfd` while the branch had advanced to `bee85c6`, and the squash took the stale one.

So main landed without the last commit, and `tests/compass-layer.test.sh` fails on main right now — its check 15 bans a `grep -c` compass probe, the CHANGELOG *explains why that probe was replaced* (quoting it), and the unscoped check fires on the explanation.

## What this restores, both from `bee85c6`

- **`close-day.md` — the catch-up deferral.** A once-only offer must not be spent on a multi-day-late close fired by `/today`'s precondition guard. Main currently has the word *"catch-up"* from the changelog's description and **none of the mechanism** — documented and absent, which is the worst combination.
- **`tests/compass-layer.test.sh` — check 15 scoped to fenced bash, plus check 17.**

## The process defect, which matters more than the git accident

A dispatched run proved `bee85c6` green *before* merging, and the merge still shipped a different tree. **"The PR is green" and "the tree that merges is green" are two different claims, and I checked only the first.**

The rule this earns: **verify the merge result, not the pre-merge run.** After any squash, re-run the suite on `main` before calling it landed. That is exactly how this was caught — the post-merge run on main went red in the same minute.

`47` checks green, `37/37` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS