### PR TITLE
AI-126: Google connect in one command + Close of Day stays last

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1343,6 +1343,40 @@ jobs:
         # only there would reach fresh clones and no existing operator.
         run: bash tests/statusline-account-alias.test.sh
 
+      - name: the daily note's Close of Day block stays last
+        # Reported 2026-09-09 as "aios-note-append --before lands blocks at the end
+        # instead of above the marker". The history says otherwise: when those blocks
+        # were appended the note contained no `## Close of Day` at any line, so the end
+        # was the only correct place and the helper was right. The marker arrived later,
+        # inserted by /close-day mid-note, ABOVE session blocks already written below it.
+        #
+        # Worth a suite because the two commands share an invariant that neither one
+        # states on its own: /close-session inserts `--before "## Close of Day"`, so the
+        # marker being LAST is what keeps session blocks above it. Nothing connected the
+        # two, and /close-day never said where its block went. Checked end to end
+        # against the real helper, with a control that replays the buggy mid-note anchor
+        # -- a suite that cannot detect the defect it was written for measures nothing.
+        run: bash tests/daily-note-block-order.test.sh
+
+      - name: the Google connector's API set derives from one manifest
+        # The set of Google APIs an operator must enable existed in SIX places before
+        # AI-126 -- connector.json's --permissions, SETUP.md's prose, the setup doc's
+        # blockquote, TROUBLESHOOTING's service->API mapping, the oauth template's
+        # scopes array, and the folder README -- and they had drifted apart: one sent
+        # people to enable a Chat API nothing requests, another omitted Gmail, contacts
+        # and forms entirely.
+        #
+        # Nothing noticed because the failure is late and blames the wrong thing: a
+        # scope whose API is off consents fine, exposes the tool, and returns
+        # `403 SERVICE_DISABLED` on the first call, which reads as an auth problem. So
+        # the suite asserts the property rather than the current values -- one list,
+        # every permission group resolving through it, an unmapped group STOPPING the
+        # script, and no doc re-enumerating it. The drift scanner carries its own
+        # controls: each historical copy is replayed as a fixture and must still be
+        # caught, because a detector that cannot fail reports "clean" just as
+        # convincingly when it is broken.
+        run: bash tests/google-connect.test.sh
+
       - name: every non-ASCII-printing hook guards Windows stdout
         # Windows consoles are cp1252, so a print() carrying an em dash raises
         # UnicodeEncodeError and the hook does NOT RUN — the failure is absence, not a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,13 +68,33 @@
 >
 > A changelog that only lists *what changed* pushes comprehension-debt onto the operator — they'd have to read a skill's source to know what it does for their day. So every entry leads with a **"What you can now do"** section: the new capabilities in **plain language, with a concrete example**, phrased as things the operator can *do* now — not a component inventory. Keep the full component list too (for the record), but lead with the practical read, and flag the load-bearing behavioral changes worth an actual read. `/aios:update` surfaces this section to the operator after applying an entry, so their own Claude session tells them what the new version unlocks. **The rule:** *translate every shipped change into a capability the operator can use — or it isn't really shipped to them, just to the repo.*
 
-## 2026-09-11 — A refused login no longer reads as "offline — fine"
+## 2026-09-11 — Google in one command, a refused login that says so, and Close of Day back at the end
 
