### PR TITLE
fix(close-session): ANYTAG is a count, not a boolean — a peer's commit read as this session's work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ## 2026-09-09 — A duplicate close could append a second block
 
-`hash: `
+`hash: ` · [#113](https://github.com/The-AIOS/aios/pull/113)
 
 > **What you can now do.** Nothing new to learn — one thing stops going wrong. `/aios:close-session` no longer appends a second block to your daily note when the only commits since your last close belong to **other sessions**.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,20 @@
 >
 > A changelog that only lists *what changed* pushes comprehension-debt onto the operator — they'd have to read a skill's source to know what it does for their day. So every entry leads with a **"What you can now do"** section: the new capabilities in **plain language, with a concrete example**, phrased as things the operator can *do* now — not a component inventory. Keep the full component list too (for the record), but lead with the practical read, and flag the load-bearing behavioral changes worth an actual read. `/aios:update` surfaces this section to the operator after applying an entry, so their own Claude session tells them what the new version unlocks. **The rule:** *translate every shipped change into a capability the operator can use — or it isn't really shipped to them, just to the repo.*
 
+## 2026-09-09 — A duplicate close could append a second block
+
+`hash: `
+
+> **What you can now do.** Nothing new to learn — one thing stops going wrong. `/aios:close-session` no longer appends a second block to your daily note when the only commits since your last close belong to **other sessions**.
+
+The idempotency gate reads the `AIOS-Session:` trailer to tell your session's commits apart from a peer's, and falls back to a coarse subject-based rule only when *no* commit in range carries a trailer — a vault that predates the trailer, where provenance is genuinely unknowable.
+
+The gate asked `ANYTAG -eq 1`. But `ANYTAG` is a **count** of tagged commits, not a boolean. So any range holding two or more tagged commits — the ordinary case in a vault written by several sessions at once — fell through to the fallback and counted a peer's commit as your session's work: exactly the failure the trailer was introduced to kill. Measured on a live vault, `ANYTAG=4` with `MINE=0` (a genuine duplicate) still appended.
+
+The condition is now `-ge 1`, so the precise path is taken whenever provenance exists at all and the fallback is reserved for the case it was written for: `ANYTAG == 0`.
+
+**Action required:** none — `/aios:update` lands it. If a recent daily note carries two near-identical `## Session —` blocks written minutes apart, that was this; delete the extra by hand.
+
 ## 2026-09-08 — Your why, your agents badge, and docs that route you
 
 `hash: 87092da · 82751c7 · 12c2559 · 3b9f43e · 3940ac8 · 3f2c8db` · [#104](https://github.com/The-AIOS/aios/pull/104) · [#105](https://github.com/The-AIOS/aios/pull/105) · [#107](https://github.com/The-AIOS/aios/pull/107) · [#108](https://github.com/The-AIOS/aios/pull/108) · [#109](https://github.com/The-AIOS/aios/pull/109) · [#110](https://github.com/The-AIOS/aios/pull/110)

--- a/plugins/aios/commands/close-session.md
+++ b/plugins/aios/commands/close-session.md
@@ -90,7 +90,13 @@ Announce the detected mode: "Detected: **vault session** — writing to daily no
        printf '%s' "$B" | head -1 | grep -qE '^session: ' && continue    # my own close → not work
        echo x
      done | grep -c .)
-     if [ "$ANYTAG" -eq 1 ]; then
+     # `-ge 1`, NOT `-eq 1`: ANYTAG is a COUNT of tagged commits, not a boolean. The degrade
+     # branch below is for "provenance is unknowable", which is ANYTAG == 0 and nothing else.
+     # With `-eq 1` any range holding TWO OR MORE tagged commits — the normal case in an
+     # active vault — fell through to the coarse rule and counted a PEER session's commit as
+     # work of mine, which is the exact bug the trailer was introduced to kill. Measured
+     # 2026-09-05: ANYTAG=4, MINE=0 (a true duplicate) and the fallback answered WORK=1 → append.
+     if [ "$ANYTAG" -ge 1 ]; then
        WORK=$MINE                                                        # precise path
      else
        # No commit in range carries a trailer → this vault predates the stamping,

--- a/tests/close-session-idempotency.test.sh
+++ b/tests/close-session-idempotency.test.sh
@@ -137,7 +137,34 @@ gate3(){
   range=$(git log --format='%H' "${stamped}..HEAD" 2>/dev/null)
   for c in $range; do
     b=$(git log -1 --format='%B' "$c" 2>/dev/null)
-    printf '%s' "$b" | grep -q '^AIOS-Session: ' && anytag=1
+    # A COUNT, exactly as the shipped gate computes it (`... | grep -c .`). Transcribing
+    # this as a boolean is what let the -eq/-ge defect live: the suite then exercised
+    # logic the command does not run. See tests 15-16.
+    printf '%s' "$b" | grep -q '^AIOS-Session: ' && anytag=$((anytag+1))
+    printf '%s' "$b" | grep -q "^AIOS-Session: ${sid}$" || continue
+    printf '%s' "$b" | head -1 | grep -qE '^session: ' && continue
+    mine=$((mine+1))
+  done
+  if [ "$anytag" -ge 1 ]; then
+    [ "$mine" -eq 0 ] && echo SKIP || echo APPEND
+  else
+    local w
+    w=$(printf '%s\n' "$range" | while IFS= read -r c; do [ -n "$c" ] && git log -1 --format=%s "$c"; done | grep -cvE '^session: ')
+    [ "$w" -eq 0 ] && echo SKIP || echo APPEND
+  fi
+}
+
+# the SHIPPED-BUT-BROKEN variant: identical except `-eq 1`. Kept so test 16 can prove
+# the regression case actually discriminates.
+gate3_eq(){
+  local sid="$1" prior stamped range mine=0 anytag=0 b
+  prior=$(grep -o "<!-- close-session: ${sid} @ [0-9a-f]* -->" "$NOTE" 2>/dev/null | tail -1)
+  [ -z "$prior" ] && { echo APPEND; return; }
+  stamped=$(printf '%s' "$prior" | sed -E 's/.* @ ([0-9a-f]*) -->/\1/')
+  range=$(git log --format='%H' "${stamped}..HEAD" 2>/dev/null)
+  for c in $range; do
+    b=$(git log -1 --format='%B' "$c" 2>/dev/null)
+    printf '%s' "$b" | grep -q '^AIOS-Session: ' && anytag=$((anytag+1))
     printf '%s' "$b" | grep -q "^AIOS-Session: ${sid}$" || continue
     printf '%s' "$b" | head -1 | grep -qE '^session: ' && continue
     mine=$((mine+1))
@@ -197,6 +224,27 @@ if command -v zsh >/dev/null 2>&1; then
 else
   sk "14. zsh unavailable — the portability proof cannot run"
 fi
+
+# ---------------------------------------------------------------------------
+# TESTS 15-16 — ANYTAG IS A COUNT, NOT A BOOLEAN.
+# The precise path must be taken whenever provenance EXISTS (anytag >= 1). The degrade
+# branch is for "provenance is unknowable", which is anytag == 0 and nothing else.
+# With `-eq 1`, any range holding TWO OR MORE tagged commits — the normal case in a vault
+# written by several sessions — fell through to the coarse rule, which counts a PEER's
+# commit as this session's work: the exact failure the AIOS-Session trailer was added to
+# kill. Measured on a live vault 2026-09-05: ANYTAG=4, MINE=0 (a true duplicate) and the
+# fallback still answered APPEND.
+# ---------------------------------------------------------------------------
+SID3="12341234-5678-90ab-cdef-000000000000"
+printf '# note3\n' > "$NOTE"
+echo y >> f; git add f; git commit -q -m "base3"
+printf '## Session — 12:00 | w\n<!-- close-session: %s @ %s -->\nb\n' "$SID" "$(git rev-parse HEAD)" >> "$NOTE"
+git add "$NOTE"; commit_as "$SID" "session: 12:00 w"
+# TWO peers commit; this session does nothing. anytag=3, mine=0 → a true duplicate.
+commit_as "$SID2" "feat: peer one ships"
+commit_as "$SID3" "feat: peer two ships"
+have "$(gate3 "$SID")" "SKIP"   "15. 2+ tagged commits, none mine → SKIP (precise path still taken)"
+have "$(gate3_eq "$SID")" "APPEND" "16. the -eq 1 variant APPENDs on that same state (the defect, reproduced)"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## The defect

`/close-session`'s idempotency gate (Step 4.5) distinguishes this session's commits from a peer's by reading the `AIOS-Session:` trailer, and degrades to a coarse subject-based rule only when provenance is unknowable — a vault predating the trailer.

`ANYTAG` is computed as a **count**:

```bash
ANYTAG=$(printf '%s\n' "$RANGE" | while IFS= read -r c; do … done | grep -c .)
```

…and then tested as a **boolean**:

```bash
if [ "$ANYTAG" -eq 1 ]; then
```

So a range holding **two or more** tagged commits — the ordinary case in a vault written by several sessions at once — takes the degrade branch and counts a **peer's** commit as this session's work. That is the exact failure the trailer was introduced to kill, reintroduced one line below it.

Measured on a live vault (2026-09-05): `ANYTAG=4`, `MINE=0` — a genuine duplicate — and the fallback answered `APPEND`, so a second near-identical `## Session —` block landed in the daily note.

The degrade branch is for *"provenance is unknowable"*, which is `ANYTAG == 0` and nothing else. Condition is now `-ge 1`.

## Why the suite passed over it

`tests/close-session-idempotency.test.sh` describes itself as transcribing the shipped gate, and that is what makes it trustworthy. Its `gate3` set the flag as a boolean:

```bash
printf '%s' "$b" | grep -q '^AIOS-Session: ' && anytag=1
```

The shipped command computes a count. So the suite exercised logic the command does not run, and `-eq 1` was correct *in the transcription* — which is why every existing test stayed green while the shipped gate was wrong. Tests 9–11 only ever construct ranges with a single tagged commit, so the divergence never showed.

`gate3` now accumulates (`anytag=$((anytag+1))`), matching the shipped computation.

## Coverage

Two cases added, both on a range with two peer-tagged commits and none of this session's:

- **15** — `gate3` returns `SKIP` (precise path taken because provenance exists).
- **16** — a `gate3_eq` control, identical but for `-eq 1`, returns `APPEND` on the same state.

16 fails if the fix is reverted, so 15 is not vacuous. Suite: 17 passed, 0 failed, and `close-session-nopush`, `changelog-entry-shape`, `changelog-read-scope` and `claude-md-integrity` stay green.

## Note on the CHANGELOG hash line

Left as `` `hash: ` `` — I'll add `· [#N]` in a follow-up commit once this has a number, and the merge hash is yours to fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwfeP6nLZYXxXgNvp2vq3t
