### PR TITLE
feat(deck-builder,update): runtime click-nav toggle; a replaced Tier-1 doc says so

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1054,6 +1054,15 @@ jobs:
         # produces the downgrade on the same inputs.
         run: bash tests/update-local-ahead.test.sh
 
+      - name: the deck-builder binds every presenter key it advertises
+        # The agent tells operators which keys a generated deck answers to, in prose, while the
+        # bindings live far away in the toolkit code blocks. Nothing connected them, so either
+        # side could drift: a promised key that does nothing on stage, or a working one nobody
+        # is told about. The cost was already paid in the second direction -- a roadmap row
+        # claimed five kit items were missing when all five were bound, because the only way to
+        # check was to grep the dispatch by hand. Both sets are EXTRACTED, never restated.
+        run: bash tests/deck-builder-nav-kit.test.sh
+
       - name: Step 2.7 gives one rule per dual-owned file, with no replaced prose left behind
         # A session reads the spec top-down and acts on the FIRST matching instruction, so a
         # stale description is not dead text -- it is the rule that runs. On 2026-09-08 an edit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ## 2026-09-09 — A duplicate close, and a measurement that hid the damage it should have shown
 
-`hash: 49cd137 · 01b46ca · d580446 · 5a0b340 · fa03b0f · 1f08508 · d5f8312` · [#112](https://github.com/The-AIOS/aios/pull/112) · [#113](https://github.com/The-AIOS/aios/pull/113) · [#111](https://github.com/The-AIOS/aios/pull/111) · [#117](https://github.com/The-AIOS/aios/pull/117) · [#118](https://github.com/The-AIOS/aios/pull/118) · [#119](https://github.com/The-AIOS/aios/pull/119) · [#120](https://github.com/The-AIOS/aios/pull/120)
+`hash: 49cd137 · 01b46ca · d580446 · 5a0b340 · fa03b0f · 1f08508 · d5f8312` · [#112](https://github.com/The-AIOS/aios/pull/112) · [#113](https://github.com/The-AIOS/aios/pull/113) · [#111](https://github.com/The-AIOS/aios/pull/111) · [#117](https://github.com/The-AIOS/aios/pull/117) · [#118](https://github.com/The-AIOS/aios/pull/118) · [#119](https://github.com/The-AIOS/aios/pull/119) · [#120](https://github.com/The-AIOS/aios/pull/120) · [#121](https://github.com/The-AIOS/aios/pull/121)
 
 > **What you can now do.** Nothing new to learn — one thing stops going wrong. `/aios:close-session` no longer appends a second block to your daily note when the only commits since your last close belong to **other sessions**.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,19 +100,31 @@ It now compares the metric that actually triggered the swap. And a failed adopti
 
 ### An entry could ship with an empty `hash:` and read as new forever
 
-**What you can now do.** Nothing to change — this one is about entries reaching you correctly. `CONTRIBUTING.md` told contributors to cite the PR number and add the hash after merge, without saying what the field holds meanwhile. It now says: **leave the line present with an empty value, never omit the line** — because the two mistakes are not symmetric. An empty value keeps the entry *shown* until a maintainer fills it. A missing line has nothing to test, so "already synced" is vacuously true and the entry is **silently skipped for every operator, forever.**
-
-CI now enforces both halves, gated by event so an open PR is never failed for doing the right thing: the line is required always, a filled value only once it lands on `main`.
+**What you can now do.** Nothing to change. `CONTRIBUTING.md` never said what the `hash:` field holds before a PR merges. It now does: **keep the line, leave the value empty.** The two mistakes are not symmetric — an empty value keeps the entry *shown* until someone fills it, while a missing line is **silently skipped for every operator, forever.** CI enforces both, gated so an open PR is never failed for doing it right.
 
 **Action required:** none.
 
 ### The hash check I shipped this morning validated the field, not its elements
 
-**What you can now do.** Nothing to change — this closes a hole in the guard from earlier today. That check asserted the `hash:` field was non-empty once an entry reached `main`. It didn't look *inside*: a field like `` `hash: a · b · ` `` — the shape an unset variable produces — passed, and then the empty element exits 128 on the ancestor test, which is read as *"not synced"*, so the entry reads NEW for you forever. The same failure the check exists to prevent, one level down.
-
-It now validates **every** element as a short SHA, and the open-PR case is unchanged (an empty value is still correct before merge).
+**What you can now do.** Nothing to change — this closes a hole in the guard from earlier today. That check asserted the `hash:` field was non-empty; it didn't look *inside*. A field like `` `hash: a · b · ` `` passed, and the empty element then reads as *"not synced"*, so the entry shows as NEW for you forever. It now validates **every** element as a short SHA.
 
 **Action required:** none.
+
+### Press **C** mid-talk to turn click/tap-to-advance on or off
+
+**What you can now do.** Change your mind about tap-to-advance **during** a talk. `click-nav` in a deck's frontmatter was a build-time default: you decided at build time and lived with it. Now **C** toggles it live, with a toast naming the new state — useful when you end up presenting from a tablet you hadn't planned on, or when a deck turns out to be full of clickable demos and every stray tap jumps a slide.
+
+Mobile still defaults to tap-halves (touch has no keyboard) and **C** can now turn that off too. A click meant for something interactive never navigates: links, buttons, form fields, embedded players and iframes are all excluded, so a live demo inside a slide no longer advances it the first time anyone uses it.
+
+**Action required:** none — regenerate or rebuild a deck to pick it up.
+
+### A replaced `CLAUDE.md` is no longer reported as a plain success
+
+**What you can now do.** Find out, at the moment it happens, if a sync replaced a `CLAUDE.md` you had edited. Previously `/aios:update` backed the file up, overwrote it, and **reported success** — so an operator who had written their own rules there lost one that every session loads, and learned of it weeks later through agents quietly behaving differently. The backup didn't help, because backups are never auto-restored.
+
+The report now names the file, the backup path, **and where that kind of rule belongs instead** — `USER.md` → `## Command personalizations`, `INTENT.md`, or `context/declared/working_style.md`, which is read in full at every Session Start and is the one most people miss. It also says *why*: `CLAUDE.md` is shared infrastructure, and its value is being the same file for every operator. If your rule is good for everyone, the route is a PR rather than a local edit.
+
+**Action required:** none. If you have edited `CLAUDE.md`, consider moving those rules to one of the three homes above — they'll survive every sync there.
 
 ### `/aios:update` held two contradictory rules for one file, and the losing one came first
 

--- a/agents/aios/communication/deck-builder.md
+++ b/agents/aios/communication/deck-builder.md
@@ -134,7 +134,7 @@ Co-author the outline in a vault note:
   output: html                            # html (recommended) | slides
   pdf: no                                 # yes | no — Phase 3.B opt-in
   offline: no                             # yes | no — Phase 3.B opt-in (embed fonts for offline-safe HTML)
-  click-nav: off                          # off (default) | edges | halves — Feature 2: DESKTOP click-to-navigate zones. off = keyboard/clicker only. MOBILE always gets tap-nav ('halves') regardless — touch has no keyboard
+  click-nav: off                          # off (default) | edges | halves — Feature 2: DESKTOP click-to-navigate zones. A BUILD-TIME default only: C toggles off<->halves live during a talk. off = keyboard/clicker only. MOBILE always gets tap-nav ('halves') regardless — touch has no keyboard
   tiers:                                  # set in Phase 1.5 — drives the K toggle. Omit / "none" = single version (no K).
     short: Keynote                        # label for the core-only cut (evocative, honest-for-THIS-deck — NOT a hardcoded duration)
     full: Full                            # label for everything (core + full-tier slides)
@@ -301,7 +301,7 @@ imgs[0].save(PDF_OUT, save_all=True, append_images=imgs[1:],
 python3 "$WORK/build.py"
 ```
 
-- HTML lands at `vault/03 - export/decks/{DATE}-{SLUG}.html` — F11-presentable. The full nav kit is keyboard-driven: `← →`/space navigate · **F** fullscreen · **M** slide menu · **K** toggles the short cut ↔ full version (labels set per deck in Phase 1.5; absent when `tiers: none`) · **N** presenter notes (audience-invisible, never printed) · **S** search the deck (titles · slide text · notes, both languages) · **B** black out (for live demos) · type a number + Enter to jump · **?** help · Esc closes overlays. Clicks never navigate by default (`click-nav: off`) — opt into `edges`/`halves` per deck.
+- HTML lands at `vault/03 - export/decks/{DATE}-{SLUG}.html` — F11-presentable. The full nav kit is keyboard-driven: `← →`/space navigate · **F** fullscreen · **M** slide menu · **K** toggles the short cut ↔ full version (labels set per deck in Phase 1.5; absent when `tiers: none`) · **N** presenter notes (audience-invisible, never printed) · **S** search the deck (titles · slide text · notes, both languages) · **B** black out (for live demos) · type a number + Enter to jump · **?** help · **C** toggles click/tap-to-advance live · Esc closes overlays. Clicks never navigate by default (`click-nav: off`) — opt into `edges`/`halves` per deck.
 - PDF (if requested) lands at `~/Downloads/{DATE}-{SLUG}.pdf` — raster, instant-open, sharing copy.
 - `build.py` lives in `/tmp` and is **discarded** — not preserved in the vault. If the deck needs editing later, re-spawn `deck-builder` on the outline at `vault/03 - export/decks/outlines/{DATE}-{SLUG}.md`.
 
@@ -346,7 +346,7 @@ Joint review pass. Checklist depends on output-format from Phase 0.
 - [ ] Master HTML loads in browser: F enters fullscreen · M opens the slide menu · K toggles the short cut ⇄ full version using the Phase-1.5 labels (or is inert/absent when `tiers: none`) · B blacks out for a live demo · type-#-Enter jumps
 - [ ] **Presenter notes (N)** — N opens the panel; its accent tracks the *active slide's* `--accent` (not the root default — the 7/16 gotcha); `.s-notes` is invisible to the audience; nothing prints (`@media print` hides `.s-notes` + `#notes`)
 - [ ] **Deck search (S)** — S opens the palette; typing filters across slide titles / slide text / presenter notes in BOTH languages (`data-es` indexed); ↑↓ selects, Enter jumps (including to an off-cut slide, which shows a `not in this cut` badge), Esc closes; deck keys (K/T/B…) stay inert while the search input is focused
-- [ ] **Click-nav (`click-nav`)** — DESKTOP: with `off` (default) center + edge clicks never navigate (keyboard/clicker intact); with `edges`/`halves`, only the intended zones advance and clicks inside `#menu`/`#help`/`#search` never navigate. **MOBILE (touch / coarse pointer): always `halves` — tap-right advances, tap-left back — regardless of the config, so phone users (no keyboard) aren't stuck on slide 1**
+- [ ] **Click-nav (`click-nav`)** — DESKTOP: with `off` (default) center + edge clicks never navigate (keyboard/clicker intact); with `edges`/`halves`, only the intended zones advance and clicks inside `#menu`/`#help`/`#search` never navigate. **MOBILE (touch / coarse pointer): always `halves` — tap-right advances, tap-left back — regardless of the config, so phone users (no keyboard) aren't stuck on slide 1** **Runtime toggle:** press **C** — the mode flips off↔halves and a toast names the new state; press it again and the previous behaviour returns. Verify a click on a link, a button and an embedded iframe still does NOT advance while the toggle is on.
 
 Surface issues for user judgment — don't auto-fix in Phase 5. Surface + ask.
 
@@ -562,6 +562,14 @@ body.light .sr-row.sel,body.light .sr-row:hover{background:rgba(0,0,0,0.05);}
   function setMode(m){ if(!hasTiers) return; mode=m; const l=activeList();
     if(l.indexOf(current)<0){ const near=l.find(n=>n>=current)||l[l.length-1]; show(near); } else refresh();
     toast(mode==='keynote'?TIER.short:TIER.full); }
+  // ONE resolver for click-to-advance, read by both the click handler and the C toggle so they can
+  // never disagree. Precedence: runtime override (C) > mobile default > build-time `click-nav`.
+  // Mobile defaults to halves because touch has no keyboard; C still lets a presenter turn it off.
+  function clickNav(){
+    if(window.__CN != null) return window.__CN;
+    var isMobile = window.matchMedia && window.matchMedia('(pointer:coarse)').matches;
+    return isMobile ? 'halves' : (window.CLICK_NAV || 'off');
+  }
   let toastT; function toast(msg){ let el=document.getElementById('toast');
     if(!el){ el=document.createElement('div'); el.id='toast';
       el.style.cssText='position:fixed;top:22px;left:50%;transform:translateX(-50%);font-family:Inter,sans-serif;font-size:10.5px;letter-spacing:2.4px;text-transform:uppercase;color:var(--accent);background:var(--surface-1);border:1px solid var(--accent);padding:8px 16px;z-index:400;transition:opacity .4s;'; document.body.appendChild(el); }
@@ -595,14 +603,23 @@ body.light .sr-row.sel,body.light .sr-row:hover{background:rgba(0,0,0,0.05);}
     else if(k==='b'||k==='B'){ document.getElementById('blackout').classList.toggle('on'); }
     else if(k==='k'||k==='K'){ setMode(mode==='keynote'?'full':'keynote'); }
     else if(k==='s'||k==='S'){ if(searchEl.classList.contains('open')) closeSearch(); else openSearch(); e.preventDefault(); }
-    else if(k==='?'){ document.getElementById('help').classList.toggle('open'); } });
+    else if(k==='?'){ document.getElementById('help').classList.toggle('open'); }
+    // C — toggle click/tap-to-advance at RUNTIME. `click-nav` in frontmatter is a build-time
+    // default; a presenter discovers mid-talk that they want it (a tablet on a lectern) or that
+    // they do not (a deck full of clickable demos), and rebuilding is not an option on stage.
+    // Cycles off <-> halves only: `edges` is a deliberate build-time choice, not a stage decision.
+    else if(k==='c'||k==='C'){ window.__CN = (clickNav()==='off') ? 'halves' : 'off';
+      toast('Click to advance: ' + (window.__CN==='off' ? 'off' : 'on')); } });
   document.addEventListener('click',function(e){ if(e.target.closest('a'))return;
+    // Never steal a click meant for something interactive. `a` alone is not enough: a deck with a
+    // form control, an embedded player or a live iframe demo would advance the slide out from under
+    // the audience the first time anyone used it.
+    if(e.target.closest('button,input,select,textarea,summary,[contenteditable],iframe,video,audio'))return;
     if(e.target.closest('#menu')||e.target.closest('#help')||e.target.closest('#search'))return;
     if(document.getElementById('menu').classList.contains('open')||document.getElementById('help').classList.contains('open')){ closeAll(); return; }
     if(document.getElementById('blackout').classList.contains('on')){ document.getElementById('blackout').classList.remove('on'); return; }
     // Feature 2 — configurable click-to-nav. DESKTOP default off (clickers/keyboard drive; no accidental/interaction nav). MOBILE (touch / coarse pointer) ALWAYS gets tap-nav ('halves': tap-right advances, tap-left back) — touch has no keyboard, so without this a phone user is stuck on slide 1. Set window.CLICK_NAV = "off" | "edges" | "halves" for desktop.
-    var isMobile = window.matchMedia && window.matchMedia('(pointer:coarse)').matches;
-    var CN = isMobile ? 'halves' : (window.CLICK_NAV || 'off');
+    var CN = clickNav();                       // resolved per click, so C takes effect immediately
     if(CN==='off') return;
     var w = window.innerWidth, edge = w*0.05;
     if(CN==='edges'){ if(e.clientX<edge) step(-1); else if(e.clientX>w-edge) step(1); }

--- a/plugins/aios/commands/update.md
+++ b/plugins/aios/commands/update.md
@@ -434,6 +434,18 @@ For each changed Tier 1 file:
    - If `local != baseline` → the operator changed it, and **now ask the second question, because "changed" is two different situations:**
      - **`upstream == baseline`** (canonical never touched this file) → the local copy is **AHEAD**. **KEEP IT. Skip the overwrite entirely.** Report *"kept your newer version"*. This branch can only ever PREVENT a write, so it cannot introduce a new failure mode — and without it the command silently downgrades the file, reports success, and the operator must re-apply the same improvement on every sync forever.
      - **`upstream != baseline`** (both sides moved) → genuine divergence → **backup-on-divergence:** copy local to `vault/04 - backups/aios-update-{YYYY-MM-DD}/{flattened-path}.md` BEFORE overwrite.
+
+       **SAY SO — a replaced file must never be reported as a plain success.** The backup is not a remedy: this command already argues, about `mcps/custom/_index.md`, that *"backups are never auto-restored, so the default outcome was silent loss of their own content."* That reasoning applies here verbatim, and hardest to the files an operator reads without opening — a rule removed from `CLAUDE.md` does not surface as a missing file or a broken command. It surfaces as **agents quietly behaving differently, weeks later, with no event to trace back to.**
+
+       So the report for this branch names three things, always:
+
+       1. **the file**, by path — not a count, not "some files"
+       2. **the backup path** it was written to
+       3. **where that kind of rule belongs instead**, when the file is `CLAUDE.md`: `USER.md` → `## Command personalizations` · `INTENT.md` (autonomy and boundaries) · `vault/00 - notes/context/declared/working_style.md`, which is read **in full at every Session Start** and is the home operators most often miss.
+
+       For `CLAUDE.md` specifically, add one sentence of *why*, because without it the operator reasonably assumes a bug: **it is Tier-1 infrastructure and its value is being the same file for every operator** — one behavioural contract, improved once, inherited everywhere. A per-vault merge would institutionalise divergence, so the overwrite is the mechanism that keeps the contract shared rather than a lossy shortcut. If the rule they wrote is good for everyone, the route is a PR to canonical, not a local edit — say that too.
+
+       _(Reported by an operator, 2026-09-09, from a live sync where three of their own hunks left `CLAUDE.md` and the run reported success. They proposed a conflict-free three-way merge; that was declined for the architectural reason above, and this is the half of the report that survived the decision.)_
    - If baseline unreachable (cross-repo hash or `stored_hash=initial`) → conservative fallback: backup.
 2.7. **Dual-owned files MERGE, never overwrite** — `.gitignore` and `.claude-plugin/marketplace.json` (see their Tier-1 entries). **Skip the three-way backup for these** (the merge itself preserves operator content). For **`.gitignore`**: keep upstream's file (framework rules + the `AIOS-OPERATOR-IGNORES` marker) and append the operator's below-marker lines —
    ```bash

--- a/tests/deck-builder-nav-kit.test.sh
+++ b/tests/deck-builder-nav-kit.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# The presenter keys the deck-builder ADVERTISES must be the keys it BINDS.
+#
+# WHY. The agent tells operators, in prose, which keys a generated deck answers
+# to. Those bindings live far away in the toolkit code blocks. Nothing connected
+# the two, so the prose and the implementation could drift in either direction:
+# a promised key that does nothing (the operator presses it on stage), or a
+# working key nobody is told about.
+#
+# The cost was already paid once, in the other direction: a roadmap row was
+# written claiming five kit items were missing from the agent. All five were
+# bound. The row was written from a deck build without re-reading the agent, and
+# the only way to know was to grep the dispatch by hand -- which is exactly the
+# check that should not be manual.
+#
+# Extraction, never restatement: the advertised set is read from the kit line
+# the operator reads, and the bound set from the code the deck actually ships.
+# A guard that hardcoded either list would go green while the doc drifted.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+A=agents/aios/communication/deck-builder.md
+[ -f "$A" ] || { echo "::error::$A missing"; exit 1; }
+
+echo "-- 1. the advertised kit and the bound keys agree --"
+python3 - "$A" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+
+# ADVERTISED: the operator-facing kit line. Single-letter/?-bolded tokens on it.
+m = re.search(r'^.*full nav kit is keyboard-driven.*$', src, re.M)
+if not m:
+    print("  FAIL could not find the advertised kit line"); sys.exit(1)
+advertised = set(re.findall(r'\*\*([A-Za-z?])\*\*', m.group(0)))
+
+# BOUND: every single-character key the toolkit dispatches on, either shape.
+bound = set(re.findall(r"""k\s*===\s*'([A-Za-z?])'""", src)) | \
+        set(re.findall(r"""e\.key\s*===\s*'([A-Za-z?])'""", src))
+bound = {k.upper() if k.isalpha() else k for k in bound}
+adv   = {k.upper() if k.isalpha() else k for k in advertised}
+
+print(f"  advertised: {' '.join(sorted(adv))}")
+print(f"  bound:      {' '.join(sorted(bound))}")
+promised_unbound = sorted(adv - bound)
+bound_unadvertised = sorted(bound - adv)
+rc = 0
+if promised_unbound:
+    print(f"  FAIL advertised but NOT bound: {' '.join(promised_unbound)}")
+    print("     an operator presses it on stage and nothing happens"); rc = 1
+else:
+    print("  ok   every advertised key is bound")
+if bound_unadvertised:
+    print(f"  FAIL bound but NOT advertised: {' '.join(bound_unadvertised)}")
+    print("     a working capability nobody is told about is a capability nobody uses"); rc = 1
+else:
+    print("  ok   every bound key is advertised")
+sys.exit(rc)
+PY
+[ $? -eq 0 ] && ok "advertised ↔ bound parity holds" || no "the kit prose and the dispatch disagree" "extracted from both sides, so one of them drifted"
+
+echo "-- 2. the runtime click-nav toggle exists and is reachable --"
+grep -qE "k==='c'\|\|k==='C'" "$A" && ok "C is bound" || no "C is not bound" "click-nav would stay build-time only"
+grep -qF 'function clickNav()' "$A" && ok "one resolver both the click handler and C read" \
+  || no "no single clickNav() resolver" "two readers of the same setting drift into disagreeing"
+# the click path must go THROUGH the resolver, or the toggle silently does nothing
+grep -qF 'var CN = clickNav();' "$A" && ok "the click handler resolves per click (so C takes effect live)" \
+  || no "the click handler does not call clickNav()" "C would flip a variable nothing reads — a toggle that appears to work and does not"
+
+echo "-- 3. a click meant for something interactive never navigates --"
+guard=$(grep -oE "closest\('button,input[^']*'\)" "$A" | head -1)
+[ -n "$guard" ] && ok "interactive guard present: ${guard:0:58}…" \
+  || no "clicks are only guarded against links" "a form control, embedded player or iframe demo would advance the slide the first time anyone used it"
+for el in button input iframe; do
+  printf '%s' "$guard" | grep -qF "$el" && ok "guards $el" || no "does not guard $el"
+done
+
+echo "-- 4. the frontmatter says the setting is a build-time DEFAULT --"
+grep -qiE 'BUILD-TIME default only: C toggles' "$A" && ok "frontmatter points at the runtime toggle" \
+  || no "frontmatter reads as the final word" "an operator would not know C exists"
+
+echo
+echo "-- $PASS passed, $FAIL failed --"
+[ "$FAIL" -eq 0 ]

--- a/tests/update-local-ahead.test.sh
+++ b/tests/update-local-ahead.test.sh
@@ -80,5 +80,34 @@ grep -q 'is \*\*AHEAD\*\*' "$SPEC" && ok "spec names the AHEAD outcome" || no "s
 grep -q 'never DOWNGRADE' "$SPEC" && ok "the auto-apply rule states the downgrade limit" || no "auto-apply rule no longer qualifies itself"
 grep -q 'Known limit' "$SPEC" && ok "the DIVERGED limit is stated, not implied" || no "the known limit was dropped"
 
+
+# ── the BOTH-MOVED branch must report loudly, not as a plain success ─────────
+# Reported by an operator, 2026-09-09: three of their own hunks left CLAUDE.md
+# on a live sync and the run reported success. The merge they proposed was
+# declined on architecture (CLAUDE.md is Tier-1; its value is being the same
+# file for every operator). The SILENCE was not declined -- a rule removed from
+# the file every session loads does not surface as a missing file or a broken
+# command, it surfaces as agents behaving differently weeks later with nothing
+# to trace back to. And the backup is not a remedy: this spec argues in its own
+# words that "backups are never auto-restored".
+BM=$(awk '/upstream != baseline.*both sides moved/{f=1} f&&/^2\.7\./{exit} f' "$SPEC")
+[ -n "$BM" ] && ok "both-moved branch extracted" || no "could not extract the both-moved branch" "anchors moved"
+printf '%s' "$BM" | grep -qiE 'never be reported as a plain success|SAY SO' \
+  && ok "the branch forbids a silent success report" \
+  || no "a replaced file can still be reported as success" "the operator learns weeks later, from behaviour"
+printf '%s' "$BM" | grep -qF 'backup path' \
+  && ok "the report names the backup path" || no "the backup path is not required in the report"
+# the three legitimate homes, so the report ROUTES instead of only informing
+for home in 'Command personalizations' 'INTENT.md' 'working_style.md'; do
+  printf '%s' "$BM" | grep -qF "$home" && ok "routes to: $home" \
+    || no "does not route to $home" "a loud replace that teaches nothing is only a louder loss"
+done
+printf '%s' "$BM" | grep -qiE 'same file for every operator' \
+  && ok "states WHY, so the operator does not read it as a bug" \
+  || no "no reason given for the replace" "without it the operator reasonably assumes a defect"
+printf '%s' "$BM" | grep -qiE 'PR to canonical' \
+  && ok "offers the universal-rule route (PR), not just the personal ones" \
+  || no "does not mention upstreaming" "a good rule stuck in one vault is a loss too"
+
 printf '\nRESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Two independent items bundled into one sync, per the operator's request.

## 1 · Deck-builder — press **C** mid-talk

`click-nav` was **build-time only**, so a presenter who changed their mind during a talk had no move: a tablet turns up on the lectern, or a deck turns out to be full of clickable demos and every stray tap jumps a slide. Rebuilding is not an option on stage.

**C** now flips `off ↔ halves` live with a toast. Mobile still defaults to tap-halves (touch has no keyboard) and **C** can turn that off too.

One **`clickNav()` resolver** is read by *both* the click handler and the C binding — precedence runtime > mobile default > build-time. Two readers of the same setting is exactly how a toggle ends up appearing to work while the click path reads a different value, so there is deliberately only one.

**The interaction guard also widened.** Links were guarded; nothing else was. A form control, an embedded player or an iframe demo inside a slide advanced the deck the first time anyone touched it.

### A scope correction worth recording

The item also asked to fold in `M`, `?`, `B`, typed-number+Enter and `Home/End` as *missing*. **All five were already bound.** The request had been written from a deck build without re-reading the agent, which is entirely reasonable — the only way to know was to grep the key dispatch by hand.

So this ships the **one real gap** instead of re-adding five working features. And `tests/deck-builder-nav-kit.test.sh` (9 checks) is the thing whose absence made that hand-grep necessary: it **extracts** the advertised kit line the operator reads and the keys the toolkit actually binds, then compares them **both ways** — a promised key that does nothing on stage, and a working key nobody is told about, are both failures.

Advertised and bound are now both `? B C F K M N S`.

## 2 · `/aios:update` — a replaced Tier-1 doc must say so

Reported by an operator whose **three `CLAUDE.md` hunks left the file on a live sync while the run reported success.**

They proposed a conflict-free three-way merge. That was **declined on architecture**: `CLAUDE.md` is Tier-1 and its value is being *the same file for every operator*, so a per-vault merge institutionalises divergence with no way back — the overwrite is the mechanism that keeps the contract shared, not a lossy shortcut.

**The silence was not declined.** A rule removed from the file every session loads doesn't surface as a missing file or a broken command — it surfaces as agents quietly behaving differently weeks later, with nothing to trace back to. And the backup is no remedy: this spec already argues, in its own words, that *"backups are never auto-restored."*

The both-moved branch now names **the file**, **the backup path**, and **the three homes such a rule belongs in** (`USER.md` → `## Command personalizations` · `INTENT.md` · `working_style.md`, read in full at every Session Start and the one operators miss) — plus **why**, without which an operator reasonably reads it as a bug, plus the **PR route** when the rule is good for everyone. A loud replace that *routes* beats a silent one that teaches nothing.

## Controls

Six mutations, all caught:

| mutation | caught by |
|---|---|
| advertise a key nobody binds | `advertised but NOT bound: Z` |
| unbind `C` (the real gap, re-injected) | `advertised but NOT bound: C` |
| click handler bypasses the resolver | `does not call clickNav()` |
| narrow the guard back to links | `clicks are only guarded against links` |
| drop the say-so rule | `a replaced file can still be reported as success` |
| drop a route target | `does not route to working_style.md` |

## Notes

- **No vault-personal references.** The deck work was learned from live decks and described generically — the diff carries no deck names, paths, ventures or operator names, checked before commit.
- The budget guard caught its own author again: today's entry hit 1,532 words and was trimmed to **1,431** rather than raising the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5bAJkH5o1snmjXYbqpzKB