-`hash: 61e7d9c`
+`hash: 61e7d9c` · [#122](https://github.com/The-AIOS/aios/pull/122) · [#123](https://github.com/The-AIOS/aios/pull/123)
 
 > **What you can now do.** Tell a lost login from a lost network. `/today`'s framework and company freshness checks, and `/close-day`'s framework check, used to throw away git's error message — so *"GitHub refused this machine's key"* and *"no internet"* both printed `unreachable`, and the plan called that *"offline — fine for now"*. A machine whose key had been removed from its GitHub account was reassured every morning. The checks now run `hooks/freshness-probe.sh`, which keeps the error text and reports a new state, **`access-denied`**, whenever the server answered and refused the credential. `/today` shows it as a task naming the repo and the fix; `/close-day` puts it above the verdict line. A genuine outage still reads `unreachable`, and only that state is called offline.
 
 **Action required:** none — `/aios:update` lands it. If you added your own `USER.md` override for this, retire it once this lands (check: your `### /today` section names `freshness-probe.sh` from `hooks/custom/`). If a check has said `unreachable` on mornings when your network was fine, run `bash ~/aios/hooks/freshness-probe.sh` — it names the repo that is refusing you.
+
+### Google Workspace connects with one command
+
+**What you can now do.** Run `bash mcps/google-workspace-mcp/connect.sh`. It creates your Google Cloud project and enables every API the connector needs in a single call, then prints the steps Google publishes no API for — as links that land on the exact page for *your* project. Afterwards, `connect.sh --finish --project-id <id> --client <downloaded.json>` installs the credential and prints the `claude mcp add` line with the permission list already filled in. `--verify` re-checks the APIs later; `--dry-run` changes nothing; `--print-apis` shows just the list.
+
+It also checks the two things that used to fail *much* later: that the client you downloaded is a **Desktop** type (a Web client fails with `redirect_uri_mismatch`) and that it belongs to the project whose APIs were enabled (using one from another project is what `403 org_internal` means). Both now stop the run and name the fix.
+
+The API list is **derived** from the `--permissions` list in `mcps/google-workspace-mcp/connector.json` — the same manifest that registers the server. It used to be written out separately in five other places, and those had drifted apart: one sent you to enable a Chat API nothing requests, another omitted Gmail, contacts and forms entirely. That mismatch is the worst failure in this setup because it fails late and blames the wrong thing — consent succeeds, the tool appears, and the first call returns `403 SERVICE_DISABLED`, which reads like an auth problem. It can no longer be expressed.
+
+**No credential ships in the repo, deliberately.** A shared OAuth client carries a hard cap of **100 grants for the life of the project, unresettable** — it would work for a while and then fail for everyone after that, with nothing in the repo able to explain why. Your own project also avoids your Workspace admin's third-party app gate, since an internal app is trusted by default.
+
+**Action required:** none if Google already works for you — nothing about your existing setup changes. Setting it up for the first time, or redoing it: run `connect.sh` instead of the console walkthrough. It needs `gcloud` for the automated half; without `gcloud` it says so and stops, and `mcps/google-workspace-mcp/personal-account-setup.md` still carries the full manual path plus the one trap no script can remove — on a consumer `@gmail.com` account, an app left in *Testing* expires its refresh token every 7 days.
+
+### `## Close of Day` goes back to the end of your daily note
+
+**What you can now do.** Trust your daily note's order. `/close-day` now appends its `## Close of Day` block at the **end** of the note, and writes it through the same per-file locking helper `/close-session` uses.
+
+Two things were wrong. The command never said *where* its block went, so it could be anchored partway up the note — and every `## Session —` block already written below that point then sat **below** Close of Day. Because `/close-session` inserts its blocks with `--before "## Close of Day"`, the marker being last is exactly what keeps session blocks above it. Separately, `/close-day` wrote the note directly while every other writer took a lock; a session block landing between its read and its write was silently overwritten. Both are fixed by the same change.
+
+**Action required:** none — `/aios:update` lands it. If a recent daily note has `## Session —` blocks sitting below `## Close of Day`, move them above it by hand — nothing will reorder them for you.
 
 ## 2026-09-09 — A duplicate close, and a measurement that hid the damage it should have shown
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -329,39 +329,41 @@ claude mcp add obsidian -- npx -y @mauricio.wolff/mcp-obsidian@latest ~/aios/vau
 
 Enables Google Calendar, Tasks, Drive, Docs, Sheets, Slides, Gmail, Contacts and Forms.
 
-**First, create your own OAuth client.** OAuth credentials are per-person secrets, so the repo cannot ship them — it ships a template and gitignores the filled-in file. Follow [`mcps/google-workspace-mcp/personal-account-setup.md`](./mcps/google-workspace-mcp/personal-account-setup.md) (steps 0–4) to create a **Desktop app** OAuth client in Google Cloud Console, then:
+**One command does most of it:**
 
 ```bash
 cd ~/aios
-cp mcps/google-workspace-mcp/oauth.json.template mcps/google-workspace-mcp/oauth.json
-# edit oauth.json — paste your client_id + client_secret (the file is gitignored)
+bash mcps/google-workspace-mcp/connect.sh
 ```
 
-**Then register the server.** The server itself is installed on demand from PyPI by `uvx` — nothing to build, and you stay current with upstream (which ships frequently):
+It creates your Google Cloud project, enables every API the connector needs in a single call, and
+then prints the handful of console steps it cannot do — as links that land on the exact page for
+your project. After those, `connect.sh --finish --project-id <id> --client <downloaded.json>`
+installs the credential and prints the `claude mcp add` command with the permission list already
+filled in from the manifest. `--dry-run` changes nothing; `--verify` re-checks the APIs later.
 
-```bash
-cd ~/aios
-CLIENT_ID=$(python3 -c "import json; print(json.load(open('mcps/google-workspace-mcp/oauth.json'))['client_id'])")
-CLIENT_SECRET=$(python3 -c "import json; print(json.load(open('mcps/google-workspace-mcp/oauth.json'))['client_secret'])")
+**Why not all of it.** Google publishes an API for project creation and API enablement, and none for
+the consent screen or for creating an OAuth client. So the floor is one command plus roughly six
+clicks, and the script is explicit about which is which rather than implying it automated the lot.
 
-claude mcp add google-workspace \
-  -e GOOGLE_OAUTH_CLIENT_ID="$CLIENT_ID" \
-  -e GOOGLE_OAUTH_CLIENT_SECRET="$CLIENT_SECRET" \
-  -e MCP_SINGLE_USER_MODE=true \
-  -e USER_GOOGLE_EMAIL="you@company.io" \
-  -e WORKSPACE_MCP_CREDENTIALS_DIR="$HOME/.google_workspace_mcp/credentials" \
-  -- uvx workspace-mcp --single-user --permissions \
-  drive:full sheets:full slides:full docs:full calendar:full tasks:full \
-  gmail:full contacts:full forms:full
-```
+**The API list is not printed in this document, on purpose.** It is derived from the `--permissions`
+list in `mcps/google-workspace-mcp/connector.json` — the same manifest that registers the server —
+so a scope whose API is not enabled cannot be expressed. That failure is the worst one here: consent
+succeeds, the tool appears, and the first call returns `403 SERVICE_DISABLED`, which looks like an
+auth failure and is not. To see the list: `bash mcps/google-workspace-mcp/connect.sh --print-apis`.
 
-On first use, Claude opens a browser for Google OAuth consent.
+**No credential ships in this repo.** OAuth credentials are per-person secrets; a shared client
+would also carry a hard cap of 100 lifetime grants that cannot be reset, so it would work for a
+while and then fail for everyone after it with nothing in the repo able to explain why.
 
-> **Enable one Google API per service you list.** The permission list above spans nine services, so your Cloud project needs the matching nine APIs enabled — the core seven (Drive, Docs, Sheets, Slides, Calendar, Tasks, Gmail) **plus People API for `contacts` and Forms API for `forms`** (and Chat API if you add `chat`). A mismatch fails *late*: consent succeeds, the tool appears, then the call returns `403 SERVICE_DISABLED`, which looks like an auth failure and isn't. The error text includes a one-click activation URL. Enabling an API is a project setting, so no re-consent is needed. If you'd rather not enable the extras, drop `contacts:full` / `forms:full` from the list instead — an unused service costs nothing, but a listed-and-unenabled one produces a confusing error the first time you touch it.
+**Prefer to do it by hand, or have no `gcloud`?**
+[`mcps/google-workspace-mcp/personal-account-setup.md`](./mcps/google-workspace-mcp/personal-account-setup.md)
+has the full console walkthrough, the four failure modes with their causes, and the one trap no
+script can remove (a consumer-account app in *Testing* expires its refresh token every 7 days).
 
 > **Register it once, from your vault.** `claude mcp add` defaults to **local** scope, which is *per-directory* — the registration only applies to sessions started in that directory. Run it from `~/aios` and that covers vault sessions, which is where this MCP is used. Adding it again from another directory creates a **second, independent copy that silently drifts** (two registrations diverged exactly this way — one grew Gmail, the other didn't, and neither surface said so). If you genuinely want it everywhere, use one `--scope user` registration instead of several local ones.
 >
-> **Google Chat is supported but off by default.** The upstream server ships Chat tools (list spaces, read/search/send messages, reactions, attachments); this permission list omits them. To enable, add `chat:full` (or `chat:readonly`) — it requests **new OAuth scopes, so it triggers a fresh consent prompt**. Note that Google restricts *sending* to some space types when using user credentials rather than an app, so verify sending against your own spaces before relying on it.
+> **Google Chat is supported but off by default.** The upstream server ships Chat tools (list spaces, read/search/send messages, reactions, attachments); the manifest's permission list omits them. To enable, add `chat:full` (or `chat:readonly`) to `connector.json` — it requests **new OAuth scopes, so it triggers a fresh consent prompt**, and re-running `connect.sh` will enable its API. Note that Google restricts *sending* to some space types when using user credentials rather than an app, so verify sending against your own spaces before relying on it.
 
 ### 3. GitHub CLI
 

--- a/mcps/google-workspace-mcp/README.md
+++ b/mcps/google-workspace-mcp/README.md
@@ -22,12 +22,25 @@ Accounts (primary + optional personal) are configured in your `USER.md` → Sour
 
 ## Setup
 
-Full walkthrough: [`SETUP.md` → Google Workspace MCP](../../SETUP.md). In short:
+```bash
+bash connect.sh                # project + every API, then the clicks that are left
+bash connect.sh --finish --project-id <id> --client ~/Downloads/client_secret_*.json
+```
 
-1. Create your own **Desktop app** OAuth client — [`personal-account-setup.md`](./personal-account-setup.md), steps 0–4.
-2. `cp oauth.json.template oauth.json`, then paste your client id + secret. **`oauth.json` is gitignored** — OAuth credentials are per-person secrets and are never committed, which is why the repo ships only the template.
-3. Register with `claude mcp add … -- uvx workspace-mcp --single-user --permissions …`.
-4. The first call opens a browser for consent. Tokens cache in `~/.google_workspace_mcp/credentials/`.
+`connect.sh` creates the Cloud project, enables the APIs **derived from `connector.json`'s
+`--permissions`** (so a scope whose API is off cannot happen), and prints the console steps Google
+exposes no API for. `--finish` checks the downloaded client is a Desktop type belonging to that
+project — the two mistakes that otherwise surface much later as `redirect_uri_mismatch` and
+`403 org_internal` — installs it `0600` outside the vault, and prints the registration command.
+`--print-apis` shows the derived list; `--verify` re-checks it; `--dry-run` changes nothing.
+
+By hand instead: [`personal-account-setup.md`](./personal-account-setup.md) — full console
+walkthrough, plus the one trap no script removes (a consumer-account app in *Testing* expires its
+refresh token every 7 days). Longer context: [`SETUP.md` → Google Workspace MCP](../../SETUP.md).
+
+**No credential ships here.** `oauth.json` is gitignored — OAuth credentials are per-person secrets,
+so the repo carries only `oauth.json.template`. The first call opens a browser for consent; tokens
+cache in `~/.google_workspace_mcp/credentials/`.
 
 **Register it once, from `~/aios`.** `claude mcp add` defaults to *local* (per-directory) scope, so a registration made from a second directory becomes an independent copy that drifts — exactly how two registrations here ended up with different service lists, with no surface reporting the difference. If you want it available everywhere, use a single `--scope user` registration rather than several local ones.
 

--- a/mcps/google-workspace-mcp/TROUBLESHOOTING.md
+++ b/mcps/google-workspace-mcp/TROUBLESHOOTING.md
@@ -70,9 +70,12 @@ brand-new service like `chat` or `appscript` → both.
 **The procedure:**
 
 1. Edit the `--permissions` list (re-register, or edit the registration in place).
-2. **Enable the matching Google API** for each service you added — People for `contacts`,
-   Forms for `forms`, Google Chat for `chat`, Apps Script for `appscript`, Custom Search for
-   `search`. Do this *before* re-consenting, so you don't approve scopes and then still 403.
+2. **Enable the matching Google API** for each service you added:
+   `bash connect.sh --verify --project-id <id>` names anything missing and prints the command
+   that enables it — or just re-run `bash connect.sh --project-id <id>`, which enables the full
+   derived set again and is idempotent. Do this *before* re-consenting, so you don't approve
+   scopes and then still 403. (Which API serves which service is written once, in `connect.sh`'s
+   `api_for()`; it used to be repeated here and the two copies disagreed.)
 3. **Restart Claude Code.** A running MCP server keeps its old command line; re-registering
    does not reload it in place.
 4. Trigger any tool call → approve the consent prompt (incognito if you're signed into

--- a/mcps/google-workspace-mcp/UPSTREAM.md
+++ b/mcps/google-workspace-mcp/UPSTREAM.md
@@ -49,6 +49,8 @@ everyone else's behavior, which is harder to debug than either extreme.
 
 | File | Ours? | Purpose |
 |---|---|---|
+| `connect.sh` | AIOS | One-command setup: creates the Cloud project and enables every API, derived from `connector.json`'s `--permissions`. Prints the console-only steps Google exposes no API for. |
+| `connector.json` | AIOS | The manifest — registration command **and** the permission list every other surface derives from. The one place the service list is written. |
 | `oauth.json.template` | AIOS | Shape of the gitignored `oauth.json` you create. Credentials are per-person secrets; the repo ships only the template. |
 | `personal-account-setup.md` | AIOS | Google Cloud Console walkthrough — create a Desktop OAuth client, wire a personal/agent account. |
 | `TROUBLESHOOTING.md` | AIOS | Local-first recovery: stale token, scope mismatch, port held by a dead process. |

--- a/mcps/google-workspace-mcp/connect.sh
+++ b/mcps/google-workspace-mcp/connect.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# connect.sh — Google Workspace connector setup, in one command.
+#
+# Google exposes an API for exactly half of this. Project creation and API
+# enablement are automatable; the consent screen and the OAuth client are
+# console-only — no API exists for either, in any gcloud release. So this script
+# does not pretend to automate the whole thing. It does the two automatable
+# parts (which are also the two tedious ones), and hands you the rest as a short
+# numbered list of links that land on the exact page for YOUR project.
+#
+# The structural part of the fix is the API list. It is DERIVED from
+# connector.json's `--permissions` — the same manifest that registers the
+# server — rather than typed here. A scope whose API is not enabled is the
+# single most confusing failure in this setup: consent succeeds, the tool
+# appears, and the first call returns `403 SERVICE_DISABLED`, which reads like
+# an auth problem and is not. Deriving both lists from one source makes that
+# mismatch impossible to express rather than something a doc has to warn about.
+#
+# Three lists of this same fact existed before this script and all three
+# disagreed. That is what a hand-maintained list does, given enough time.
+#
+# Usage:
+#   bash connect.sh                      create a project, enable every API
+#   bash connect.sh --project-id ID      use a project you already have
+#   bash connect.sh --new                create another, even if one exists
+#   bash connect.sh --verify  --project-id ID    re-check the APIs are on
+#   bash connect.sh --finish  --project-id ID --client PATH.json
+#                                        install the downloaded client + print
+#                                        the registration command
+#   bash connect.sh --print-apis         print the derived API list and exit
+#   bash connect.sh --dry-run            say what would happen, change nothing
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$HERE/connector.json"
+CRED_DIR="${GOOGLE_WORKSPACE_CRED_DIR:-$HOME/.google_workspace_mcp}"
+
+MODE=connect
+PROJECT_ID=""
+CLIENT_JSON=""
+FORCE_NEW=0
+DRY_RUN=0
+
+b(){ printf '\033[1m%s\033[0m\n' "$1"; }
+say(){ printf '%s\n' "$1"; }
+die(){ printf '\n✗ %s\n' "$1" >&2; [ -n "${2:-}" ] && printf '  %s\n' "$2" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-id) PROJECT_ID="${2:-}"; shift 2 ;;
+    --client)     CLIENT_JSON="${2:-}"; shift 2 ;;
+    --new)        FORCE_NEW=1; shift ;;
+    --verify)     MODE=verify; shift ;;
+    --finish)     MODE=finish; shift ;;
+    --print-apis) MODE=print-apis; shift ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    -h|--help)    sed -n '4,34p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)             die "unknown argument: $1" "run with --help" ;;
+  esac
+done
+
+# ── the mapping: one permission group → the Google API that serves it ────────
+# This is the ONLY place an API name is written. Everything else derives.
+# A group with no row here is a hard failure, never a silent skip — see
+# derive_apis(). Adding a service to connector.json's --permissions without
+# adding its row here stops the script rather than shipping a half-enabled
+# project, which is the whole point.
+api_for(){
+  case "$1" in
+    drive)     printf 'drive.googleapis.com\n' ;;
+    docs)      printf 'docs.googleapis.com\n' ;;
+    sheets)    printf 'sheets.googleapis.com\n' ;;
+    slides)    printf 'slides.googleapis.com\n' ;;
+    calendar)  printf 'calendar-json.googleapis.com\n' ;;
+    tasks)     printf 'tasks.googleapis.com\n' ;;
+    gmail)     printf 'gmail.googleapis.com\n' ;;
+    contacts)  printf 'people.googleapis.com\n' ;;
+    forms)     printf 'forms.googleapis.com\n' ;;
+    chat)      printf 'chat.googleapis.com\n' ;;
+    search)    printf 'customsearch.googleapis.com\n' ;;
+    appscript) printf 'script.googleapis.com\n' ;;
+    *)         return 1 ;;
+  esac
+}
+
+# `openid`, `userinfo.email` and `userinfo.profile` are deliberately absent:
+# they are granted by the consent screen itself and have no API to enable.
+
+need_python(){
+  command -v python3 >/dev/null 2>&1 \
+    || die "python3 not found." "It reads connector.json. On macOS: xcode-select --install"
+}
+
+# Permission GROUPS, in manifest order: `drive:full` → `drive`.
+permission_groups(){
+  python3 - "$MANIFEST" <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception as e:
+    sys.exit("connector.json unreadable: %s" % e)
+args = d.get("register", {}).get("args", [])
+if "--permissions" not in args:
+    sys.exit("connector.json register.args has no --permissions list")
+out = []
+for a in args[args.index("--permissions") + 1:]:
+    if a.startswith("-"):
+        break
+    out.append(a.split(":")[0])
+if not out:
+    sys.exit("--permissions is present but empty")
+print("\n".join(out))
+PY
+}
+
+has_line(){ printf '%s\n' "$2" | grep -qx -- "$1"; }
+
+# Newline-separated API list on stdout. Non-zero if any group is unmapped.
+derive_apis(){
+  local groups g a apis="" unmapped=""
+  groups="$(permission_groups)" || return 1
+  while IFS= read -r g; do
+    [ -n "$g" ] || continue
+    if a="$(api_for "$g")"; then
+      has_line "$a" "$apis" || apis="${apis:+$apis
+}$a"
+    else
+      unmapped="$unmapped $g"
+    fi
+  done <<EOF
+$groups
+EOF
+  if [ -n "$unmapped" ]; then
+    printf 'no Google API is mapped for permission group(s):%s\n' "$unmapped" >&2
+    printf 'add a row to api_for() in %s — the manifest and this mapping must agree.\n' "$0" >&2
+    return 1
+  fi
+  printf '%s\n' "$apis"
+}
+
+# ── print-apis: the derivation, inspectable on its own ───────────────────────
+if [ "$MODE" = print-apis ]; then
+  need_python
+  APIS="$(derive_apis)" || die "could not derive the API list from connector.json"
+  printf '%s\n' "$APIS"
+  exit 0
+fi
+
+need_python
+APIS="$(derive_apis)" || die "could not derive the API list from connector.json"
+API_COUNT="$(printf '%s\n' "$APIS" | grep -c .)"
+
+# ── preflight ────────────────────────────────────────────────────────────────
+command -v gcloud >/dev/null 2>&1 || die \
+  "gcloud is not installed — this script needs it to create the project and enable APIs." \
+  "Install: https://cloud.google.com/sdk/docs/install  ·  then re-run this script.
+  Prefer to do it all by hand? personal-account-setup.md still has the full console walkthrough."
+
+ACCOUNT="$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null | head -1)"
+[ -n "$ACCOUNT" ] || die \
+  "gcloud is installed but not authenticated." \
+  "Run: gcloud auth login
+  Sign in as the ACCOUNT YOU WANT THE MCP TO ACT AS — the project must belong to it."
+
+DOMAIN="${ACCOUNT##*@}"
+case "$DOMAIN" in
+  gmail.com|googlemail.com) ACCOUNT_KIND=consumer ;;
+  *)                        ACCOUNT_KIND=workspace ;;
+esac
+
+# ── finish: install the downloaded client, then print the registration ───────
+if [ "$MODE" = finish ]; then
+  [ -n "$PROJECT_ID" ] || die "--finish needs --project-id (the project whose APIs were enabled)"
+  [ -n "$CLIENT_JSON" ] || die "--finish needs --client <path to the downloaded client_secret_*.json>"
+  [ -f "$CLIENT_JSON" ] || die "no such file: $CLIENT_JSON"
+
+  # Two traps that ARE readable, so they stop the run instead of surfacing later
+  # as `redirect_uri_mismatch` and `403 org_internal` — neither of which names
+  # its own cause.
+  CHECK="$(python3 - "$CLIENT_JSON" "$PROJECT_ID" <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception as e:
+    sys.exit("that file is not readable JSON: %s" % e)
+want = sys.argv[2]
+if "web" in d and "installed" not in d:
+    sys.exit("this is a WEB application client. The flow redirects to http://localhost, "
+             "which a Web client rejects with redirect_uri_mismatch.\n  "
+             "Create the client again with Application type = Desktop app.")
+if "installed" not in d:
+    sys.exit("this JSON has neither an `installed` nor a `web` client. "
+             "Download it again from the Clients page (the button is on the client's row).")
+got = d["installed"].get("project_id", "")
+if got and got != want:
+    sys.exit("this client belongs to project `%s`, but the APIs were enabled in `%s`.\n  "
+             "Using it is the cause of `403 org_internal` and of `SERVICE_DISABLED` errors.\n  "
+             "Download the client from %s, or re-run with --project-id %s." % (got, want, want, got))
+print(d["installed"].get("client_id", ""))
+PY
+)" || die "$CHECK"
+  CLIENT_ID="$CHECK"
+
+  mkdir -p "$CRED_DIR"
+  if [ "$DRY_RUN" = 1 ]; then
+    say "dry-run: would copy $CLIENT_JSON → $CRED_DIR/client_secret.json (chmod 600)"
+  else
+    cp "$CLIENT_JSON" "$CRED_DIR/client_secret.json" || die "could not write $CRED_DIR/client_secret.json"
+    chmod 600 "$CRED_DIR/client_secret.json"
+    say "✓ client installed at $CRED_DIR/client_secret.json (0600, machine-local, never in the vault)"
+  fi
+  say "✓ Desktop client, and it belongs to $PROJECT_ID"
+  say ""
+  b "Register the connector"
+  say "Run /aios:mcps-setup and pick Google Workspace, or register it directly:"
+  say ""
+  python3 - "$MANIFEST" "$CRED_DIR" <<'PY'
+import json, sys, shlex
+d = json.load(open(sys.argv[1]))
+reg = d.get("register", {})
+args = reg.get("args", [])
+cmd = ["claude", "mcp", "add", d.get("id", "google-workspace"), "--scope", "user",
+       "--env", "GOOGLE_CLIENT_SECRET_PATH=%s/client_secret.json" % sys.argv[2],
+       "--env", "OAUTHLIB_RELAX_TOKEN_SCOPE=1",
+       "--", reg.get("command", "uvx")] + args
+print("  " + " ".join(shlex.quote(c) for c in cmd))
+PY
+  say ""
+  say "Then restart your Claude session — MCP tools register at session start, so one added"
+  say "mid-session is not callable until the next one."
+  exit 0
+fi
+
+# ── verify: read the enabled APIs back ───────────────────────────────────────
+if [ "$MODE" = verify ]; then
+  [ -n "$PROJECT_ID" ] || die "--verify needs --project-id"
+  ENABLED="$(gcloud services list --enabled --project="$PROJECT_ID" --format='value(config.name)' 2>&1)" \
+    || die "could not list services for $PROJECT_ID" "$ENABLED"
+  MISSING=""
+  while IFS= read -r a; do
+    [ -n "$a" ] || continue
+    has_line "$a" "$ENABLED" || MISSING="${MISSING:+$MISSING }$a"
+  done <<EOF
+$APIS
+EOF
+  if [ -n "$MISSING" ]; then
+    say "✗ not enabled in $PROJECT_ID:"
+    for m in $MISSING; do say "    $m"; done
+    say ""
+    say "  Enable them:  gcloud services enable$(printf ' %s' $MISSING) --project=$PROJECT_ID"
+    exit 1
+  fi
+  say "✓ all $API_COUNT APIs enabled in $PROJECT_ID"
+  say "  (the consent screen and the client cannot be read back — Google exposes no API for"
+  say "   either. If the connector still fails, TROUBLESHOOTING.md maps each error to its page.)"
+  exit 0
+fi
+
+# ── connect: the main path ───────────────────────────────────────────────────
+b "Google Workspace connector"
+say "account:  $ACCOUNT"
+say "APIs:     $API_COUNT, derived from connector.json's --permissions"
+say ""
+
+if [ -z "$PROJECT_ID" ]; then
+  EXISTING="$(gcloud projects list --filter='projectId:aios-workspace-*' --format='value(projectId)' 2>/dev/null)"
+  if [ -n "$EXISTING" ] && [ "$FORCE_NEW" = 0 ]; then
+    say "You already have a project from a previous run:"
+    printf '%s\n' "$EXISTING" | sed 's/^/    /'
+    say ""
+    die "not creating a second one." \
+        "Re-run with --project-id <one of the above> to continue with it,
+  or --new to create another anyway."
+  fi
+  PROJECT_ID="aios-workspace-$(date +%y%m%d)-$(printf '%04d' $((RANDOM % 10000)))"
+  if [ "$DRY_RUN" = 1 ]; then
+    say "dry-run: would create project $PROJECT_ID"
+  else
+    say "Creating project $PROJECT_ID …"
+    OUT="$(gcloud projects create "$PROJECT_ID" --name='AIOS Google Workspace' 2>&1)" || {
+      case "$OUT" in
+        *already*in*use*|*ALREADY_EXISTS*)
+          die "project id $PROJECT_ID is taken (ids are globally unique across all of Google)." \
+              "Re-run — the suffix is random — or pass your own with --project-id." ;;
+        *)
+          die "gcloud projects create failed." "$OUT" ;;
+      esac
+    }
+    say "✓ project created"
+  fi
+else
+  say "Using project $PROJECT_ID"
+fi
+
+if [ "$DRY_RUN" = 1 ]; then
+  say "dry-run: would enable $API_COUNT APIs in $PROJECT_ID:"
+  printf '%s\n' "$APIS" | sed 's/^/    /'
+else
+  say ""
+  say "Enabling $API_COUNT APIs (one call — this is the step that takes ten searches in the console) …"
+  # shellcheck disable=SC2046  # deliberate split: gcloud takes the APIs as separate args
+  OUT="$(gcloud services enable $(printf '%s ' $APIS) --project="$PROJECT_ID" 2>&1)" \
+    || die "could not enable the APIs in $PROJECT_ID." "$OUT"
+  say "✓ enabled:"
+  printf '%s\n' "$APIS" | sed 's/^/    /'
+fi
+
+CONSOLE="https://console.cloud.google.com"
+say ""
+b "What is left — it is console-only, because Google publishes no API for it"
+say ""
+say "  1. Branding — app name + your email on the consent screen"
+say "     $CONSOLE/auth/branding?project=$PROJECT_ID"
+say ""
+if [ "$ACCOUNT_KIND" = workspace ]; then
+  say "  2. Audience → Internal"
+  say "     $CONSOLE/auth/audience?project=$PROJECT_ID"
+  say "     $ACCOUNT is a Workspace account, so Internal is available and is the one"
+  say "     you want: the app is internal to your org, trusted by default, with no test-user"
+  say "     list and no 7-day re-auth clock. (If your admin gates internal apps, this is the"
+  say "     step where you will find out — it is a one-line ask, not a review.)"
+else
+  say "  2. Audience → External, then add $ACCOUNT as a Test user"
+  say "     $CONSOLE/auth/audience?project=$PROJECT_ID"
+  say "     A consumer account has no organization, so External is the only option Google"
+  say "     offers — and the account must be on the test-user list or consent returns"
+  say "     403 access_denied."
+  say ""
+  say "     ⚠ Testing expires the refresh token after 7 days. It fails weeks later, on a"
+  say "       machine you are not watching, as \`invalid_grant\` — the single most expensive"
+  say "       trap in this setup, because it does not fail during setup. If anything"
+  say "       scheduled depends on this connector, publish the app (Audience → Publish app)"
+  say "       and read what Google asks of you at that screen before assuming it is free:"
+  say "       Gmail and Drive are sensitive scopes."
+fi
+say ""
+say "  3. Create the OAuth client — Application type: Desktop app — and download the JSON"
+say "     $CONSOLE/auth/clients/create?project=$PROJECT_ID"
+say "     Desktop is required: it is the only type that allows the http://localhost redirect"
+say "     this flow uses. A Web client fails with redirect_uri_mismatch."
+say ""
+b "Then come back and run"
+say "  bash $0 --finish --project-id $PROJECT_ID --client ~/Downloads/client_secret_*.json"
+say ""
+say "It checks the client is Desktop and belongs to this project — the two mistakes that"
+say "otherwise surface much later as redirect_uri_mismatch and 403 org_internal — installs"
+say "it 0600 outside the vault, and prints the registration command."
+say ""
+say "Re-check the APIs any time:  bash $0 --verify --project-id $PROJECT_ID"

