### PR TITLE
docs(quota-watch): document + guard the operator pause marker (split from #111)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1258,6 +1258,15 @@ jobs:
         # the no-baseline case and say so) rather than that the optimisation is merely described.
         run: bash tests/changelog-read-scope.test.sh
 
+      - name: the quota-watch pause cannot silently disable the autopilot
+        # A pause is the one operator capability whose failure mode is SILENCE: a stale,
+        # empty or mistyped marker that was honoured would leave rotation off with nothing
+        # saying so, and the operator would start hitting caps believing the autopilot runs.
+        # The contract is fail-toward-running -- anything that is not a FUTURE timestamp is
+        # ignored AND removed. These import the shipped paused_until() rather than restating
+        # its parsing, so the checks cannot pass while the real function drifts.
+        run: bash tests/quota-watch-pause.test.sh
+
       - name: the compass layer ships the method, not one operator's answer
         # This feature was derived from a live vault — a named student's AI session, a
         # biography, corpus percentages, a purpose statement. Every one of those is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,21 @@ CI now enforces both halves, gated by event so an open PR is never failed for do
 
 **Action required:** none.
 
+### You can pause the quota autopilot for a while
+
+**What you can now do.** Suspend account rotation temporarily without uninstalling anything or editing thresholds — useful when you want to stay on one account through a piece of work. Write a future expiry into `~/.claude/quota-watch.paused`:
+
+```bash
+date -v+2H +%s > ~/.claude/quota-watch.paused    # macOS — pause two hours
+date -d '+2 hours' +%s > ~/.claude/quota-watch.paused    # Linux
+```
+
+ISO-8601 with an offset works too. While it holds a future time the watcher does nothing — no rotation, no adoption check — and logs that it is paused. Delete the file to resume early.
+
+**It cannot be forgotten into permanence.** An expired *or malformed* marker is ignored and deleted, with the reason logged, so a typo or a stale pause from last week fails toward the autopilot **running**. A capability that can quietly leave your quota protection off is worse than not having it.
+
+**Action required:** none — the marker is opt-in and no file means no change.
+
 ## 2026-09-08 — Your why, your agents badge, and docs that route you
 
 `hash: 87092da · 82751c7 · 12c2559 · 3b9f43e · 3940ac8 · 3f2c8db` · [#104](https://github.com/The-AIOS/aios/pull/104) · [#105](https://github.com/The-AIOS/aios/pull/105) · [#107](https://github.com/The-AIOS/aios/pull/107) · [#108](https://github.com/The-AIOS/aios/pull/108) · [#109](https://github.com/The-AIOS/aios/pull/109) · [#110](https://github.com/The-AIOS/aios/pull/110)

--- a/hooks/claude-identity/README.md
+++ b/hooks/claude-identity/README.md
@@ -300,6 +300,27 @@ No "primary" / "come-home" semantics. Earlier versions returned to a preferred a
 
 **If you want to force a specific account** (e.g., machine A back to `primary@example.com` so machine B can use `secondary@example.com` exclusively): run `claude-identity.sh switch primary@example.com` manually. That's the escape hatch.
 
+### Pausing the autopilot temporarily
+
+`switch` above is the *spatial* escape hatch — force one account. This is the **temporal** one: suspend rotation entirely for a while, without uninstalling the launchd agent or editing thresholds.
+
+Write a future expiry into `$CLAUDE_CONFIG_DIR/quota-watch.paused` (`~/.claude/quota-watch.paused` unless you set `CLAUDE_CONFIG_DIR`). Either form is accepted:
+
+```bash
+# epoch seconds — pause two hours (macOS)
+date -v+2H +%s > ~/.claude/quota-watch.paused
+# epoch seconds — pause two hours (Linux)
+date -d '+2 hours' +%s > ~/.claude/quota-watch.paused
+# or ISO-8601 with an offset
+echo '2026-09-09T18:00:00-06:00' > ~/.claude/quota-watch.paused
+```
+
+While it holds a future timestamp the watcher logs `PAUSED by operator until …` and returns immediately — **no rotation and no adoption check.** Resume early by deleting the file.
+
+**It cannot be forgotten into permanence, and that is the point.** An expired *or malformed* marker is ignored **and removed**, with the reason logged — so a typo, a stale pause from last week, or an empty file all fail toward the autopilot running rather than toward it silently staying off. A capability that can quietly disable your quota protection forever is worse than not having it.
+
+**Why a file rather than an environment variable:** the hot path runs from the statusLine pipe, whose environment the operator does not control. A file under the config dir is the one channel both the launchd agent and the statusLine kick can read.
+
 **Cross-machine coordination is not solved here.** If two machines share an account pool, both can end up on the same account and compete for its caps. Future work: a shared state file over git / iCloud that both watchers read to coordinate. Until then, the manual escape hatch is the only lever.
 
 ## Files written
@@ -312,6 +333,7 @@ No "primary" / "come-home" semantics. Earlier versions returned to a preferred a
 | `~/.claude/rate-limit-cache.json` | Latest quota snapshot from Stop hook | 600 |
 | `~/.claude/quota-watch.log` | Watcher's per-tick decision log | 644 |
 | `~/.claude/swap-log.jsonl` | Append-only log of every auto-swap | 644 |
+| `~/.claude/quota-watch.paused` | **Operator-written** — future expiry that suspends rotation; auto-removed once past | 644 |
 | `~/.claude.json.bak-claude-switch` | Rollback snapshot of last swap | 644 |
 
 None of these should ever be committed — `~/.claude/` is outside the vault by design.

--- a/hooks/claude-identity/_watch.py
+++ b/hooks/claude-identity/_watch.py
@@ -395,9 +395,52 @@ def pick_target(current: str, t5: int, t7: int) -> tuple:
     return None, "all alternatives still capped: " + "; ".join(blocked)
 
 
+PAUSE_FILE = os.path.join(CONFIG_DIR, "quota-watch.paused")
+
+
+def paused_until() -> float:
+    """Operator pause: rotation is suspended while PAUSE_FILE holds a future
+    epoch (or ISO-8601 with offset). An expired or malformed marker is ignored
+    and removed, so a forgotten pause cannot silently disable the autopilot
+    forever. 0 means not paused.
+
+    Why a file and not an env var: the hot path runs from the statusLine pipe,
+    whose environment the operator does not control; a file under CONFIG_DIR is
+    the one channel both the launchd agent and the statusLine kick can read."""
+    try:
+        with open(PAUSE_FILE) as f:
+            raw = f.read().strip()
+    except FileNotFoundError:
+        return 0
+    except Exception:
+        return 0
+    until = 0.0
+    try:
+        until = float(raw)
+    except ValueError:
+        try:
+            from datetime import datetime
+            until = datetime.fromisoformat(raw).timestamp()
+        except Exception:
+            until = 0.0
+    if until <= time.time():
+        try:
+            os.remove(PAUSE_FILE)
+            log(f"pause marker expired or unreadable ({raw!r}) — removed, autopilot resumes")
+        except OSError:
+            pass
+        return 0
+    return until
+
+
 def main(self_path: str) -> None:
     try:
         t5, t7 = thresholds()
+
+        until = paused_until()
+        if until:
+            log(f"PAUSED by operator until {time.strftime('%Y-%m-%d %H:%M', time.localtime(until))} — no rotation, no adoption check")
+            return
 
         if not os.path.exists(CACHE):
             log("no cache yet — skip (is the Stop hook installed?)")

--- a/tests/quota-watch-pause.test.sh
+++ b/tests/quota-watch-pause.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# The operator pause marker must suspend rotation, and must NEVER be able to
+# disable the autopilot permanently by accident.
+#
+# WHY. A pause is the one operator-facing capability whose failure mode is
+# silence: if a stale, empty or mistyped marker were honoured, quota rotation
+# would stay off and nothing would say so -- the operator would simply start
+# hitting caps with an autopilot they believe is running. So the contract is
+# fail-toward-running: anything not a FUTURE timestamp is ignored AND removed.
+#
+# These call the SHIPPED paused_until() by importing _watch.py, rather than
+# re-implementing its parsing here. A test that restates the logic it checks
+# passes while the real function drifts.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+W=hooks/claude-identity/_watch.py
+R=hooks/claude-identity/README.md
+for f in "$W" "$R"; do [ -f "$f" ] || { echo "::error::$f missing"; exit 1; }; done
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Import the real module with CLAUDE_CONFIG_DIR pointed at a scratch dir, so
+# nothing touches the operator's own ~/.claude.
+probe() { # $1 = file contents ("" = no file); prints "<until> <file_exists>"
+  local body="$1"
+  rm -f "$TMP/quota-watch.paused"
+  [ "$body" = "__none__" ] || printf '%s' "$body" > "$TMP/quota-watch.paused"
+  CLAUDE_CONFIG_DIR="$TMP" python3 - "$W" <<'PY'
+import importlib.util, os, sys
+spec = importlib.util.spec_from_file_location("w", sys.argv[1])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+u = m.paused_until()
+print(f"{1 if u else 0} {1 if os.path.exists(m.PAUSE_FILE) else 0}")
+PY
+}
+
+echo "-- 1. a FUTURE marker pauses, and is kept --"
+r=$(probe "$(python3 -c 'import time;print(int(time.time())+3600)')")
+[ "$r" = "1 1" ] && ok "future epoch pauses and the marker survives" || no "future epoch → '$r' (want '1 1')" "a live pause must hold and not delete itself"
+r=$(probe "$(python3 -c 'import datetime,time;print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(hours=1)).isoformat())')")
+[ "$r" = "1 1" ] && ok "future ISO-8601 pauses too (documented as accepted)" || no "future ISO → '$r' (want '1 1')" "the README documents both forms"
+
+echo "-- 2. anything that is NOT a future timestamp fails toward RUNNING, and self-clears --"
+# Each of these is a way an operator can leave a marker that must not disable the autopilot.
+for label in "past epoch:$(python3 -c 'import time;print(int(time.time())-60)')" "garbage:not-a-date" "empty:" "whitespace: "; do
+  name=${label%%:*}; body=${label#*:}
+  r=$(probe "$body")
+  [ "$r" = "0 0" ] && ok "$name → not paused, marker removed" \
+    || no "$name → '$r' (want '0 0')" "a marker that is not a future timestamp must be ignored AND removed, or a typo disables quota protection silently"
+done
+r=$(probe "__none__")
+[ "$r" = "0 0" ] && ok "no marker → not paused" || no "no marker → '$r' (want '0 0')"
+
+echo "-- 3. the pause is reachable from the docs, with the real path --"
+grep -qF 'quota-watch.paused' "$R" && ok "README names the marker file" \
+  || no "the capability is undocumented" "an undocumented operator feature in shared code is a personalization"
+grep -qiE 'Pausing the autopilot' "$R" && ok "it has a findable section heading" || no "no section for it"
+grep -qF 'CLAUDE_CONFIG_DIR' "$R" && ok "documents the path honours CLAUDE_CONFIG_DIR" \
+  || no "documents a hardcoded path" "_watch.py resolves CONFIG_DIR from CLAUDE_CONFIG_DIR first"
+grep -qiE 'expired \*?or\* ?malformed|malformed' "$R" && ok "documents the fail-toward-running behaviour" \
+  || no "auto-expiry/self-clearing undocumented" "the operator cannot rely on what is not written down"
+# the code's own path must match what the doc claims
+grep -qF '"quota-watch.paused"' "$W" && ok "code and doc name the same file" || no "the code's filename does not match the doc"
+
+echo
+echo "-- $PASS passed, $FAIL failed --"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
**The feature here is @fernandezdiegoh's, from #111** — his commit, his authorship, unchanged. It arrived alongside an unrelated fix, so I split it out rather than asking him to: the fix merges on its own, and the capability gets the paperwork a shared-code feature owes an operator.

Closes the review comment I left on #111. Nothing was owed by him — this is our side of it.

## Why it needed a door of its own

As it stood, an operator could not discover the pause: no documentation anywhere, no test, no CHANGELOG, and no stated format (the code accepts an epoch float *or* ISO-8601, which a reader had to infer from the source). Canonical's rule is the reviewer half of `custom/`-first — **an undocumented feature in shared code is a personalization**, however useful. It's useful, so it gets documented instead of removed.

## What this adds around his implementation

- **README § "Pausing the autopilot temporarily"**, placed beside the existing `switch` hatch — that one is *spatial* (force an account), this is *temporal* (suspend for a while). Both accepted formats, copy-pasteable macOS **and** Linux commands, and the note that the path honours `CLAUDE_CONFIG_DIR` rather than being hardcoded to `~/.claude`.
- **A row in § Files written**, flagged operator-written, since every other row there is something the tool writes.
- **`tests/quota-watch-pause.test.sh` (12 checks)** which **imports the shipped `paused_until()`** rather than re-implementing its parsing. A test that restates the logic it checks passes while the real function drifts.

## The contract the tests pin

**Fail-toward-running.** A future epoch or ISO-8601 marker pauses and is kept. A **past, malformed, empty, or whitespace-only** marker is ignored *and removed*, with the reason logged.

That asymmetry is the entire safety property, and it's his design — I only pinned it. A pause is the one operator capability whose failure mode is **silence**: a honoured stale marker leaves rotation off with nothing saying so, and the operator starts hitting caps believing the autopilot is running. *"A forgotten pause cannot silently disable the autopilot forever"* was in his comment, and it's the right instinct.

His implementation passed every one of those cases on the first run.

## Controls

Four mutations, all caught — because a suite nobody has seen fail is not a suite:

| mutation | caught by |
|---|---|
| honour a malformed marker | `garbage → '1 1' (want '0 0')` |
| stop removing expired markers | `past epoch → '0 1' (want '0 0')` |
| un-document the capability | `no section for it` |
| rename the file in code only | `future epoch → '0 0' (want '1 1')` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5bAJkH5o1snmjXYbqpzKB