### PR TITLE
fix(quota-watch): adoption check uses the triggering metric and notifies once per swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,14 @@ The probe now reports **entries, highest number, and duplicates** in one pass, c
 
 **Action required:** none. Next time `/aios:compact` runs it measures this way. If it reports a mismatch, stop and diff before letting it compact.
 
+### Eleven "adoption failed" alerts in six minutes, for a rotation that worked
+
+**What you can now do.** Stop getting that. When the quota autopilot rotates accounts, it checks afterwards that the live session actually picked up the new credential — and it was checking the wrong number. A swap triggered by the **7-day** cap was judged on whether **5-hour** usage fell, and those two have nothing to do with each other: the new account's 5h baseline reflects whatever you were doing on it, not the account you left. So a rotation that worked perfectly reported failure, once per tick.
+
+It now compares the metric that actually triggered the swap. And a failed adoption is a **state, not an event** — the log still records every tick, but your desktop gets **one** notification per rotation instead of one every three seconds.
+
+**Action required:** none.
+
 ### An entry could ship with an empty `hash:` and read as new forever
 
 **What you can now do.** Nothing to change — this one is about entries reaching you correctly. `CONTRIBUTING.md` told contributors to cite the PR number and add the hash after merge, without saying what the field holds meanwhile. It now says: **leave the line present with an empty value, never omit the line** — because the two mistakes are not symmetric. An empty value keeps the entry *shown* until a maintainer fills it. A missing line has nothing to test, so "already synced" is vacuously true and the entry is **silently skipped for every operator, forever.**

--- a/hooks/claude-identity/_watch.py
+++ b/hooks/claude-identity/_watch.py
@@ -219,8 +219,19 @@ def check_adoption(cache: dict) -> None:
     # would report a failure that has not had a chance to happen yet.
     if (cache.get("captured_at") or 0) <= (last.get("ts") or 0):
         return
-    before = last.get("five_hour_pct") or 0
-    current = cache.get("five_hour_pct") or 0
+    # Compare the metric that TRIGGERED the rotation, not always the 5h window.
+    # A swap fired by the 7d cap lands on an account whose 5h baseline has nothing
+    # to do with the source's, so "5h did not fall" is not evidence of anything.
+    # Measured 2026-09-08: gmail rotated to sovra on 7d 98%; gmail's 5h was 7%,
+    # sovra's own 5h sat at 21-35% because the operator was using it — eleven
+    # "adoption failed" alerts in six minutes while the 7d had gone 98% -> 17%.
+    reason = last.get("reason") or ""
+    if reason.startswith("7d"):
+        key, label = "seven_day_pct", "7d"
+    else:
+        key, label = "five_hour_pct", "5h"
+    before = last.get(key) or 0
+    current = cache.get(key) or 0
     if current < before - ADOPTION_DROP_PTS:
         # It fell: adopted. Clear any previous alert so a recovered system does
         # not keep showing a stale warning.
@@ -230,20 +241,34 @@ def check_adoption(cache: dict) -> None:
             except OSError:
                 pass
         return
+    swap_ts = int(last.get("ts") or 0)
     msg = (
-        f"rotation to {_read_active_email()} happened {int(elapsed)}s ago but 5h usage "
+        f"rotation to {_read_active_email()} happened {int(elapsed)}s ago but {label} usage "
         f"is still {round(current)}% (was {round(before)}% before the swap). The live "
         f"session did not adopt the new credential — most likely Claude Code stopped "
         f"re-reading the credential store. Restart open sessions and check whether an "
         f"update changed that behaviour."
     )
     log(f"ADOPTION FAILED: {msg}")
-    notify(msg)
+    # Notify ONCE per rotation. This runs on every tick (30 s, 3 s in the hot
+    # zone) and a failed adoption is a STATE, not an event: the log carries every
+    # tick, the desktop gets one notification per swap. The alert file keyed by
+    # the swap's ts is what remembers that the operator was already told.
+    already_notified = False
+    try:
+        with open(ALERT_FILE) as f:
+            already_notified = json.load(f).get("swap_ts") == swap_ts
+    except Exception:
+        pass
+    if not already_notified:
+        notify(msg)
     try:
         with open(ALERT_FILE, "w") as f:
             json.dump({
                 "ts": int(now),
+                "swap_ts": swap_ts,
                 "kind": "adoption_failed",
+                "metric": label,
                 "message": msg,
                 "pct_before": before,
                 "pct_now": current,


### PR DESCRIPTION
## What

`check_adoption()` in `hooks/claude-identity/_watch.py`:

- compares the metric that **triggered** the rotation (`7d …` reason → `seven_day_pct`, otherwise `five_hour_pct`) instead of always the 5h window;
- notifies the desktop **once per rotation**: the alert file is keyed by the swap's `ts`, and a tick that finds the same `ts` already recorded logs but does not re-notify.

## Why

A rotation fired by the 7d cap lands on an account whose 5h baseline is unrelated to the source's, so "5h did not fall by 3 points" is not evidence of a failed adoption. And the fast path kicks the watcher every 30 s (3 s in the hot zone) with no dedupe, so a (false) failure became a notification storm.

Measured 2026-09-08 23:30–23:37 on a 3-account setup: gmail → sovra on `7d at 98%`; gmail 5h 7 %, sovra's own 5h 21–35 % while the operator worked; 7d went 98 % → 17 % (adopted). **Eleven "adoption failed" desktop alerts in six minutes**, one per tick, on a rotation that had worked.

## Verified

- `py_compile` clean; one real `claude-identity.sh watch` tick after the patch logs `cooldown active … skip` with no `ADOPTION FAILED`, and the stale `rotation-alert.json` is gone (7d 98 → 17 counts as adopted).
- The log keeps one line per tick, as before; only the `notify()` is deduped. The alert file gains `swap_ts` and `metric`; the statusLine renderer only reads `kind`/`message`, unchanged.

Second commit: an operator **pause marker** (`CONFIG_DIR/quota-watch.paused` holding a future epoch or ISO-8601) that suspends rotation and the adoption check until it expires; the marker removes itself once past due. There was no kill switch before: the statusLine fast path has no operator-controlled env, and unloading launchd covers only one of the two entry points.

Sibling of #83 (same operator setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)