--- a/mcps/google-workspace-mcp/oauth.json.template
+++ b/mcps/google-workspace-mcp/oauth.json.template
@@ -2,23 +2,5 @@
   "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
   "client_secret": "YOUR_CLIENT_SECRET",
   "token_uri": "https://oauth2.googleapis.com/token",
-  "scopes": [
-    "https://www.googleapis.com/auth/documents",
-    "https://www.googleapis.com/auth/drive.file",
-    "https://www.googleapis.com/auth/documents.readonly",
-    "https://www.googleapis.com/auth/presentations.readonly",
-    "https://www.googleapis.com/auth/calendar.events",
-    "https://www.googleapis.com/auth/calendar.readonly",
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/tasks",
-    "https://www.googleapis.com/auth/tasks.readonly",
-    "https://www.googleapis.com/auth/drive",
-    "https://www.googleapis.com/auth/userinfo.email",
-    "https://www.googleapis.com/auth/drive.readonly",
-    "https://www.googleapis.com/auth/userinfo.profile",
-    "openid",
-    "https://www.googleapis.com/auth/calendar",
-    "https://www.googleapis.com/auth/presentations",
-    "https://www.googleapis.com/auth/spreadsheets.readonly"
-  ]
+  "_scopes": "Not configured here. The server requests scopes from the --permissions list in connector.json; run `bash connect.sh --print-apis` for the APIs those need enabled."
 }

--- a/mcps/google-workspace-mcp/personal-account-setup.md
+++ b/mcps/google-workspace-mcp/personal-account-setup.md
@@ -1,100 +1,204 @@
-# Google Workspace MCP — Personal-Account Setup
+# Google Workspace MCP — Setup
 
