### PR TITLE
docs(changelog): the 2026-09-08 hash field — 87092da + 82751c7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ## 2026-09-08 — The framework could tell you what you did, and nothing could tell you what it meant
 
-`hash: PENDING` · [#PENDING](https://github.com/The-AIOS/aios/pull/PENDING)
+`hash: 87092da · 82751c7` · [#104](https://github.com/The-AIOS/aios/pull/104) · [#105](https://github.com/The-AIOS/aios/pull/105)
 
 > **What you can now do.** Nothing, on day one — and that is the design, not a gap. Every tracked thing in this framework *completes*: a key flips, a ship lands, a streak extends, and then asks what is next. That machinery answers **what did I do**. Nothing answered **what did it mean**. This adds the second answer — but only once your own vault holds enough evidence to derive it honestly, because a purpose the system invents for you is worse than none.
 


### PR DESCRIPTION
Two hashes: #104 shipped the compass layer, #105 restored the commit #104's stale PR head dropped. Both named, because an operator who synced between them would have the feature with a red suite and a documented-but-absent catch-up deferral — the any-hash rule then correctly reads the entry as new for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119KRepWmVRdp7qPbcXVezS