### PR TITLE
fix(update): Step 2.7 held two rules for `mcps/_index.md`, and the data-losing one came first

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1054,6 +1054,15 @@ jobs:
         # produces the downgrade on the same inputs.
         run: bash tests/update-local-ahead.test.sh
 
+      - name: Step 2.7 gives one rule per dual-owned file, with no replaced prose left behind
+        # A session reads the spec top-down and acts on the FIRST matching instruction, so a
+        # stale description is not dead text -- it is the rule that runs. On 2026-09-08 an edit
+        # replaced the mcps/_index.md handling by anchoring on the code fence, which left the
+        # sentence introducing the OLD approach sitting above the new one: two contradictory
+        # rules for one file, data-losing one first. Only reading the spec as written catches
+        # this; a hand-run of the command follows intent and sails past it.
+        run: bash tests/update-dual-owned-rules.test.sh
+
       - name: the snapshot archiver survives concurrent writers
         # AI-102's whole point. The suite injects a realistic decide-to-write window into a
         # locked and an unlocked copy and races six writers through each: the unlocked control

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ## 2026-09-09 — A duplicate close, and a measurement that hid the damage it should have shown
 
-`hash: 49cd137 · 01b46ca · d580446 · 5a0b340 · fa03b0f` · [#112](https://github.com/The-AIOS/aios/pull/112) · [#113](https://github.com/The-AIOS/aios/pull/113) · [#117](https://github.com/The-AIOS/aios/pull/117)
+`hash: 49cd137 · 01b46ca · d580446 · 5a0b340 · fa03b0f` · [#112](https://github.com/The-AIOS/aios/pull/112) · [#113](https://github.com/The-AIOS/aios/pull/113) · [#111](https://github.com/The-AIOS/aios/pull/111) · [#117](https://github.com/The-AIOS/aios/pull/117) · [#118](https://github.com/The-AIOS/aios/pull/118) · [#119](https://github.com/The-AIOS/aios/pull/119)
 
 > **What you can now do.** Nothing new to learn — one thing stops going wrong. `/aios:close-session` no longer appends a second block to your daily note when the only commits since your last close belong to **other sessions**.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,14 @@ CI now enforces both halves, gated by event so an open PR is never failed for do
 
 **Action required:** none.
 
+### `/aios:update` held two contradictory rules for one file, and the losing one came first
+
+**What you can now do.** Nothing to change — but if you keep your own notes in `mcps/_index.md`, this protected them. Step 2.7 was carrying **two** rules for that file: the current one (keep your version and show you canonical's diff) and a replaced one that copied only your `## Bundling candidates` section forward — silently dropping anything you'd written elsewhere in the file. The replaced rule appeared **first**, and a session acts on the first instruction that matches.
+
+Both are cleaned up, and a check now asserts Step 2.7 states exactly one strategy per shared file with no prose from a replaced approach left behind.
+
+**Action required:** none. If you have written in `mcps/_index.md` outside the bundling-candidates section, it is worth a look — but the current rule never overwrites that file, so nothing should be missing.
+
 ### You can pause the quota autopilot for a while
 
 **What you can now do.** Suspend account rotation temporarily without uninstalling anything or editing thresholds — useful when you want to stay on one account through a piece of work. Write a future expiry into `~/.claude/quota-watch.paused`:

--- a/plugins/aios/commands/update.md
+++ b/plugins/aios/commands/update.md
@@ -474,7 +474,7 @@ For each changed Tier 1 file:
      # Report: old .gitignore backed up to vault/04 - backups/…, and say WHICH carry path ran.
    fi
    ```
-   For `marketplace.json`: apply the JSON union (its Tier-1 entry). For **`mcps/_index.md`**: take upstream's file, then carry the operator's `## Bundling candidates` body over upstream's — the heading is the ownership boundary, so no marker has to be introduced and a legacy copy needs no migration.
+   For `marketplace.json`: apply the JSON union (its Tier-1 entry).
    For **`mcps/_index.md`** the rule is **KEEP LOCAL AND REPORT, never merge and never overwrite.** A section-scoped splice was built and tested first and is deliberately *not* shipped: operators write wherever the point belongs — measured on a live vault, one addition sat in `## Bundling candidates` (which a splice carries) and another under `## Adding a new MCP` (which it silently dropped). Arbitrary prose in arbitrary sections has no mechanical merge, so the honest move is to protect the data and hand the human the delta:
 
    ```bash
@@ -491,7 +491,7 @@ For each changed Tier 1 file:
 
    This trades an automatic canonical update for a guarantee that nothing of the operator's is lost, which is the right side of that trade for a registry file: a missed canonical row is visible in the diff above and costs a manual paste, while a silent overwrite of their rows is unrecoverable without going to `vault/04 - backups/` — and backups are never auto-restored. If canonical's guidance in this file ever needs to reach every operator regardless, that is a CHANGELOG action item, not a silent replace.
 
-   These three never take the plain overwrite below.   These three never take the plain overwrite below.
+   These three never take the plain overwrite below.
 3. **Overwrite** (every OTHER changed file) using the right tool:
    - `.md` files **inside** `vault/` → `mcp__obsidian__write_note` (keeps Obsidian graph consistent)
    - `.md` files **outside** `vault/` (root + `hooks/`, `mcps/`, `plugins/`, `skills/`, `agents/`, `templates/`) → `Bash cp` or `Write`

--- a/tests/update-dual-owned-rules.test.sh
+++ b/tests/update-dual-owned-rules.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 2.7 must give exactly ONE strategy per dual-owned file, and must not
+# carry prose describing an approach that was replaced.
+#
+# WHY. Found by running /aios:update as the command rather than by hand. An edit
+# on 2026-09-08 replaced the mcps/_index.md handling: a section-scoped splice
+# was swapped for keep-local-and-report, because the splice silently dropped
+# operator additions written outside `## Bundling candidates`. The edit was
+# anchored on the CODE FENCE, so it replaced the implementation and left the
+# sentence that introduced it -- and that sentence came FIRST. Step 2.7 then
+# held two contradictory rules for one file, with the data-losing one on top,
+# plus a sentence duplicated onto itself.
+#
+# This is not a typo class. A session reads the spec top-down and acts on the
+# first instruction that matches, so a stale description is not dead text --
+# it is the rule that runs. Hand-executing the command cannot catch it, because
+# a hand-run follows intent; only reading the spec as written does.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+U=plugins/aios/commands/update.md
+[ -f "$U" ] || { echo "::error::$U missing"; exit 1; }
+
+# Step 2.7 only — a rule stated elsewhere (the Tier-1 entry) is a pointer, not a strategy.
+SEC=$(awk '/^2\.7\./{f=1} f&&/^3\. \*\*Overwrite\*\*/{exit} f' "$U")
+[ -n "$SEC" ] && ok "Step 2.7 extracted ($(printf '%s' "$SEC" | wc -l | tr -d ' ') lines)" \
+  || { no "could not extract Step 2.7" "the anchors moved; fix the extraction before trusting the rest"; echo; echo "-- $PASS passed, $FAIL failed --"; exit 1; }
+
+echo "-- 1. one strategy per dual-owned file --"
+# Each dual-owned file must be introduced exactly once in this section.
+for f in 'mcps/_index.md'; do
+  n=$(printf '%s' "$SEC" | grep -cF "For **\`$f\`**")
+  [ "$n" -eq 1 ] && ok "$f: exactly one strategy stated" \
+    || no "$f: $n strategy statements in Step 2.7" "a session acts on the FIRST match, so a second rule is not redundancy -- it is the rule that runs"
+done
+
+echo "-- 2. the replaced approach leaves no prose behind --"
+# The splice was abandoned because it drops additions outside one section. Any
+# surviving instruction to carry a single section back is the data-losing rule.
+printf '%s' "$SEC" | grep -qiE "carry the operator's \`## Bundling candidates\` body" \
+  && no "the abandoned section-splice is still instructed" "it silently drops operator additions written in any other section -- measured on a live vault" \
+  || ok "no instruction to splice a single section"
+# keep-local-and-report must be the one that IS stated
+printf '%s' "$SEC" | grep -qF 'KEEP LOCAL AND REPORT' \
+  && ok "keep-local-and-report is the stated rule" \
+  || no "keep-local-and-report is missing" "without it a session falls back to the plain overwrite, which loses the operator's registry rows"
+
+echo "-- 3. no sentence duplicated onto itself --"
+# The `X.   X.` shape is what a replace-by-anchor produces when the new text
+# ends with the same sentence the anchor preserved.
+dupes=$(printf '%s\n' "$SEC" | grep -oE '([A-Z][^.]{15,120}\.)[[:space:]]+\1' | head -3)
+[ -z "$dupes" ] && ok "no self-duplicated sentence in Step 2.7" \
+  || { no "a sentence is duplicated onto itself" "the tell of an anchored replace whose new text re-stated the anchor"; printf '%s\n' "$dupes" | sed 's/^/       /'; }
+
+echo
+echo "-- $PASS passed, $FAIL failed --"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
**Found by running `/aios:update` as the command rather than executing its steps by hand** — which is the only way this class of defect is visible. A hand-run follows *intent* and sails straight past a stale instruction; reading the spec as written hits it in the first thirty seconds.

Prompted by the operator asking whether I was actually running the command. I wasn't. This is what that cost.

## The defect

Yesterday's edit swapped the `mcps/_index.md` handling from a section-scoped splice to keep-local-and-report, because the splice silently dropped operator additions written outside `## Bundling candidates`. That change was **anchored on the code fence**, so it replaced the implementation and left the sentence introducing it — and that sentence came **first**:

```
line 477:  For **`mcps/_index.md`**: take upstream's file, then carry the operator's
           `## Bundling candidates` body over upstream's …          ← the ABANDONED rule
line 478:  For **`mcps/_index.md`** the rule is KEEP LOCAL AND REPORT, never merge
           and never overwrite …                                    ← the CURRENT rule
```

A session reads top-down and acts on the first instruction that matches. So that was not dead prose — **it was the rule that would run**, and it's the one that loses operator data. Line 494 also carried its trailing sentence duplicated onto itself, the other tell of an anchored replace whose new text restated its anchor.

## Why a check and not just a fix

This is a spec executed by a session, so its failure mode is *plausibility* — both sentences read fine in isolation, and nothing downstream errors. `tests/update-dual-owned-rules.test.sh` (5 checks) extracts Step 2.7 and asserts:

- exactly **one** strategy statement per dual-owned file
- **no** surviving instruction to splice a single section forward
- keep-local-and-report is the rule that *is* stated (so a future edit can't leave the file with no rule, falling back to the plain overwrite)
- no sentence duplicated onto itself

## Controls

The mutations **are the real defect, re-injected** — not invented cases:

| mutation | caught by |
|---|---|
| restore the abandoned splice sentence | `mcps/_index.md: 2 strategy statements in Step 2.7` |
| duplicate the trailing sentence | `a sentence is duplicated onto itself` |
| drop keep-local-and-report | `keep-local-and-report is missing` |

## Operator impact

Low, and worth stating precisely: no operator lost anything, because the *current* rule never overwrites that file and my own vault's sync had already taken the keep-local path. The risk was a session that read line 477 first and spliced — which would have dropped anything written outside one section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5bAJkH5o1snmjXYbqpzKB