-> **Purpose.** Wire the `google-workspace-mcp` to a **personal Google account** (e.g. an agent's own gmail like `your-agent@gmail.com`), so the agent can read/act on Drive, Docs, Sheets, Slides, Calendar, Tasks, and Gmail for that account — including folders **shared with** it.
+> **Purpose.** Wire the `google-workspace-mcp` to a Google account so an agent can read and act on
+> Drive, Docs, Sheets, Slides, Calendar, Tasks, Gmail, contacts and Forms for that account —
+> including folders **shared with** it.
 >
-> Written from a real setup (2026-07-22) on a fortress agent machine. Uses the **local** MCP (its own OAuth client, `uvx`-launched) per the AIOS MCP policy — not the claude.ai-hosted Google connector, which is bound to the active claude.ai OAuth grant and breaks on account switch.
+> Uses the **local** MCP (its own OAuth client, `uvx`-launched) per the AIOS MCP policy — not the
+> claude.ai-hosted Google connector, which is bound to the active claude.ai OAuth grant and breaks
+> on an account switch.
 
-## The three traps (read first — they cost the most time)
+---
 
-1. **`Error 403: org_internal` — "can only be used within its organization."**
-   The OAuth client belongs to a Google Cloud project whose consent screen is **Internal** (locked to a Workspace org). A **personal gmail can never use an Internal client.** → Create a **fresh project under the personal account itself** (no org → **External** consent available). Do *not* reuse a client from a work/org project.
+## Start here — one command
 
-2. **`Error 403: access_denied` — "has not completed the Google verification process / developer-approved testers."**
-   The app is in **Testing** mode and the account isn't on the test-user list. → Add the account as a **Test user** (below). Testing + test-user is enough to *authorize* and gets you running today — but it is **not a permanent state**. See trap #3, which is the bill for stopping here.
+```bash
+bash mcps/google-workspace-mcp/connect.sh
+```
 
-3. **The whole thing works, then dies exactly 7 days later — `invalid_grant: Token has been expired or revoked`.**
-   Google expires the **refresh token** of an app whose publishing status is **Testing** after 7 days. Nothing is misconfigured and nothing was revoked by a human: the grant reached its built-in expiry.
+It creates a Google Cloud project and enables every API the connector needs, then prints the few
+steps that are left as links that land on the exact console page for **your** project.
 
-   This is the trap that costs the most over the life of the setup, and it costs the most *because it does not fail during setup*. Traps #1 and #2 fail loudly while you are still holding the context — you are in the console, you read the error, you fix it. This one fails on a Tuesday three weeks later, on a machine you are not looking at, and it presents as "the MCP broke" rather than "a policy clock ran out". Whatever depends on this server — a daily-ritual pipeline, a scheduled routine, an agent that reads your calendar every morning — goes dark once a week until a human clicks through a consent screen. The setup guide is the only place that can warn you, because by the time it happens nobody connects the symptom to the step that caused it.
+**Why only "most of it".** Google publishes an API for project creation and API enablement, and
+publishes none for the consent screen or for creating an OAuth client — not in any `gcloud` release.
+So the honest split is: the script does the two automatable parts, which are also the two tedious
+ones, and hands you roughly six clicks it cannot do. It does not pretend otherwise, and it does not
+leave you a half-configured project if it stops.
 
-   → **The lever is the publishing status, not verification.** The 7-day clock is attached to **Testing**; moving the app to **In production** (Audience → *Publish app*) is what stops it. Publishing and *being verified* are two different things — an app can sit in Production **unverified**, still showing the "Google hasn't verified this app" screen this document already tells you to expect.
+Then, after the clicks:
 
-   → **Check what Google asks of you before assuming it is free, because this MCP uses sensitive scopes.** Gmail and Drive are not the basic `email`/`profile`/`openid` trio; they are the scope classes that pull an app into Google's verification requirements, and the requirements (and any user caps on an unverified Production app) are Google's to change, not this document's to promise. **Read what the Audience screen tells you at the moment you click Publish** — that is the only current answer. If it does ask for verification and you do not want to go through it, that is a real decision, not a formality.
+```bash
+# installs the client you downloaded, checks it, prints the registration command
+bash mcps/google-workspace-mcp/connect.sh --finish --project-id <your-project> \
+     --client ~/Downloads/client_secret_*.json
 
-   → **Whichever way you go, write the cost down** next to whatever depends on this server. Staying in Testing means **a manual re-auth every 7 days, forever** — a legitimate choice for a throwaway experiment, and the wrong default for a server a daily automation depends on, which is exactly what this document is setting up.
+# re-check the APIs at any time
+bash mcps/google-workspace-mcp/connect.sh --verify --project-id <your-project>
+```
 
-## Part A — Google Cloud Console (the human clicks)
+`--dry-run` shows what would happen and changes nothing. `--print-apis` prints just the API list.
 
-**0. Sign in as the target account.** Open [console.cloud.google.com](https://console.cloud.google.com) **signed in as the personal gmail you're wiring** (use a clean browser profile / incognito so it doesn't grab a work account). This is what makes the consent screen External.
+### What the script checks, and what it can only tell you
 
-**1. New project** — project dropdown → New Project → name it (e.g. `my-agent-workspace-mcp`) → **Location: No organization** → Create → select it.
+Four things used to go wrong here, and they were documented as *"traps — read first."* A trap that
+has to be read is a trap that gets sprung, so three of the four are now checks:
 
-**2. Enable APIs** — APIs & Services → **Library** → enable each (search → Enable). **Enable one API per service you put in `--permissions`** — the two lists must match, or the server starts fine and the tools 403 at call time:
-> **Drive · Docs · Sheets · Slides · Calendar · Tasks · Gmail** — the core seven
-> **People API** ← required for `contacts:full` · **Forms API** ← required for `forms:full` · **Google Chat API** ← required for `chat:full`
+| What went wrong | Now |
+|---|---|
+| A scope is granted but its **API was never enabled** → consent succeeds, the tool appears, and the first call returns `403 SERVICE_DISABLED`, which reads like an auth problem and is not | **Cannot happen.** The API list is derived from the same `--permissions` in `connector.json` that registers the server. One list, so there is nothing to mismatch. |
+| The OAuth client came from a **different project** → `403 org_internal` | **Checked.** `--finish` reads the client's own `project_id` and refuses if it is not the project whose APIs were enabled. |
+| The client was created as **Web application** instead of Desktop → `redirect_uri_mismatch` | **Checked.** `--finish` refuses a Web client and names Desktop as the fix. |
+| The account is not on the **test-user list** → `403 access_denied` | **Told, not checked** — no API exposes the consent screen. The script shows the step only when your account type can actually hit it, with a link to the page. |
 
-*A mismatch here fails late and confusingly.* The scope is granted, OAuth consent succeeds, the tool is exposed — and then the call returns `403 SERVICE_DISABLED: <API> has not been used in project <N> before or it is disabled`, which reads like an auth problem but isn't. If you see that, the error text carries a direct activation URL; open it, enable, wait a minute, retry. No re-consent needed — enabling an API is a project setting, not a scope change.
+The API list is not written in this document on purpose. It used to be, and it drifted: this file
+listed an API nothing requested, while a third copy elsewhere omitted three services entirely.
+Nobody noticed, because a wrong API list fails late and blames the wrong thing. To see the list:
 
-*(Other AIOS tools use other Google APIs — Generative Language/Gemini for nano-banana, YouTube Data, Analytics — enable those only if you use those tools; they're not needed for this MCP.)*
+```bash
+bash mcps/google-workspace-mcp/connect.sh --print-apis
+```
 
-**3. OAuth consent screen** (new UI may call this **Google Auth Platform**):
-- **User type / Audience: External** ← the fix for trap #1.
-- App name + user-support email + developer email = the personal gmail.
-- **Audience → Test users → + Add users →** the personal gmail → **Save** ← the fix for trap #2.
-- Leave in **Testing** (do not publish).
+### The one trap no script can remove — a 7-day clock
 
-**4. Create the client** — Credentials → **+ Create Credentials → OAuth client ID → Application type: Desktop app** → Create → **Download JSON** (it's `client_secret_*.json`, type `installed`). Desktop type is required — it allows the `http://localhost` redirect the flow uses.
+**On a consumer Google account** (`@gmail.com`), the consent screen has no organization to be
+internal to, so the app is External and starts in **Testing**. Google expires the **refresh token**
+of a Testing app after **7 days**. Nothing is misconfigured and nobody revoked anything: the grant
+reached its built-in expiry, and it presents as `invalid_grant: Token has been expired or revoked`.
 
-## Part B — Wire it (the agent runs)
+This is the most expensive item on the page *because it does not fail during setup.* The other three
+fail while you are still holding the context — you are in the console, you read the error, you fix
+it. This one fails on a Tuesday three weeks later, on a machine you are not watching. Anything that
+depends on the server — a daily ritual, a scheduled routine, an agent that reads your calendar each
+morning — goes dark once a week until a human clicks through a consent screen.
 
-**Nothing to install** — the server is fetched from PyPI on demand by `uvx` (see [`UPSTREAM.md`](./UPSTREAM.md)). Skip straight to the credentials.
+- **The lever is the publishing status, not verification.** The 7-day clock is attached to
+  **Testing**. Moving the app to **In production** (Audience → *Publish app*) is what stops it.
+  Publishing and *being verified* are different things: an app can sit in Production **unverified**,
+  still showing the "Google hasn't verified this app" screen.
+- **Read what Google asks of you at that screen before assuming it is free.** Gmail and Drive are
+  not the basic `email`/`profile`/`openid` trio — they are the scope classes that pull an app into
+  Google's verification requirements, and those requirements are Google's to change, not this
+  document's to promise. The Audience screen at the moment you click Publish is the only current
+  answer. If it does ask for verification and you would rather not, that is a real decision.
+- **Either way, write the cost down** next to whatever depends on this server. Staying in Testing
+  means a manual re-auth **every 7 days, forever** — fine for a throwaway experiment, wrong for a
+  server a daily automation depends on.
 
-Stash the downloaded client securely (out of Downloads, machine-local, never in the vault):
+**On a Workspace account** (any other domain) none of this applies: the app is Internal to your own
+organization, trusted by default, with no test-user list and no 7-day clock. If your Workspace admin
+gates internal apps you will find out at the Audience step — that is a one-line ask, not a review.
+
+---
+
+## Doing it by hand
+
+The script is the path; this is the reference for when it stops, or when you would rather not
+install `gcloud`. Same outcome, more clicks.
+
+**0. Sign in as the target account.** Open [console.cloud.google.com](https://console.cloud.google.com)
+signed in as **the account you are wiring** (a clean browser profile or incognito, so it does not
+grab a different one). This is what decides whether the consent screen can be External.
+
+**1. New project** — project dropdown → New Project → name it → for a consumer account set
+**Location: No organization** → Create → select it.
+
+**2. Enable the APIs** — APIs & Services → **Library** → search and Enable each one. Get the list
+from `connect.sh --print-apis`; **one API per service in `--permissions`**, and the two lists must
+match or the server starts fine and the tools 403 at call time.
+
+*A mismatch here fails late and confusingly.* The scope is granted, consent succeeds, the tool is
+exposed — then the call returns `403 SERVICE_DISABLED: <API> has not been used in project <N> before
+or it is disabled`. The error text carries a direct activation URL; open it, enable, wait a minute,
+retry. No re-consent is needed — enabling an API is a project setting, not a scope change.
+
+*(Other AIOS tools use other Google APIs — Gemini for image generation, YouTube Data, Analytics.
+Enable those only if you use those tools; none is needed for this MCP.)*
+
+**3. Consent screen** (the console may call it **Google Auth Platform**):
+- **Audience: Internal** on a Workspace account · **External** on a consumer account — a consumer
+  account can never use an Internal client, which is what `403 org_internal` means.
+- App name + user-support email + developer email.
+- **External only: Audience → Test users → + Add users →** your account → **Save**.
+
+**4. Create the client** — Clients → **+ Create client → Application type: Desktop app** → Create →
+**Download JSON** (it arrives as `client_secret_*.json`, type `installed`). Desktop is required: it
+is the only type that allows the `http://localhost` redirect this flow uses.
+
+---
+
+## Wire it
+
+**Nothing to install** — the server is fetched from PyPI on demand by `uvx` (see
+[`UPSTREAM.md`](./UPSTREAM.md)). `connect.sh --finish` does the next two steps for you, including
+the checks above; by hand it is:
+
 ```bash
 mkdir -p ~/.google_workspace_mcp
 cp ~/Downloads/client_secret_*.json ~/.google_workspace_mcp/client_secret.json
 chmod 600 ~/.google_workspace_mcp/client_secret.json
 ```
 
-Register the MCP at **user scope**, pointing at that file (creds land in `~/.claude.json`, machine-local):
+Then register at **user scope** (creds land in `~/.claude.json`, machine-local). `--finish` prints
+this command with the manifest's own permission list already filled in, which is the version to
+prefer — a hand-typed permission list is a fourth copy of the same fact:
+
 ```bash
 claude mcp add google-workspace --scope user \
   --env GOOGLE_CLIENT_SECRET_PATH="$HOME/.google_workspace_mcp/client_secret.json" \
   --env OAUTHLIB_INSECURE_TRANSPORT=1 \
   --env OAUTHLIB_RELAX_TOKEN_SCOPE=1 \
-  -- uvx workspace-mcp --single-user --tool-tier core
+  -- uvx workspace-mcp --single-user --permissions <from connector.json>
 ```
-- **`--single-user`** = bypass multi-user session mapping; use the one token in the credentials dir. Right for an agent that IS one account.
-- **`GOOGLE_CLIENT_SECRET_PATH`** > inline `GOOGLE_OAUTH_CLIENT_ID/SECRET` — keeps the secret in a `600` file, not the process args.
-- **`OAUTHLIB_RELAX_TOKEN_SCOPE=1`** — Google silently adds `openid`; without this the flow errors on "scope changed."
 
-## Part C — Authorize the account (one-time consent)
+- **`--single-user`** = bypass multi-user session mapping; use the one token in the credentials dir.
+  Right for an agent that IS one account.
+- **`GOOGLE_CLIENT_SECRET_PATH`** > inline `GOOGLE_OAUTH_CLIENT_ID/SECRET` — keeps the secret in a
+  `600` file, not in the process args.
+- **`OAUTHLIB_RELAX_TOKEN_SCOPE=1`** — Google silently adds `openid`; without this the flow errors
+  on "scope changed."
 
-The server does OAuth on first tool call and catches the redirect at **`localhost:8000` on the machine running the MCP**. The redirect MUST reach that machine:
+## Authorize the account (one-time consent)
+
+The server does OAuth on first tool call and catches the redirect at **`localhost:8000` on the
+machine running the MCP**. The redirect MUST reach that machine:
+
 - **At the machine's screen:** open the consent URL there.
-- **Remote (e.g. a headless machine):** tunnel first, then open the URL on your laptop:
-  ```bash
-  ssh -L 8000:localhost:8000 <the-mcp-host>
-  ```
+- **Remote / headless:** tunnel first, then open the URL on your laptop —
+  `ssh -L 8000:localhost:8000 <the-mcp-host>`.
 
-To drive it without a session restart, run a one-shot consent (`from_client_secrets_file` + `run_local_server(port=8000)`), which prints the URL and, on success, writes the token to `~/.google_workspace_mcp/credentials/{email}.json` in the store's exact format (`token, refresh_token, token_uri, client_id, client_secret, scopes, expiry`). Run it **unbuffered** (`python -u`) or the URL stays stuck in the stdout buffer while `run_local_server` blocks.
+To drive it without a session restart, run a one-shot consent (`from_client_secrets_file` +
+`run_local_server(port=8000)`), which prints the URL and, on success, writes the token to
+`~/.google_workspace_mcp/credentials/{email}.json` in the store's exact format (`token,
+refresh_token, token_uri, client_id, client_secret, scopes, expiry`). Run it **unbuffered**
+(`python -u`) or the URL stays stuck in the stdout buffer while `run_local_server` blocks. If the
+long URL gets mangled in a chat → terminal → browser hop, `make_auth_link.py` rebuilds it as a
+clickable page.
 
-At the consent screen you'll see **"Google hasn't verified this app"** — this is expected for a Testing app (not a block): **Advanced → Go to {app} (unsafe) → continue → approve.**
+At the consent screen you will see **"Google hasn't verified this app"** — expected for a Testing
+app, not a block: **Advanced → Go to {app} (unsafe) → continue → approve.**
 
-## Part D — Verify + use
+## Verify + use
 
-- **Token:** `~/.google_workspace_mcp/credentials/{email}.json` — confirm `refresh_token: yes` (self-renews; no constant re-auth).
-- **Smoke test** (Drive `sharedWithMe`) confirms the account + that shared folders are visible before reloading anything.
-- **To use the MCP tools in a Claude session, restart the session** — MCP tools register at session start, so an MCP added mid-session isn't callable until the next start. After restart, `mcp__google-workspace__*` tools are live and `--single-user` uses the stored token.
+- **Token:** `~/.google_workspace_mcp/credentials/{email}.json` — confirm `refresh_token: yes`
+  (it self-renews; no constant re-auth).
+- **APIs:** `connect.sh --verify --project-id <your-project>` names anything missing and prints the
+  command that enables it.
+- **Smoke test** (Drive `sharedWithMe`) confirms the account and that shared folders are visible
+  before reloading anything.
+- **Restart your Claude session** to use the tools — MCP tools register at session start, so one
+  added mid-session is not callable until the next start. After the restart the
+  `mcp__google-workspace__*` tools are live and `--single-user` uses the stored token.
 
 ## Gotchas condensed
+
 | Symptom | Cause | Fix |
 |---|---|---|
-| `403 org_internal` | client from an org/Internal project | new project under the personal account, External consent |
+| `403 org_internal` | client from an org/Internal project, used by a consumer account | new project under that account, External consent — `--finish` catches this before it happens |
 | `403 access_denied` (testers) | account not a test user | add it under Audience → Test users |
-| `invalid_grant` after ~7 days | app publishing status still **Testing** | move it to **In production** (trap #3) — check what Google asks at that screen; these are sensitive scopes |
-| `redirect_uri_mismatch` | client isn't Desktop type | recreate as Desktop, or add `http://localhost:8000/` |
+| `403 SERVICE_DISABLED` | the scope's API is not enabled | `connect.sh --verify` names it; the error text also carries a direct activation link |
+| `invalid_grant` after ~7 days | publishing status still **Testing** | move it to **In production**; read what Google asks at that screen — these are sensitive scopes |
+| `redirect_uri_mismatch` | client is not Desktop type | recreate as Desktop — `--finish` catches this before it happens |
 | consent URL never prints | Python stdout buffered while `run_local_server` blocks | run `python -u` / `PYTHONUNBUFFERED=1` |
-| "scope has changed" error | Google added `openid` | `OAUTHLIB_RELAX_TOKEN_SCOPE=1` |
+| "scope has changed" | Google added `openid` | `OAUTHLIB_RELAX_TOKEN_SCOPE=1` |
 | tools missing after wiring | MCP added mid-session | restart the Claude session |
 | redirect fails when remote | `localhost:8000` hit the wrong machine | `ssh -L 8000:localhost:8000 <host>` |

--- a/plugins/aios/commands/close-day.md
+++ b/plugins/aios/commands/close-day.md
@@ -102,7 +102,37 @@ Apply the result from step 1's `.aios-update` check (BEHIND / synced / access-de
 
 ## Output
 
-Append to the daily note being closed (may be today or yesterday if closing after midnight):
+**Write it through the race-safe helper, at the END of the note.** Both halves of that are
+load-bearing, and both were learned from the same incident (2026-09-09, operator-reported):
+
+```bash
+# write the block below to a temp file first, then:
+~/aios/hooks/aios-note-append \
+  --note "$HOME/aios/vault/01 - calendar/{YYYY-MM}/{YYYY-MM-DD}.md" \
+  -m "Close day {YYYY-MM-DD} — {verdict in a few words}" \
+  --block-file /tmp/aios-close-day-block.$$.md
+```
+
+- **No `--before`** — the helper appends at the end, which is exactly where this block goes.
+  **`## Close of Day` is the LAST section of the note**, after every `## Session —` block. This is
+  not cosmetic: `/close-session` inserts its blocks with `--before "## Close of Day"`, so the
+  marker being last is what keeps session blocks *above* it. Anchor this block anywhere else —
+  the Energy note, the close-day question, wherever the eye lands while reading the note — and
+  every session block already written below that point ends up **below Close of Day**, which is
+  what an operator sees and reports.
+- **Through the helper, not a direct write.** A lock only works if every writer takes it. The
+  note is written concurrently by `/close-session` (including `--auto` broadcasts closing several
+  sessions at once), and those take a per-file lock and re-read the latest note under it. A
+  direct read-modify-write here does not, so a session block landing between this command's read
+  and its write is **silently overwritten** — the failure that costs a session its capture with
+  nothing reporting it.
+
+**Updating an existing block** (the note already has a `## Close of Day` — re-running on the same
+day) is the one case the helper cannot do, since it appends rather than replacing a section. Then:
+re-read the note immediately before writing, merge into the existing section rather than adding a
+second one, and **never relocate an existing `## Session —` block** while doing it.
+
+The block, appended to the daily note being closed (may be today or yesterday if closing after midnight):
 
 ```
 ---

--- a/tests/daily-note-block-order.test.sh
+++ b/tests/daily-note-block-order.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# The daily note's section order — `## Close of Day` stays last (AI-126 bundle)
+#
+# Reported 2026-09-09: two `--auto` close blocks "landed BELOW Close of Day".
+# The reported cause was `aios-note-append --before` failing to find its marker.
+# The git history says otherwise — at 18:43 and 19:20, when those two blocks were
+# appended, the note contained NO `## Close of Day` at any line, so appending at
+# the end was the only correct action and the helper did it correctly. The marker
+# appeared at 20:11, inserted by /close-day at line 153 of a note whose session
+# blocks already ran to line 267.
+#
+# So the defect was placement by /close-day, and the helper was sound. This suite
+# asserts the CONTRACT rather than either implementation's current text, because
+# the contract is what the two commands share:
+#
+#   Close of Day is the LAST section. /close-session inserts before it, so the
+#   marker being last is exactly what keeps session blocks above it.
+#
+# It is checked end to end against the real helper — a close-day append followed
+# by a session close — so it fails if either side stops holding up its half.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; return 0; }
+
+HELPER="$PWD/hooks/aios-note-append"
+CLOSE_DAY="plugins/aios/commands/close-day.md"
+CLOSE_SESSION="plugins/aios/commands/close-session.md"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+[ -x "$HELPER" ] || { printf '  FAIL  %s missing or not executable\n' "$HELPER"; exit 1; }
+
+# a throwaway repo, because the helper commits through aios-commit
+mk_note(){ # $1 = note contents on stdin → echoes the note path
+  local d="$TMP/repo-$RANDOM"; mkdir -p "$d"
+  ( cd "$d" && git init -q . \
+      && git config user.email t@example.com && git config user.name t )
+  cat > "$d/note.md"
+  ( cd "$d" && git add -A && git commit -qm init )
+  printf '%s\n' "$d/note.md"
+}
+append(){ # $1 = note · $2 = block text file · $3.. = extra args
+  local n="$1" b="$2"; shift 2
+  ( cd "$(dirname "$n")" && "$HELPER" --note "$n" --block-file "$b" -m "probe" --no-push "$@" ) >/dev/null 2>&1
+}
+headings(){ grep '^## ' "$1" | sed 's/ *|.*//'; }
+
+echo "── 1. the specs agree on the contract ──"
+grep -q -- '--before "## Close of Day"' "$CLOSE_SESSION" \
+  && ok "/close-session inserts before the Close of Day marker" \
+  || no "/close-session no longer uses --before \"## Close of Day\"" \
+        "if that changed, the ordering contract changed with it — update this suite deliberately"
+grep -q 'aios-note-append' "$CLOSE_DAY" \
+  && ok "/close-day writes through the locking helper" \
+  || no "/close-day does not reference aios-note-append" \
+        "a lock only works if EVERY writer takes it; a direct write here clobbers a concurrent session block"
+grep -qiE 'LAST section|at the END of the note' "$CLOSE_DAY" \
+  && ok "/close-day names the end of the note as the insertion point" \
+  || no "/close-day never says WHERE its block goes" \
+        "unstated placement is how it landed mid-note above two session blocks"
+
+echo "── 2. helper: marker ABSENT → append at end ──"
+# This is the case the incident was blamed on. It is correct behaviour: with no
+# marker in the file there is nowhere else for the block to go.
+N="$(printf '%s\n' '# Day' '' '## Energy note' '_Close-day question: did it land?_' | mk_note)"
+printf '%s\n' '## Session — 18:05 | first' 'body' > "$TMP/b1.md"
+append "$N" "$TMP/b1.md" --before "## Close of Day"
+if [ "$(headings "$N" | tail -1)" = "## Session — 18:05" ]; then
+  ok "no marker → block appended at the end"
+else
+  no "unexpected order with the marker absent" "$(headings "$N" | tr '\n' '|')"
+fi
+
+echo "── 3. helper: marker PRESENT → insert above it ──"
+N="$(printf '%s\n' '# Day' '' '## Session — 18:05 | first' 'body' '' '## Close of Day' 'verdict' | mk_note)"
+printf '%s\n' '## Session — 19:19 | second' 'body' > "$TMP/b2.md"
+append "$N" "$TMP/b2.md" --before "## Close of Day"
+GOT="$(headings "$N" | tr '\n' '|')"
+[ "$GOT" = "## Session — 18:05|## Session — 19:19|## Close of Day|" ] \
+  && ok "marker present → inserted above it, after the earlier session" \
+  || no "insertion landed wrong" "$GOT"
+
+echo "── 4. END TO END — close-day appends last, then two sessions close ──"
+# The actual reported sequence, with the fixed ordering: sessions run, close-day
+# appends its block at the END (no --before), then later sessions close against
+# the marker. Close of Day must still be last and no session may be below it.
+N="$(printf '%s\n' '# Day' '' '## Energy note' '_Close-day question: did it land?_' | mk_note)"
+printf '%s\n' '## Session — 18:05 | first' 'body' > "$TMP/s1.md"
+printf '%s\n' '## Close of Day' 'verdict' > "$TMP/cd.md"
+printf '%s\n' '## Session — 18:42 | second' 'body' > "$TMP/s2.md"
+printf '%s\n' '## Session — 19:19 | third'  'body' > "$TMP/s3.md"
+append "$N" "$TMP/s1.md" --before "## Close of Day"   # marker absent → end
+append "$N" "$TMP/cd.md"                              # close-day: NO --before
+append "$N" "$TMP/s2.md" --before "## Close of Day"
+append "$N" "$TMP/s3.md" --before "## Close of Day"
+GOT="$(headings "$N" | tr '\n' '|')"
+WANT="## Energy note|## Session — 18:05|## Session — 18:42|## Session — 19:19|## Close of Day|"
+[ "$GOT" = "$WANT" ] && ok "Close of Day is last; all three sessions above it" \
+  || no "ordering broke" "got:  $GOT
+        want: $WANT"
+BELOW="$(sed -n '/^## Close of Day/,$p' "$N" | grep -c '^## Session —' || true)"
+[ "$BELOW" = 0 ] && ok "no session block below Close of Day" \
+  || no "$BELOW session block(s) below Close of Day — the reported symptom"
+
+echo "── 5. CONTROL — the buggy placement must FAIL this suite ──"
+# Anchoring the close-day block mid-note is what actually happened. If this suite
+# cannot tell that apart from the fixed order, it is not measuring anything.
+N="$(printf '%s\n' '# Day' '' '## Energy note' '_Close-day question: did it land?_' | mk_note)"
+append "$N" "$TMP/s1.md" --before "## Close of Day"
+append "$N" "$TMP/cd.md" --before "_Close-day question"   # the bug: mid-note anchor
+append "$N" "$TMP/s2.md" --before "## Close of Day"
+BELOW="$(sed -n '/^## Close of Day/,$p' "$N" | grep -c '^## Session —' || true)"
+if [ "$BELOW" -ge 1 ]; then
+  ok "control: a mid-note anchor puts $BELOW session(s) below the marker (detected)"
+else
+  no "control: the buggy placement produced a CLEAN note" \
+     "this suite would pass against the defect it exists to catch"
+fi
+
+printf '\n%d passed · %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/fixtures/google-connect-enum-scan.py
+++ b/tests/fixtures/google-connect-enum-scan.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Find docs that re-enumerate the Google APIs an operator must enable (AI-126).
+
+The API set is derived from connector.json's --permissions. Any doc that also
+lists it is a second copy, and the copies drifted: one sent operators to enable
+a Chat API nothing requested, another omitted three services entirely, and a
+third disagreed with both.
+
+Two things make this harder than grepping for a literal, and each one is a way
+the drift actually hid:
+
+  1. The worst copy was PROSE -- "the core seven (Drive, Docs, Sheets, Slides,
+     Calendar, Tasks, Gmail) plus People API for contacts" -- so a search for
+     `*.googleapis.com` would not have found it at all.
+  2. In another the instruction and the list were on DIFFERENT lines: an
+     "Enable APIs" step followed by a blockquote naming the services. A
+     per-line check misses that, so this scans a small window.
+
+The discriminator is enable-language. A line that names services without it is
+a value statement ("enables Calendar, Tasks, Drive ...") or diagnostic advice
+("`list_spreadsheets` goes through the Drive API, so it passes even when Sheets
+and Docs are disabled") -- both legitimate, neither a list to maintain. Note
+that `disabled` deliberately does not match: that sentence describes a symptom,
+it does not hand anyone a checklist.
+"""
+import glob
+import re
+import sys
+
+NAMES = ["Drive", "Docs", "Sheets", "Slides", "Calendar", "Tasks", "Gmail",
+         "People", "Forms", "Chat", "Contacts", "Apps Script", "Custom Search"]
+TARGETS = ["SETUP.md", "README.md", "CHEATSHEET.md", "TOOLS.md"]
+WINDOW = 3
+
+# An INSTRUCTION puts its verb next to its object: "Enable the matching Google
+# API", "needs the matching nine APIs enabled". Prose that merely happens to use
+# both words does not -- "the Tasks source is enabled but never queried [...] get
+# the ID from the Tasks API" has 150 characters between them and is a note about
+# a different thing entirely. Requiring proximity, in either order, is what keeps
+# this guard off correct text; a guard that fires on correct text gets switched
+# off, which is worse than not having it.
+INSTRUCTION_RE = re.compile(
+    r"[Ee]nabl\w*.{0,40}?\bAPIs?\b" r"|" r"\bAPIs?\b.{0,40}?[Ee]nabl\w*")
+
+
+def names_in(text):
+    return sum(1 for s in NAMES if re.search(r"\b%s\b" % s, text))
+
+
+hits = []
+for f in TARGETS + sorted(glob.glob("mcps/google-workspace-mcp/*.md")):
+    try:
+        lines = open(f, encoding="utf-8").read().split("\n")
+    except OSError:
+        continue
+    for i in range(len(lines)):
+        chunk = " ".join(lines[i:i + WINDOW])   # one line, so proximity spans the window
+        if INSTRUCTION_RE.search(chunk) and names_in(chunk) >= 3:
+            hits.append("%s:%d" % (f, i + 1))
+            break  # one report per file is enough to fail the build
+
+print(" ".join(hits))
+sys.exit(0)

--- a/tests/google-connect.test.sh
+++ b/tests/google-connect.test.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# connect.sh — the Google connector's one-command setup (AI-126)
+#
+# The thing worth asserting is the DERIVATION, not the happy path. Before this
+# script, the set of Google APIs an operator had to enable was written down in
+# three places — connector.json's `--permissions`, the setup doc's numbered
+# list, and the oauth template's `scopes` array — and all three had drifted
+# apart: the doc told you to enable a Chat API nothing requested, and the
+# template's scopes omitted Gmail, contacts and forms entirely.
+#
+# Nobody noticed because the failure is late and misleading. A scope whose API
+# is off consents fine, exposes the tool, and returns `403 SERVICE_DISABLED` at
+# the first call, which reads like an auth problem. So this suite asserts the
+# property that makes that impossible: exactly ONE list exists, every permission
+# group resolves through it, and an unmapped group STOPS the script instead of
+# quietly producing a half-enabled project.
+#
+# The gcloud stub is what makes the rest testable — every mutating path is
+# exercised without a Google account, and the stub records its calls so
+# `--dry-run` can be proven to mutate nothing rather than assumed to.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; return 0; }
+
+SCRIPT="mcps/google-workspace-mcp/connect.sh"
+MANIFEST="mcps/google-workspace-mcp/connector.json"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+[ -f "$SCRIPT" ] || { printf '  FAIL  %s does not exist\n' "$SCRIPT"; exit 1; }
+
+# ── a gcloud that records instead of calling Google ──────────────────────────
+mk_gcloud(){ # $1 = bin dir · $2 = "authed"|"anon" · $3 = existing project ids (may be empty)
+  mkdir -p "$1"
+  cat > "$1/gcloud" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "\$GCLOUD_LOG"
+case "\$1 \$2" in
+  "auth list")      [ "$2" = authed ] && printf 'operator@%s\n' "\$STUB_DOMAIN" ;;
+  "projects list")  printf '%s\n' "$3" ;;
+  "projects create") exit 0 ;;
+  "services enable") exit 0 ;;
+  "services list")  printf '%s\n' "\$STUB_ENABLED" ;;
+esac
+exit 0
+STUB
+  chmod +x "$1/gcloud"
+}
+
+run(){ # run connect.sh with a controlled PATH; echoes output, sets RC
+  local bin="$1"; shift
+  OUTPUT="$(PATH="$bin:$PATH" bash "$SCRIPT" "$@" 2>&1)"; RC=$?
+}
+
+echo "── 1. the API set derives from connector.json, and covers every group ──"
+PERM_GROUPS="$(python3 -c '
+import json,sys
+a=json.load(open(sys.argv[1]))["register"]["args"]
+print("\n".join(x.split(":")[0] for x in a[a.index("--permissions")+1:] if not x.startswith("-")))' "$MANIFEST")"
+NGROUPS="$(printf '%s\n' "$PERM_GROUPS" | grep -c .)"
+APIS="$(bash "$SCRIPT" --print-apis 2>&1)"; RC=$?
+NAPIS="$(printf '%s\n' "$APIS" | grep -c .)"
+if [ "$RC" -ne 0 ]; then
+  no "--print-apis failed" "$APIS"
+elif [ "$NGROUPS" -lt 5 ]; then
+  no "only $NGROUPS permission groups parsed — the manifest probe is broken, not the manifest"
+elif [ "$NAPIS" -eq "$NGROUPS" ]; then
+  ok "$NGROUPS permission groups → $NAPIS APIs, one each"
+else
+  no "$NGROUPS groups produced $NAPIS APIs" "$APIS"
+fi
+
+# every API is a plausible service name, and the list has no duplicates
+BAD="$(printf '%s\n' "$APIS" | grep -vE '^[a-z0-9-]+\.googleapis\.com$' | grep . || true)"
+[ -z "$BAD" ] && ok "every derived entry is an API service name" || no "not API service names: $BAD"
+DUPES="$(printf '%s\n' "$APIS" | sort | uniq -d | grep . || true)"
+[ -z "$DUPES" ] && ok "no duplicate APIs" || no "duplicated: $DUPES"
+
+echo "── 2. CONTROL — an unmapped permission group must STOP the script ──"
+# This is the assertion the whole design rests on. If a new service can be added
+# to the manifest and silently produce a project missing its API, the derivation
+# buys nothing. Inject a bogus group and require a hard failure that NAMES it.
+FIXDIR="$TMP/fixture"; mkdir -p "$FIXDIR"
+cp "$SCRIPT" "$FIXDIR/connect.sh"
+python3 - "$MANIFEST" "$FIXDIR/connector.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+args = d["register"]["args"]
+args.insert(args.index("--permissions") + 1, "quantumdrive:full")
+json.dump(d, open(sys.argv[2], "w"), indent=2)
+PY
+if grep -q 'quantumdrive' "$FIXDIR/connector.json"; then
+  ok "injection assertion: the fixture really contains the unmapped group"
+  OUT="$(bash "$FIXDIR/connect.sh" --print-apis 2>&1)"; RC=$?
+  if [ "$RC" -eq 0 ]; then
+    no "an unmapped group produced a SUCCESSFUL API list" "$OUT"
+  elif printf '%s' "$OUT" | grep -q 'quantumdrive'; then
+    ok "unmapped group fails loudly and names the group"
+  else
+    no "it failed, but without naming the offending group" "$OUT"
+  fi
+else
+  no "fixture injection did not take — this check proves nothing"
+fi
+
+echo "── 3. one list, and it lives in the script's mapping only ──"
+# Extract api_for()'s line range and require every API-service literal in the
+# file to sit inside it. A second hardcoded list anywhere else is the drift this
+# change removes, so it fails the build rather than waiting to be noticed.
+START="$(grep -n '^api_for()' "$SCRIPT" | head -1 | cut -d: -f1)"
+END="$(awk -v s="$START" 'NR>s && /^}/ {print NR; exit}' "$SCRIPT")"
+if [ -n "$START" ] && [ -n "$END" ]; then
+  OUTSIDE="$(grep -nE '[a-z0-9-]+\.googleapis\.com' "$SCRIPT" \
+    | awk -F: -v s="$START" -v e="$END" '$1 < s || $1 > e' | grep . || true)"
+  [ -z "$OUTSIDE" ] \
+    && ok "every API literal is inside api_for() (lines $START-$END)" \
+    || no "API name written outside the mapping:" "$OUTSIDE"
+else
+  no "could not locate api_for() — the structural check cannot run"
+fi
+
+# and the docs must not restate it either — they defer to --print-apis
+DOCDRIFT=""
+for d in mcps/google-workspace-mcp/personal-account-setup.md mcps/google-workspace-mcp/README.md; do
+  [ -f "$d" ] || continue
+  grep -qE '^[^h]*[a-z0-9-]+\.googleapis\.com' "$d" && DOCDRIFT="$DOCDRIFT $d"
+done
+[ -z "$DOCDRIFT" ] \
+  && ok "setup docs restate no API list" \
+  || no "a doc hardcodes API names again:$DOCDRIFT" "point at --print-apis instead"
+grep -q -- '--print-apis' mcps/google-workspace-mcp/personal-account-setup.md \
+  && ok "the setup doc points at --print-apis" \
+  || no "personal-account-setup.md does not reference --print-apis"
+
+# The copy in SETUP.md was PROSE, not a literal -- "the core seven (Drive, Docs,
+# Sheets, Slides, Calendar, Tasks, Gmail) plus People API for contacts ... and Chat
+# API if you add chat" -- so a check for `*.googleapis.com` would have missed it
+# entirely, which is how it drifted to naming an API nothing requests. Catch the
+# shape instead: a line that says "API" and names three or more of the services is
+# an enumeration of the list, wherever it lives.
+#
+# A line that names the services WITHOUT saying "API" is a value statement ("enables
+# Calendar, Tasks, Drive ...") and is fine -- it tells an operator what they get, it
+# does not send them to go and enable things.
+ENUM="$(python3 tests/fixtures/google-connect-enum-scan.py)"
+[ -z "$ENUM" ] \
+  && ok "no doc enumerates the APIs to enable in prose either" \
+  || no "a doc re-enumerates the API list:" "$ENUM"
+
+
+# CONTROLS for that scanner. A drift detector with no controls is the thing it is
+# meant to prevent: it would report "clean" just as convincingly if it were broken,
+# and it very nearly was -- the first version fired on an unrelated SETUP.md note
+# about USER.md Sources, and an earlier one MISSED the copy whose service names sat
+# in a blockquote on the following line. So each historical copy is replayed as a
+# fixture and must still be caught, and the coincidence must stay silent.
+CTL="$TMP/enumctl"; mkdir -p "$CTL"
+cp tests/fixtures/google-connect-enum-scan.py "$CTL/scan.py"
+ctl(){ # $1 label · $2 expect(catch|silent) · stdin = the fixture
+  rm -f "$CTL/SETUP.md"; cat > "$CTL/SETUP.md"
+  R="$(cd "$CTL" && python3 scan.py)"
+  if [ "$2" = catch ]; then
+    [ -n "$R" ] && ok "scanner control: $1 → caught" || no "scanner control: $1 → MISSED" "the detector cannot see a copy it is supposed to catch"
+  else
+    [ -z "$R" ] && ok "scanner control: $1 → silent" || no "scanner control: $1 → false positive" "$R"
+  fi
+}
+ctl "prose copy (the SETUP.md one)" catch <<'FIX'
+so your Cloud project needs the matching nine APIs enabled — the core seven (Drive, Docs, Sheets, Slides, Calendar, Tasks, Gmail) plus People API for `contacts` and Forms API for `forms`.
+FIX
+ctl "list on the line AFTER the instruction" catch <<'FIX'
+**2. Enable APIs** — APIs & Services → **Library** → enable each (search → Enable).
+> **Drive · Docs · Sheets · Slides · Calendar · Tasks · Gmail** — the core seven
+FIX
+ctl "service→API mapping (the TROUBLESHOOTING one)" catch <<'FIX'
+2. **Enable the matching Google API** for each service you added — People for `contacts`,
+   Forms for `forms`, Google Chat for `chat`, Apps Script for `appscript`, Custom Search for
+   `search`.
+FIX
+ctl "unrelated prose using both words far apart" silent <<'FIX'
+**What Claude asks you** (only if needed):
+- Your Google email (for Calendar/Tasks/Drive)
+- **Which Google Tasks list to read.** Without it the Tasks source is enabled but never queried — `/aios:today` will have no tasks. Get the ID from the Tasks API (`tasklists.list`).
+FIX
+
+echo "── 3b. the mapping covers every service the upstream supports ──"
+# connector.json only requests nine today, so the other suites cannot notice a
+# missing row until someone edits the manifest and the script stops. The README
+# documents the full set the upstream server accepts; every one of them should
+# already resolve, so adding a service stays a one-line manifest edit.
+UPSTREAM_SVCS="$(sed -n 's/^Services: //p' mcps/google-workspace-mcp/README.md | tr -d '`' | tr '·' '\n' | tr -d ' ' | grep . || true)"
+if [ -z "$UPSTREAM_SVCS" ]; then
+  no "could not read the service list from README.md — this check proves nothing"
+else
+  NSVC="$(printf '%s\n' "$UPSTREAM_SVCS" | grep -c .)"
+  UNMAPPED=""
+  for svc in $UPSTREAM_SVCS; do
+    grep -qE "^[[:space:]]*$svc\)" "$SCRIPT" || UNMAPPED="$UNMAPPED $svc"
+  done
+  [ -z "$UNMAPPED" ] \
+    && ok "all $NSVC upstream services have a row in api_for()" \
+    || no "no api_for() row for:$UNMAPPED" "adding one of these to connector.json would stop connect.sh"
+fi
+
+echo "── 4. preflight refuses cleanly ──"
+# A PATH holding every tool the script needs EXCEPT gcloud. An empty PATH would
+# also remove bash and python3, so the run would die for the wrong reason and the
+# check would pass without ever exercising the branch it names.
+NOGC="$TMP/nogcloud"; mkdir -p "$NOGC"
+for t in bash env python3 dirname basename grep sed awk tr cat date mkdir head cut sort uniq wc ls cp chmod printf; do
+  p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$NOGC/$t"
+done
+[ -x "$NOGC/python3" ] && ok "harness: python3 reachable without gcloud" \
+  || no "harness: could not stage python3 — the no-gcloud check cannot run"
+BASH_BIN="$(command -v bash)"
+OUTPUT="$(PATH="$NOGC" "$BASH_BIN" "$SCRIPT" 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ]; then
+  no "ran to completion with no gcloud on PATH"
+elif printf '%s' "$OUTPUT" | grep -q 'gcloud is not installed'; then
+  ok "no gcloud → clean refusal naming gcloud"
+else
+  no "refused, but not because of gcloud" "$OUTPUT"
+fi
+printf '%s' "$OUTPUT" | grep -q 'cloud.google.com/sdk' \
+  && ok "and points at the installer" || no "refusal offers no way forward"
+
+BIN="$TMP/anon"; mk_gcloud "$BIN" anon ""
+export GCLOUD_LOG="$TMP/anon.log"; : > "$GCLOUD_LOG"; export STUB_DOMAIN=gmail.com STUB_ENABLED=""
+run "$BIN"
+if [ "$RC" -eq 0 ]; then
+  no "proceeded while gcloud was unauthenticated"
+elif printf '%s' "$OUTPUT" | grep -q 'gcloud auth login'; then
+  ok "unauthenticated gcloud → refusal naming \`gcloud auth login\`"
+else
+  no "refused but never named the fix" "$OUTPUT"
+fi
+grep -q 'projects create' "$GCLOUD_LOG" && no "created a project despite refusing" || ok "no project created on refusal"
+
+echo "── 5. --dry-run mutates nothing ──"
+BIN="$TMP/dry"; mk_gcloud "$BIN" authed ""
+export GCLOUD_LOG="$TMP/dry.log"; : > "$GCLOUD_LOG"; export STUB_DOMAIN=gmail.com STUB_ENABLED=""
+run "$BIN" --dry-run
+if grep -qE 'projects create|services enable' "$GCLOUD_LOG"; then
+  no "--dry-run called a mutating gcloud command" "$(cat "$GCLOUD_LOG")"
+else
+  ok "--dry-run issued no mutating gcloud call"
+fi
+printf '%s' "$OUTPUT" | grep -q 'would enable' && ok "--dry-run still reports what it would do" \
+  || no "--dry-run printed no plan" "$OUTPUT"
+
+echo "── 6. the full run enables every derived API in ONE call ──"
+BIN="$TMP/run"; mk_gcloud "$BIN" authed ""
+export GCLOUD_LOG="$TMP/run.log"; : > "$GCLOUD_LOG"; export STUB_DOMAIN=gmail.com STUB_ENABLED=""
+run "$BIN"
+ENABLE_CALLS="$(grep -c '^services enable' "$GCLOUD_LOG" || true)"
+[ "$ENABLE_CALLS" = 1 ] \
+  && ok "one \`services enable\` call, not $NAPIS of them" \
+  || no "expected 1 enable call, saw $ENABLE_CALLS"
+MISSED=""
+while IFS= read -r a; do
+  [ -n "$a" ] || continue
+  grep -q -- "$a" "$GCLOUD_LOG" || MISSED="$MISSED $a"
+done <<EOF
+$APIS
+EOF
+[ -z "$MISSED" ] && ok "all $NAPIS APIs passed to gcloud" || no "never enabled:$MISSED"
+
+echo "── 7. the account type decides which clicks are shown ──"
+printf '%s' "$OUTPUT" | grep -q 'Test user' \
+  && ok "consumer account → test-user step shown" || no "consumer account: no test-user step"
+printf '%s' "$OUTPUT" | grep -q '7 days' \
+  && ok "consumer account → the 7-day Testing clock is named" || no "consumer: 7-day clock not named"
+BIN="$TMP/ws"; mk_gcloud "$BIN" authed ""
+export GCLOUD_LOG="$TMP/ws.log"; : > "$GCLOUD_LOG"; export STUB_DOMAIN=example.com STUB_ENABLED=""
+run "$BIN"
+if printf '%s' "$OUTPUT" | grep -q 'Internal'; then
+  ok "workspace account → Internal audience"
+else
+  no "workspace account was not routed to Internal" "$OUTPUT"
+fi
+printf '%s' "$OUTPUT" | grep -q '7 days' \
+  && no "workspace account shown the 7-day clock, which cannot apply to it" \
+  || ok "workspace account not warned about a trap it cannot hit"
+
+echo "── 8. an existing project is offered, never silently duplicated ──"
+BIN="$TMP/exist"; mk_gcloud "$BIN" authed "aios-workspace-260101-1234"
+export GCLOUD_LOG="$TMP/exist.log"; : > "$GCLOUD_LOG"; export STUB_DOMAIN=gmail.com STUB_ENABLED=""
+run "$BIN"
+if grep -q 'projects create' "$GCLOUD_LOG"; then
+  no "created a second project while one already existed"
+elif printf '%s' "$OUTPUT" | grep -q 'aios-workspace-260101-1234'; then
+  ok "existing project surfaced instead of creating another"
+else
+  no "neither reused nor reported the existing project" "$OUTPUT"
+fi
+export GCLOUD_LOG="$TMP/exist2.log"; : > "$GCLOUD_LOG"
+run "$BIN" --new
+grep -q 'projects create' "$GCLOUD_LOG" && ok "--new overrides and creates one" || no "--new did not create"
+
+echo "── 9. --finish rejects the two client mistakes that fail LATE ──"
+BIN="$TMP/fin"; mk_gcloud "$BIN" authed ""
+export GCLOUD_LOG="$TMP/fin.log"; : > "$GCLOUD_LOG"; export STUB_DOMAIN=gmail.com STUB_ENABLED=""
+export GOOGLE_WORKSPACE_CRED_DIR="$TMP/creds"
+cat > "$TMP/web.json" <<'J'
+{"web":{"client_id":"x.apps.googleusercontent.com","client_secret":"s","project_id":"p1"}}
+J
+cat > "$TMP/wrongproj.json" <<'J'
+{"installed":{"client_id":"x.apps.googleusercontent.com","client_secret":"s","project_id":"other-project"}}
+J
+cat > "$TMP/good.json" <<'J'
+{"installed":{"client_id":"x.apps.googleusercontent.com","client_secret":"s","project_id":"p1"}}
+J
+run "$BIN" --finish --project-id p1 --client "$TMP/web.json"
+{ [ "$RC" -ne 0 ] && printf '%s' "$OUTPUT" | grep -qi 'desktop'; } \
+  && ok "a Web client is rejected, naming Desktop as the fix" \
+  || no "Web client accepted (this surfaces later as redirect_uri_mismatch)" "$OUTPUT"
+run "$BIN" --finish --project-id p1 --client "$TMP/wrongproj.json"
+{ [ "$RC" -ne 0 ] && printf '%s' "$OUTPUT" | grep -q 'other-project'; } \
+  && ok "a client from another project is rejected, naming both projects" \
+  || no "wrong-project client accepted (this surfaces later as 403 org_internal)" "$OUTPUT"
+run "$BIN" --finish --project-id p1 --client "$TMP/good.json"
+if [ "$RC" -ne 0 ]; then
+  no "a valid Desktop client for the right project was rejected" "$OUTPUT"
+elif [ -f "$TMP/creds/client_secret.json" ]; then
+  PERM="$(ls -l "$TMP/creds/client_secret.json" | cut -c1-10)"
+  case "$PERM" in -rw-------) ok "valid client installed 0600 outside the vault" ;;
+                  *) no "installed with permissions $PERM, expected -rw-------" ;; esac
+else
+  no "accepted but wrote no credential file"
+fi
+printf '%s' "$OUTPUT" | grep -q 'claude mcp add' \
+  && ok "--finish prints the registration command" || no "--finish printed no registration command"
+# the registration it prints must come from the manifest, not a second copy
+printf '%s' "$OUTPUT" | grep -q -- '--permissions' \
+  && ok "the printed registration carries the manifest's permissions" \
+  || no "printed registration has no --permissions — it is not manifest-derived"
+
+echo "── 10. --verify reports missing APIs, and says what cannot be checked ──"
+BIN="$TMP/ver"; mk_gcloud "$BIN" authed ""
+export GCLOUD_LOG="$TMP/ver.log"; : > "$GCLOUD_LOG"; export STUB_DOMAIN=gmail.com
+export STUB_ENABLED="$(printf '%s\n' "$APIS" | head -3)"
+run "$BIN" --verify --project-id p1
+{ [ "$RC" -ne 0 ] && printf '%s' "$OUTPUT" | grep -q 'gmail.googleapis.com'; } \
+  && ok "a partially-enabled project fails and names what is missing" \
+  || no "missing APIs not reported" "$OUTPUT"
+printf '%s' "$OUTPUT" | grep -q 'gcloud services enable' \
+  && ok "and prints the command that fixes it" || no "no remediation command"
+export STUB_ENABLED="$APIS"
+run "$BIN" --verify --project-id p1
+{ [ "$RC" -eq 0 ] && printf '%s' "$OUTPUT" | grep -q "all $NAPIS APIs enabled"; } \
+  && ok "a fully-enabled project verifies clean" || no "clean project did not verify" "$OUTPUT"
+printf '%s' "$OUTPUT" | grep -qi 'cannot be read back' \
+  && ok "verify states what it CANNOT check rather than implying full coverage" \
+  || no "verify implies it checked the consent screen, which no API exposes"
+
+echo "── 11. portable to the bash 3.2 that ships on macOS ──"
+B32=""
+grep -qE '^\s*declare -A|^\s*local -A' "$SCRIPT" && B32="$B32 associative-array"
+grep -qE '\bmapfile\b|\breadarray\b'            "$SCRIPT" && B32="$B32 mapfile"
+grep -qE '\$\{[A-Za-z_]+\^\^|\$\{[A-Za-z_]+,,'  "$SCRIPT" && B32="$B32 case-expansion"
+[ -z "$B32" ] && ok "no bash 4+ constructs" || no "bash 4-only construct(s):$B32"
+
+# Assigning a bash special variable is SILENT: the write is discarded and the read
+# returns bash's value. This suite lost an hour to `GROUPS=` returning the caller's
+# gid (20) as if it were manifest data -- and only under bash, because zsh has no
+# such variable, so the same line worked when pasted into a terminal.
+# Enumerated, not globbed: `BASH_[A-Z]+` also matches a perfectly ordinary
+# BASH_BIN and reports it as a bug. A guard that fires on correct code gets
+# switched off, which is worse than not having it.
+SPECIAL='GROUPS|SECONDS|RANDOM|LINENO|PIPESTATUS|FUNCNAME|DIRSTACK|SHELLOPTS|UID|EUID|PPID|HISTCMD'
+SPECIAL="$SPECIAL|BASHPID|BASHOPTS|BASH_REMATCH|BASH_SOURCE|BASH_LINENO|BASH_VERSION|BASH_VERSINFO|BASH_SUBSHELL|BASH_COMMAND|BASH_ARGC|BASH_ARGV"
+for f in "$SCRIPT" "$0"; do
+  HIT="$(grep -nE "^[[:space:]]*(local[[:space:]]+|export[[:space:]]+)?($SPECIAL)=" "$f" | grep . || true)"
+  [ -z "$HIT" ] \
+    && ok "$(basename "$f") assigns no bash special variable" \
+    || no "$(basename "$f") assigns a bash special variable:" "$HIT"
+done
+bash -n "$SCRIPT" && ok "parses cleanly" || no "syntax error"
+
+echo "── 12. the oauth template carries no scope list to drift ──"
+TPL="mcps/google-workspace-mcp/oauth.json.template"
+if [ -f "$TPL" ]; then
+  python3 - "$TPL" <<'PY' && ok "template has no frozen \`scopes\` array" || no "the template still ships a scope list — it is a fourth copy, and nothing reads it"
+import json, sys
+d = json.load(open(sys.argv[1]))
+sys.exit(1 if "scopes" in d else 0)
+PY
+  python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$TPL" \
+    && ok "template is valid JSON" || no "template is not valid JSON"
+  for k in client_id client_secret; do
+    python3 -c '
+import json,sys
+sys.exit(0 if sys.argv[2] in json.load(open(sys.argv[1])) else 1)' "$TPL" "$k" \
+      && ok "template keeps \`$k\` (SETUP.md reads it)" || no "template lost \`$k\` — SETUP.md reads it"
+  done
+fi
+
+printf '\n%d passed · %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Two items, one update. Both were shipping-today work; they share a changelog entry.

## 1 · AI-126 — Google connect in one command

`bash mcps/google-workspace-mcp/connect.sh` creates the Cloud project, enables every API the connector needs in **one** `gcloud services enable` call, and prints the console-only steps as links that land on the exact page for that project. `--finish` installs the downloaded client and prints the registration; `--verify` re-checks; `--print-apis` shows the derived list; `--dry-run` mutates nothing.

**The structural half is the derivation.** The API set existed in **six** places and they had drifted:

| Surface | State before |
|---|---|
| `connector.json` `--permissions` | 9 groups — the real request |
| `personal-account-setup.md` | 10 APIs, including a **Chat API nothing requests** |
| `SETUP.md` prose | "the core seven … plus People API … and Chat API if you add `chat`" |
| `TROUBLESHOOTING.md` | its own service→API mapping, incl. `appscript`/`search` the script couldn't resolve |
| `oauth.json.template` `scopes` | 17 scopes, **no gmail, no contacts, no forms** |
| folder `README.md` | pointed at a hand-typed registration |

Nothing noticed because the failure is late and misattributed: a scope whose API is off consents fine, exposes the tool, then returns `403 SERVICE_DISABLED` on first call — which reads as auth. `api_for()` is now the only place an API name is written; every other surface is a pointer. An unmapped permission group **stops** the script rather than producing a half-enabled project, and all 12 upstream services have a row, so adding one stays a one-line manifest edit.

**Two traps became checks, because they read back something real.** `--finish` parses the downloaded `client_secret_*.json`: a `web` key → refused, naming Desktop (`redirect_uri_mismatch` caught at setup); `installed.project_id` ≠ the enabled project → refused, naming both (`403 org_internal`, same). The consent screen genuinely cannot be read back — no API exposes it — so the script *says so* in `--verify` rather than implying coverage it doesn't have.

**Account-type branching.** A Workspace account is routed to Internal (no test-user list, no 7-day clock); a consumer account gets the test-user step and the refresh-token warning. Each is shown only where it can actually fire, instead of one generic warning both audiences must filter.

The template's `scopes` array was a frozen personal grant that nothing reads — `SETUP.md` takes only `client_id`/`client_secret`. Removed rather than maintained as a fourth copy.

No credential ships. The reasoning is on the record in the spec: the 100-grant lifetime cap is unresettable, and our operators' Workspace admins gate third-party apps, so a shared client relocates the friction rather than removing it.

## 2 · `## Close of Day` stays last

**The reported cause was wrong, and checking mattered.** The report was that `aios-note-append --before` lands blocks at the end instead of above its marker. The history says otherwise — at 18:43 and 19:20, when both blocks were appended, the note contained **no `## Close of Day` at any line**, so the end was the only correct place and the helper did it right (verified behaviourally, blocks 2 and 3 of the new suite). The marker arrived at 20:11, inserted by `/close-day` at line 153 of a note whose session blocks already ran to 267.

So the defect is `/close-day`'s, and there were two:

- **It never said where its block went.** `/close-session` inserts `--before "## Close of Day"`, so the marker being last is precisely what keeps session blocks above it. Neither command stated the shared invariant, so an anchor partway up the note read as reasonable — and every session block below that point ended up below Close of Day.
- **It used `aios-note-append` zero times.** A lock only works if every writer takes it. It was the one unlocked writer on a file that `--auto` broadcasts merge-append into under a per-file lock, so a session block landing between its read and its write was silently overwritten.

Both fixed by writing through the helper with no `--before`.

## Tests

`tests/google-connect.test.sh` (46) · `tests/daily-note-block-order.test.sh` (8) — both wired into `validate.yml`, green under bash 5 and under the bash **3.2** Apple ships. 48/48 suites green locally.

Three assertions are load-bearing rather than descriptive:

- **The unmapped-group control** — a fixture manifest with a bogus group must make the script *fail and name it*, with an injection assertion first proving the fixture really carries it. Without this the derivation guarantees nothing.
- **The drift scanner's own controls** — each of the three historical copies is replayed as a fixture and must still be caught, *and* the unrelated `SETUP.md` sentence that broke its first version must stay silent. The first detector fired on correct text; an earlier one missed the copy whose service names sat in a blockquote on the following line. A guard that fires on correct code gets switched off; one that can't fail reports "clean" just as convincingly when broken.
- **The ordering control** — replays the buggy mid-note anchor and requires the suite to detect it.

Two bugs the suites caught in their own harness, both worth naming because they're silent classes:

- `GROUPS=` is a **bash special read-only variable**. The assignment was discarded and the probe read the caller's gid (`20`) as manifest data — under bash only, since zsh has no such variable, so the same line worked pasted into a terminal. There is now a guard asserting neither the script nor the suite assigns an enumerated bash special.
- The no-`gcloud` preflight check first used an empty `PATH`, which also removes `bash` and `python3` — so the run died for the wrong reason and the check passed without exercising its branch. It now stages a PATH holding every needed tool *except* `gcloud`.