### PR TITLE
fix(test): the hash check validated the field, not its elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ## 2026-09-09 — A duplicate close, and a measurement that hid the damage it should have shown
 
-`hash: 49cd137 · 01b46ca · d580446 · 5a0b340 · fa03b0f · ` · [#112](https://github.com/The-AIOS/aios/pull/112) · [#113](https://github.com/The-AIOS/aios/pull/113) · [#111](https://github.com/The-AIOS/aios/pull/111) · [#117](https://github.com/The-AIOS/aios/pull/117) · [#118](https://github.com/The-AIOS/aios/pull/118) · [#119](https://github.com/The-AIOS/aios/pull/119)
+`hash: 49cd137 · 01b46ca · d580446 · 5a0b340 · fa03b0f · 1f08508` · [#112](https://github.com/The-AIOS/aios/pull/112) · [#113](https://github.com/The-AIOS/aios/pull/113) · [#111](https://github.com/The-AIOS/aios/pull/111) · [#117](https://github.com/The-AIOS/aios/pull/117) · [#118](https://github.com/The-AIOS/aios/pull/118) · [#119](https://github.com/The-AIOS/aios/pull/119)
 
 > **What you can now do.** Nothing new to learn — one thing stops going wrong. `/aios:close-session` no longer appends a second block to your daily note when the only commits since your last close belong to **other sessions**.
 
@@ -103,6 +103,14 @@ It now compares the metric that actually triggered the swap. And a failed adopti
 **What you can now do.** Nothing to change — this one is about entries reaching you correctly. `CONTRIBUTING.md` told contributors to cite the PR number and add the hash after merge, without saying what the field holds meanwhile. It now says: **leave the line present with an empty value, never omit the line** — because the two mistakes are not symmetric. An empty value keeps the entry *shown* until a maintainer fills it. A missing line has nothing to test, so "already synced" is vacuously true and the entry is **silently skipped for every operator, forever.**
 
 CI now enforces both halves, gated by event so an open PR is never failed for doing the right thing: the line is required always, a filled value only once it lands on `main`.
+
+**Action required:** none.
+
+### The hash check I shipped this morning validated the field, not its elements
+
+**What you can now do.** Nothing to change — this closes a hole in the guard from earlier today. That check asserted the `hash:` field was non-empty once an entry reached `main`. It didn't look *inside*: a field like `` `hash: a · b · ` `` — the shape an unset variable produces — passed, and then the empty element exits 128 on the ancestor test, which is read as *"not synced"*, so the entry reads NEW for you forever. The same failure the check exists to prevent, one level down.
+
+It now validates **every** element as a short SHA, and the open-PR case is unchanged (an empty value is still correct before merge).
 
 **Action required:** none.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ## 2026-09-09 — A duplicate close, and a measurement that hid the damage it should have shown
 
-`hash: 49cd137 · 01b46ca · d580446 · 5a0b340 · fa03b0f · 1f08508` · [#112](https://github.com/The-AIOS/aios/pull/112) · [#113](https://github.com/The-AIOS/aios/pull/113) · [#111](https://github.com/The-AIOS/aios/pull/111) · [#117](https://github.com/The-AIOS/aios/pull/117) · [#118](https://github.com/The-AIOS/aios/pull/118) · [#119](https://github.com/The-AIOS/aios/pull/119)
+`hash: 49cd137 · 01b46ca · d580446 · 5a0b340 · fa03b0f · 1f08508` · [#112](https://github.com/The-AIOS/aios/pull/112) · [#113](https://github.com/The-AIOS/aios/pull/113) · [#111](https://github.com/The-AIOS/aios/pull/111) · [#117](https://github.com/The-AIOS/aios/pull/117) · [#118](https://github.com/The-AIOS/aios/pull/118) · [#119](https://github.com/The-AIOS/aios/pull/119) · [#120](https://github.com/The-AIOS/aios/pull/120)
 
 > **What you can now do.** Nothing new to learn — one thing stops going wrong. `/aios:close-session` no longer appends a second block to your daily note when the only commits since your last close belong to **other sessions**.
 

--- a/tests/changelog-entry-shape.test.sh
+++ b/tests/changelog-entry-shape.test.sh
@@ -65,8 +65,16 @@ hline=$(awk '/^## [0-9]{4}-[0-9]{2}-[0-9]{2}/{n++} n==1 && /^`hash:/{print; exit
   || no "the newest entry has NO \`hash:\` line" "with no hashes to test, the entry is silently skipped for every operator forever"
 if [ "${AIOS_CHANGELOG_REQUIRE_HASH:-0}" = "1" ]; then
   val=$(printf '%s' "$hline" | sed -E 's/^`hash:([^`]*)`.*/\1/' | tr -d ' ')
-  [ -n "$val" ] && ok "on main: the hash is filled ($val)" \
+  [ -n "$val" ] && ok "on main: the hash field is filled" \
     || no "on main: \`hash:\` is still empty" "fill it with the squash-merge commit; an empty value reads NEW for every operator until someone does"
+  # EVERY ELEMENT, not just the field. A trailing or interior empty element -- the shape
+  # `a · b · ` that an unset shell variable produces -- passes the non-empty test above and
+  # then exits 128 on the ancestor check, which the any-hash rule reads as "not synced", so
+  # the entry reads NEW forever. That is the exact failure this section exists to prevent,
+  # one level down, and it shipped to main once before this check existed.
+  bad=$(printf '%s' "$val" | awk -F'·' '{for(i=1;i<=NF;i++){e=$i; gsub(/^[ \t]+|[ \t]+$/,"",e); if(e=="") printf "%d ", i; else if(e !~ /^[0-9a-f]{7,40}$/) printf "%d(%s) ", i, e}}')
+  [ -z "$bad" ] && ok "on main: every hash element is a short SHA ($(printf '%s' "$val" | awk -F'·' '{print NF}') elements)" \
+    || no "on main: malformed hash element(s) at position $bad" "an empty or non-SHA element exits 128 on the ancestor test -> the entry reads NEW for every operator forever"
 else
   printf '  ok   hash value not required here (open PR: empty is the correct pre-merge state)\n'; PASS=$((PASS+1))
 fi


### PR DESCRIPTION
Self-inflicted, twice in the same field in one day — which is what makes it worth a mechanism rather than resolving to be more careful.

## What happened

This morning's check (#117) asserted `hash:` is non-empty once an entry is on `main`. It never looked *inside* the field.

An hour later I appended an empty element — `` `hash: a · b · ` `` — because a shell variable set in one tool call was unset in the next. **The check passed.** That element then exits 128 on `merge-base --is-ancestor`, which the any-hash rule reads as *"inconclusive, not synced"*, so the entry would read NEW for every operator forever.

That is exactly the failure #117 exists to prevent, one level down. The guard was satisfied by a weaker property than the one it names.

## The fix

- The live field on `main` is repaired (`1f08508` recorded).
- The strict check now validates **every** element against `^[0-9a-f]{7,40}$` and reports the offending position.
- #117's asymmetry is preserved and re-verified: strict mode runs only on a push to `main`, so an open PR with an empty value still passes (17/0 with strict off, 18/0 with it on).

## Controls

**M1 is the defect that actually shipped**, not an invented case:

| mutation | caught |
|---|---|
| trailing empty element | `malformed hash element(s) at position 7` |
| interior empty element | `position 2` |
| a PR number where a SHA belongs | `position 6(#119)` |
| truncated sha | `position 6(1f085)` |

## The process note, because it generalises

Compute and write a hash in **one** tool call. Shell state does not survive between them, so `$SQ` from a previous call expands to nothing — silently, no error, just a malformed field. Two of today's defects were that shape, and this check is what makes the third one impossible to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5bAJkH5o1snmjXYbqpzKB