### PR TITLE
AI-126 follow-up: the session drives the Google connect, not the operator + AI-150 Half B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ Two changes make the session the one holding the tooling. `connect.sh --finish` 
 
 `/aios:mcps-setup` was the worst offender and is rewritten: it had been telling sessions to *"ask user to run"* a `uvx` command with a hand-typed permission list — which had drifted to six services while the connector requested nine, so following it produced a server that started cleanly and then returned `403` on Gmail at the first call. It now drives the tooling and never types a permission list; `connector.json` is the only place that list lives.
 
+**If you don't have `gcloud`, you find out before anything happens** — the preflight runs first, including under `--dry-run`, and says plainly that nothing was created so you are not left half-configured. It names the install command for your actual platform (on a Mac with Homebrew, the one-liner) and offers the by-hand console path as a real alternative. Same for not being logged in.
+
 **Action required:** none, and nothing about a working setup changes. If you have been putting off connecting Google because the instructions read like a build script, this is the version to ask your session about.
 
 ### On macOS, `git` was probably never the thing blocking you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,26 @@ The API list is **derived** from the `--permissions` list in `mcps/google-worksp
 
 **Action required:** none if Google already works for you — nothing about your existing setup changes. Setting it up for the first time, or redoing it: run `connect.sh` instead of the console walkthrough. It needs `gcloud` for the automated half; without `gcloud` it says so and stops, and `mcps/google-workspace-mcp/personal-account-setup.md` still carries the full manual path plus the one trap no script can remove — on a consumer `@gmail.com` account, an app left in *Testing* expires its refresh token every 7 days.
 
+### You should not have been running those Google scripts yourself
+
+**What you can now do.** Say *"connect my Google Workspace"*, or run `/aios:mcps-setup` and pick it. Your session creates the Cloud project, enables the APIs, hands you only the two or three console pages Google exposes no API for, and once you say you are done it validates the credential you downloaded and registers the server. **Your part is about six clicks and one download — no terminal commands.**
+
+This morning's version shipped the tooling and pointed *you* at it: run a script, click through the console, then run a second script with a project id you had to copy and a path into `~/Downloads` you had to get right, then run a third printed command. One command from the framework's point of view; three from yours.
+
+Two changes make the session the one holding the tooling. `connect.sh --finish` now needs **no arguments** — it reads the project id the connect run recorded and finds the newest `client_secret_*.json` itself, and because it already refuses a wrong-type or wrong-project client, guessing the file is safe rather than risky. And the connect run prints one stable `AIOS_PROJECT_ID=` line, so a session driving it reads that instead of parsing prose written for a human.
+
+`/aios:mcps-setup` was the worst offender and is rewritten: it had been telling sessions to *"ask user to run"* a `uvx` command with a hand-typed permission list — which had drifted to six services while the connector requested nine, so following it produced a server that started cleanly and then returned `403` on Gmail at the first call. It now drives the tooling and never types a permission list; `connector.json` is the only place that list lives.
+
+**Action required:** none, and nothing about a working setup changes. If you have been putting off connecting Google because the instructions read like a build script, this is the version to ask your session about.
+
+### On macOS, `git` was probably never the thing blocking you
+
+**What you can now do.** Know that you are not blocked on `git` when Homebrew misbehaves. macOS ships `git` with the **Xcode Command Line Tools** (`xcode-select --install` — no Apple ID, not the full Xcode), so this guide's GitHub steps work before you have a package manager at all. `git --version` settles it in one line; if it answers, `brew install git` would only put a second copy ahead of it on your `PATH`.
+
+Homebrew is still the simplest way to get `node`, `gh`, `python` and `uv` in one command, so it stays step 1 of the macOS prerequisites. `SETUP.md` just no longer implies that everything after it is waiting on it.
+
+**Action required:** none.
+
 ### `## Close of Day` goes back to the end of your daily note
 
 **What you can now do.** Trust your daily note's order. `/close-day` now appends its `## Close of Day` block at the **end** of the note, and writes it through the same per-file locking helper `/close-session` uses.

--- a/SETUP.md
+++ b/SETUP.md
@@ -132,8 +132,19 @@ Run your two side-by-side: Obsidian on the left for context, your execution surf
 
 ### macOS (~5 min)
 
+> **`git` is very likely already installed, and that matters if Homebrew gives you trouble.** macOS
+> ships `git` with the **Xcode Command Line Tools** — `xcode-select --install`, which needs no Apple
+> ID and is not the full Xcode. So the GitHub steps in this guide work *before* you have a package
+> manager at all. Check with `git --version`: if it answers, `git` is done, and `brew install git`
+> would only add a second copy ahead of it on your `PATH`.
+>
+> Homebrew is still the simplest way to get `node`, `gh`, `python` and `uv` in one command, so it
+> stays step 1. The point is narrower and worth knowing while you are in it: **if the Homebrew
+> install is what is blocking you, you are not blocked on `git`** — and a guide that opens with
+> "install Homebrew" makes it look like you are.
+
 ```bash
-# 1. Homebrew (skip if you have it)
+# 1. Homebrew (skip if you have it — and see the note above if it gives you trouble)
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # 2. Toolchain
@@ -329,18 +340,24 @@ claude mcp add obsidian -- npx -y @mauricio.wolff/mcp-obsidian@latest ~/aios/vau
 
 Enables Google Calendar, Tasks, Drive, Docs, Sheets, Slides, Gmail, Contacts and Forms.
 
-**One command does most of it:**
+**Ask your Claude session to do it** — *"connect my Google Workspace"*, or run
+`/aios:mcps-setup` and pick it. **You should not be running scripts for this.** The session creates
+the Cloud project, enables every API the connector needs, hands you the two or three console pages
+Google exposes no API for, and once you say you are done it validates the credential you downloaded
+and registers the server. Your part: about six clicks and one download.
+
+The tooling underneath is `mcps/google-workspace-mcp/connect.sh` — documented here because it is
+worth knowing what is running on your machine, not because you have to type it:
 
 ```bash
-cd ~/aios
-bash mcps/google-workspace-mcp/connect.sh
+bash mcps/google-workspace-mcp/connect.sh            # project + every API, then the clicks left
+bash mcps/google-workspace-mcp/connect.sh --finish   # validates + installs the client you downloaded
 ```
 
-It creates your Google Cloud project, enables every API the connector needs in a single call, and
-then prints the handful of console steps it cannot do — as links that land on the exact page for
-your project. After those, `connect.sh --finish --project-id <id> --client <downloaded.json>`
-installs the credential and prints the `claude mcp add` command with the permission list already
-filled in from the manifest. `--dry-run` changes nothing; `--verify` re-checks the APIs later.
+`--finish` needs no arguments — it reads the project id recorded by the connect run and the newest
+`client_secret_*.json` in `~/Downloads`, then prints the `claude mcp add` line with the permission
+list already filled in from the manifest. `--dry-run` changes nothing; `--verify` re-checks the APIs;
+`--print-apis` prints just the derived list.
 
 **Why not all of it.** Google publishes an API for project creation and API enablement, and none for
 the consent screen or for creating an OAuth client. So the floor is one command plus roughly six

--- a/mcps/google-workspace-mcp/connect.sh
+++ b/mcps/google-workspace-mcp/connect.sh
@@ -172,8 +172,29 @@ esac
 
 # ── finish: install the downloaded client, then print the registration ───────
 if [ "$MODE" = finish ]; then
-  [ -n "$PROJECT_ID" ] || die "--finish needs --project-id (the project whose APIs were enabled)"
-  [ -n "$CLIENT_JSON" ] || die "--finish needs --client <path to the downloaded client_secret_*.json>"
+  # Both arguments DEFAULT, because every argument is something that can be got
+  # wrong -- and these two are the worst kind: a project id that must be copied
+  # exactly, and a glob path into ~/Downloads. The connect run already knew the
+  # project id, so asking for it back makes the tool's own bookkeeping the
+  # operator's problem.
+  if [ -z "$PROJECT_ID" ] && [ -f "$CRED_DIR/.aios-project" ]; then
+    PROJECT_ID="$(cat "$CRED_DIR/.aios-project" 2>/dev/null)"
+    [ -n "$PROJECT_ID" ] && say "project: $PROJECT_ID (recorded by your last connect run)"
+  fi
+  [ -n "$PROJECT_ID" ] || die \
+    "no project id — pass --project-id, or run \`connect.sh\` first so it records one." \
+    "The connect run writes it to $CRED_DIR/.aios-project."
+
+  if [ -z "$CLIENT_JSON" ]; then
+    # Newest client_secret_*.json in ~/Downloads. Safe to guess precisely BECAUSE
+    # the checks below reject a client of the wrong type or from another project,
+    # so a wrong guess fails loudly instead of installing quietly.
+    CLIENT_JSON="$(ls -t "$HOME"/Downloads/client_secret_*.json 2>/dev/null | head -1)"
+    [ -n "$CLIENT_JSON" ] || die \
+      "no client_secret_*.json found in ~/Downloads." \
+      "Download it from the Clients page, or pass --client <path>."
+    say "client: $CLIENT_JSON (newest in ~/Downloads)"
+  fi
   [ -f "$CLIENT_JSON" ] || die "no such file: $CLIENT_JSON"
 
   # Two traps that ARE readable, so they stop the run instead of surfacing later
@@ -294,6 +315,13 @@ else
   say "Using project $PROJECT_ID"
 fi
 
+# One stable, greppable line. A session driving this reads THIS, never the prose
+# below it -- prose is written for the human and is free to be rewritten.
+printf 'AIOS_PROJECT_ID=%s\n' "$PROJECT_ID"
+if [ "$DRY_RUN" = 0 ]; then
+  mkdir -p "$CRED_DIR" && printf '%s\n' "$PROJECT_ID" > "$CRED_DIR/.aios-project"
+fi
+
 if [ "$DRY_RUN" = 1 ]; then
   say "dry-run: would enable $API_COUNT APIs in $PROJECT_ID:"
   printf '%s\n' "$APIS" | sed 's/^/    /'
@@ -341,8 +369,9 @@ say "     $CONSOLE/auth/clients/create?project=$PROJECT_ID"
 say "     Desktop is required: it is the only type that allows the http://localhost redirect"
 say "     this flow uses. A Web client fails with redirect_uri_mismatch."
 say ""
-b "Then come back and run"
-say "  bash $0 --finish --project-id $PROJECT_ID --client ~/Downloads/client_secret_*.json"
+b "Then say \"done\" — your Claude session finishes the rest"
+say "  It reads the project id and the downloaded client on its own. By hand:"
+say "  bash $0 --finish"
 say ""
 say "It checks the client is Desktop and belongs to this project — the two mistakes that"
 say "otherwise surface much later as redirect_uri_mismatch and 403 org_internal — installs"

--- a/mcps/google-workspace-mcp/connect.sh
+++ b/mcps/google-workspace-mcp/connect.sh
@@ -88,6 +88,26 @@ api_for(){
 # `openid`, `userinfo.email` and `userinfo.profile` are deliberately absent:
 # they are granted by the consent screen itself and have no API to enable.
 
+# The most actionable install instruction for THIS machine. A doc URL is the
+# fallback, not the answer: on macOS with Homebrew already present there is a
+# one-liner, and handing someone a documentation page instead is the same
+# friction this script exists to remove. It SUGGESTS and never installs —
+# putting an SDK on an operator's machine is their call, not a script's.
+gcloud_install_hint(){
+  case "$OSTYPE" in
+    darwin*)
+      if command -v brew >/dev/null 2>&1; then
+        printf 'brew install --cask google-cloud-sdk'
+      else
+        printf 'https://cloud.google.com/sdk/docs/install — or install Homebrew first, then: brew install --cask google-cloud-sdk'
+      fi ;;
+    msys*|cygwin*|win*)
+      printf 'https://cloud.google.com/sdk/docs/install (Windows installer)' ;;
+    *)
+      printf 'https://cloud.google.com/sdk/docs/install' ;;
+  esac
+}
+
 need_python(){
   command -v python3 >/dev/null 2>&1 \
     || die "python3 not found." "It reads connector.json. On macOS: xcode-select --install"
@@ -155,14 +175,24 @@ API_COUNT="$(printf '%s\n' "$APIS" | grep -c .)"
 # ── preflight ────────────────────────────────────────────────────────────────
 command -v gcloud >/dev/null 2>&1 || die \
   "gcloud is not installed — this script needs it to create the project and enable APIs." \
-  "Install: https://cloud.google.com/sdk/docs/install  ·  then re-run this script.
-  Prefer to do it all by hand? personal-account-setup.md still has the full console walkthrough."
+  "Nothing has been created, so you are not half-configured.
+
+  Install it:  $(gcloud_install_hint)
+  Then re-run this script.
+
+  Or skip gcloud entirely: personal-account-setup.md walks the whole thing through
+  the console by hand. Same result, more clicks."
 
 ACCOUNT="$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null | head -1)"
 [ -n "$ACCOUNT" ] || die \
-  "gcloud is installed but not authenticated." \
-  "Run: gcloud auth login
-  Sign in as the ACCOUNT YOU WANT THE MCP TO ACT AS — the project must belong to it."
+  "gcloud is installed but nobody is logged in." \
+  "Nothing has been created, so you are not half-configured.
+
+  Run:  gcloud auth login
+
+  Sign in as the ACCOUNT YOU WANT THE MCP TO ACT AS — the project is created under
+  whoever is logged in, and a client from one account cannot serve another. Then
+  re-run this script."
 
 DOMAIN="${ACCOUNT##*@}"
 case "$DOMAIN" in

--- a/plugins/aios/commands/mcps-setup.md
+++ b/plugins/aios/commands/mcps-setup.md
@@ -200,12 +200,25 @@ Creates a dedicated Slack app. Messages post AS THE BOT, not as the user. Requir
 - **Register:** `claude mcp add stitch -- npx -y @_davideast/stitch-mcp proxy` (reads `STITCH_API_KEY` from env at launch — keep it in the marker block, not in args)
 - **Bonus — seed a known design system:** by default, Stitch auto-invents a design system per project. To generate screens in a reference brand's style (Stripe, Linear, Apple, etc.), paste a pre-built `DESIGN.md` from [VoltAgent/awesome-design-md](https://github.com/VoltAgent/awesome-design-md) (69 files) into `create_design_system` → `apply_design_system` before `generate_screen_from_text`. The same files also drop into any code project root for Claude Code / Cursor — no Stitch dependency.
 
-### Google Workspace (interactive OAuth, one-time per machine)
+### Google Workspace (one-time per machine — YOU run the tooling, the operator clicks)
 
-- **Ask first:** "Want Google Workspace MCP (Calendar, Tasks, Drive, Docs, Sheets, Slides, Gmail)? This is the most-used MCP for /today and /close-day — skip only if you genuinely don't use Google Workspace. (y/skip)"
-- No token to paste. This MCP uses OAuth browser flow.
-- After deps installed, ask user to run `uvx workspace-mcp --single-user --permissions drive:full sheets:full slides:full docs:full calendar:full tasks:full` once in a terminal — it opens a browser, user signs in, OAuth token is cached locally.
-- Already registered in `~/.claude.json` on most setups (top-level `mcpServers`). If not, register: `claude mcp add google-workspace -- uvx workspace-mcp --single-user --permissions drive:full sheets:full slides:full docs:full calendar:full tasks:full`
+- **Ask first:** "Want Google Workspace (Calendar, Tasks, Drive, Docs, Sheets, Slides, Gmail, Contacts, Forms)? It's what makes `/today` and `/close-day` read your real day instead of guessing — skip only if you genuinely don't use Google. (y/skip)"
+- No token to paste. OAuth browser flow.
+
+> ⚠️ **Do NOT hand the operator a shell command, and do NOT type a `--permissions` list into this file.** Both were here and both were wrong: the list that sat in this section had drifted to six services while the connector requested nine, so following it produced a working server that 403'd on Gmail at the first call. **The permission list has exactly one home — `mcps/google-workspace-mcp/connector.json`** — and `connect.sh` derives everything from it. An operator who is asked to run a script is also being asked to get its arguments right; that is the friction this flow exists to remove, and a C-level operator is the last person who should be assembling a `uvx` invocation.
+
+**The division of labour, and it is the whole point of this section: Google exposes no API for the consent screen or the OAuth client, so a human must click roughly six times. Everything either side of those clicks is yours.**
+
+1. **You run** `bash ~/aios/mcps/google-workspace-mcp/connect.sh`. It creates the Cloud project and enables every API the connector needs. **Read the project id from the `AIOS_PROJECT_ID=` line**, never from the surrounding prose — that line exists so you don't parse prose that is free to change.
+   - No `gcloud`? It says so and stops. Offer the operator the choice rather than deciding for them: install `gcloud` (one `brew install --cask google-cloud-sdk`, then you re-run this), or walk the console by hand via `personal-account-setup.md`. Don't install a package manager or an SDK on their machine without asking.
+2. **You present only the clicks** — the three deep links the script printed, already pointed at their project, plus what each screen needs. Do not paste the script's full output at them; it also talks to you. Close with: *"Download the JSON when you create the client, then tell me you're done."*
+3. **The operator clicks and downloads.** Irreducible — no API exists for any of it.
+4. **On "done", you run** `bash ~/aios/mcps/google-workspace-mcp/connect.sh --finish`. Both of its arguments default: the project id from the connect run, the client from the newest `client_secret_*.json` in `~/Downloads`. It refuses a Web-type client or one belonging to a different project — so if the operator created the wrong thing you find out **here**, with the fix named, instead of weeks later as `redirect_uri_mismatch` or `403 org_internal`.
+5. **You register it** with the `claude mcp add` line `--finish` prints. It is generated from the manifest, so it carries the current permission list by construction — use it verbatim rather than composing one.
+   - **`claude mcp add` writes `~/.claude.json`, which a sandboxed tool call cannot touch — and it prints success anyway.** Run it un-sandboxed, then **verify by reading the file back**, not by trusting the exit code: `python3 -c "import json,os;print('google-workspace' in json.load(open(os.path.expanduser('~/.claude.json'))).get('mcpServers',{}))"`. A registration that silently did not land looks identical to one that did.
+6. **Tell them to restart the session**, and that the first Google tool call opens a browser once for consent. MCP tools register at session start, so it is not callable until then.
+
+**The operator's total: one `y`, about six clicks, one download, one "done". No terminal commands.** If you find yourself about to type a `bash` line into the chat for them to run, you have taken a step that belongs to you.
 
 ### NotebookLM (interactive CLI, one-time per machine)
 

--- a/tests/google-connect.test.sh
+++ b/tests/google-connect.test.sh
@@ -186,6 +186,63 @@ ctl "unrelated prose using both words far apart" silent <<'FIX'
 - **Which Google Tasks list to read.** Without it the Tasks source is enabled but never queried — `/aios:today` will have no tasks. Get the ID from the Tasks API (`tasklists.list`).
 FIX
 
+echo "── 3a. no doc hands the operator a hand-typed --permissions list ──"
+# The SEVENTH copy of this fact was not an API list at all -- it was a
+# `--permissions` list inside a `uvx` command that mcps-setup.md told the
+# operator to run, and it had drifted to SIX services while the connector
+# requested nine. Following it produced a server that started fine and 403'd on
+# Gmail at the first call. Same class as the API list, different surface, so it
+# needs its own assertion: a LIST is three or more service:level tokens on ONE
+# line -- that is the shape someone copies. Individual services named in
+# explanatory prose (`chat:full` is off by default, `search:full` needs a key)
+# are not a list and must not fire.
+SVC='(drive|sheets|slides|docs|calendar|tasks|gmail|contacts|forms|chat|search|appscript):(full|readonly|organize|drafts|send)'
+perm_lists(){ # $1 = file → prints "path:line" for any line carrying >=3 tokens
+  grep -nE -- "$SVC" "$1" 2>/dev/null | while IFS= read -r hit; do
+    ln="${hit%%:*}"; body="${hit#*:}"
+    n="$(printf '%s' "$body" | grep -oE -- "$SVC" | sort -u | grep -c .)"
+    [ "$n" -ge 3 ] && printf '%s:%s(%s tokens) ' "$1" "$ln" "$n"
+  done
+}
+HARD=""
+for f in SETUP.md README.md CHEATSHEET.md TOOLS.md plugins/aios/commands/mcps-setup.md \
+         mcps/google-workspace-mcp/README.md mcps/google-workspace-mcp/personal-account-setup.md \
+         mcps/google-workspace-mcp/TROUBLESHOOTING.md; do
+  [ -f "$f" ] || continue
+  HARD="$HARD$(perm_lists "$f")"
+done
+[ -z "$HARD" ] \
+  && ok "no hand-typed --permissions list outside connector.json" \
+  || no "a doc hard-codes the permission list:" "$HARD
+        connector.json is its only home; connect.sh --finish prints the registration from it"
+
+# CONTROLS — the exact drifted line that shipped, and the prose that must not fire.
+CTL2="$TMP/permctl"; mkdir -p "$CTL2"
+printf '%s\n' 'ask user to run `uvx workspace-mcp --single-user --permissions drive:full sheets:full slides:full docs:full calendar:full tasks:full`' > "$CTL2/SETUP.md"
+R="$(cd "$CTL2" && grep -nE -- "$SVC" SETUP.md | while IFS= read -r h; do b="${h#*:}"; n="$(printf '%s' "$b" | grep -oE -- "$SVC" | sort -u | grep -c .)"; [ "$n" -ge 3 ] && echo hit; done)"
+[ -n "$R" ] && ok "control: the drifted uvx list → caught" || no "control: the real drifted list → MISSED"
+printf '%s\n' '**Google Chat is off by default.** Add `chat:full` (or `chat:readonly`) for spaces.' > "$CTL2/SETUP.md"
+R="$(cd "$CTL2" && grep -nE -- "$SVC" SETUP.md | while IFS= read -r h; do b="${h#*:}"; n="$(printf '%s' "$b" | grep -oE -- "$SVC" | sort -u | grep -c .)"; [ "$n" -ge 3 ] && echo hit; done)"
+[ -z "$R" ] && ok "control: prose naming one service → silent" || no "control: prose fired a false positive"
+
+echo "── 3c. a session can drive it without parsing prose ──"
+BIN="$TMP/drv"; mk_gcloud "$BIN" authed ""
+export GCLOUD_LOG="$TMP/drv.log"; : > "$GCLOUD_LOG"; export STUB_DOMAIN=example.com STUB_ENABLED=""
+export GOOGLE_WORKSPACE_CRED_DIR="$TMP/drvcreds"
+run "$BIN" --dry-run
+ID="$(printf '%s' "$OUTPUT" | sed -n 's/^AIOS_PROJECT_ID=//p')"
+{ [ -n "$ID" ] && [ "$(printf '%s' "$ID" | grep -c .)" = 1 ]; } \
+  && ok "one stable AIOS_PROJECT_ID= line ($ID)" \
+  || no "no single machine-readable project id line" "a driver would have to parse prose"
+# --dry-run must not leave state behind
+[ -f "$TMP/drvcreds/.aios-project" ] && no "--dry-run recorded project state" || ok "--dry-run records no state"
+# a real run records it, and --finish then needs NO arguments
+export GCLOUD_LOG="$TMP/drv2.log"; : > "$GCLOUD_LOG"
+run "$BIN"
+[ "$(cat "$TMP/drvcreds/.aios-project" 2>/dev/null)" = "$(printf '%s' "$OUTPUT" | sed -n 's/^AIOS_PROJECT_ID=//p')" ] \
+  && ok "a real run records the project id for --finish" \
+  || no "project id not recorded, or disagrees with the emitted line"
+
 echo "── 3b. the mapping covers every service the upstream supports ──"
 # connector.json only requests nine today, so the other suites cannot notice a
 # missing row until someone edits the manifest and the script stops. The README

--- a/tests/google-connect.test.sh
+++ b/tests/google-connect.test.sh
@@ -267,8 +267,18 @@ echo "── 4. preflight refuses cleanly ──"
 # also remove bash and python3, so the run would die for the wrong reason and the
 # check would pass without ever exercising the branch it names.
 NOGC="$TMP/nogcloud"; mkdir -p "$NOGC"
+# `type -P` resolves ONLY a real executable on disk. `command -v` would answer
+# with a bare name for a shell function -- and an interactive shell may well wrap
+# `grep` in one -- producing a farm of DANGLING symlinks. The script then fails
+# with "grep: command not found" and the check appears to pass for the right
+# reason while actually never reaching the branch it names.
 for t in bash env python3 dirname basename grep sed awk tr cat date mkdir head cut sort uniq wc ls cp chmod printf; do
-  p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$NOGC/$t"
+  p="$(type -P "$t" 2>/dev/null)" || p=""
+  [ -n "$p" ] && [ -x "$p" ] && ln -sf "$p" "$NOGC/$t"
+done
+for t in grep sed python3; do
+  [ -x "$NOGC/$t" ] || no "harness: $NOGC/$t is not a working executable" \
+    "a dangling link makes the no-gcloud check fail for the wrong reason"
 done
 [ -x "$NOGC/python3" ] && ok "harness: python3 reachable without gcloud" \
   || no "harness: could not stage python3 — the no-gcloud check cannot run"
@@ -295,6 +305,39 @@ else
   no "refused but never named the fix" "$OUTPUT"
 fi
 grep -q 'projects create' "$GCLOUD_LOG" && no "created a project despite refusing" || ok "no project created on refusal"
+
+echo "── 4b. --dry-run refuses too, and says nothing was created ──"
+# A dry run must NOT skip the preflight. Skipping it would print a confident
+# plan that cannot execute -- the operator's whole reason for running --dry-run
+# is to find out whether this will work on their machine. And a red refusal
+# mid-setup makes anyone wonder if they are now half-configured, so both
+# refusals say plainly that nothing was created.
+OUTPUT="$(PATH="$NOGC" "$BASH_BIN" "$SCRIPT" --dry-run 2>&1)"; RC=$?
+{ [ "$RC" -ne 0 ] && printf '%s' "$OUTPUT" | grep -q 'gcloud is not installed'; } \
+  && ok "--dry-run with no gcloud → refuses, naming gcloud" \
+  || no "--dry-run skipped the missing-gcloud preflight" "it would print a plan that cannot run" 
+printf '%s' "$OUTPUT" | grep -qi 'nothing has been created' \
+  && ok "and says nothing was created" || no "refusal leaves the operator wondering if they are half-configured"
+# the hint must be actionable for THIS platform, not a bare doc URL when a one-liner exists
+if [ "$(uname -s)" = Darwin ] && command -v brew >/dev/null 2>&1; then
+  printf '%s' "$OUTPUT" | grep -q 'brew install --cask google-cloud-sdk' \
+    && ok "macOS + brew → the hint is the one-liner" \
+    || no "on a Mac with brew the hint is still a doc URL" "$OUTPUT"
+else
+  printf '%s' "$OUTPUT" | grep -q 'cloud.google.com/sdk' \
+    && ok "hint points at the installer for this platform" || no "no install hint at all"
+fi
+
+BIN="$TMP/anon2"; mk_gcloud "$BIN" anon ""
+export GCLOUD_LOG="$TMP/anon2.log"; : > "$GCLOUD_LOG"; export STUB_DOMAIN=gmail.com STUB_ENABLED=""
+run "$BIN" --dry-run
+{ [ "$RC" -ne 0 ] && printf '%s' "$OUTPUT" | grep -q 'gcloud auth login'; } \
+  && ok "--dry-run while logged out → refuses, naming \`gcloud auth login\`" \
+  || no "--dry-run skipped the authentication preflight" "$OUTPUT"
+printf '%s' "$OUTPUT" | grep -qi 'nothing has been created' \
+  && ok "and says nothing was created" || no "logged-out refusal does not reassure"
+grep -qE 'projects create|services enable' "$GCLOUD_LOG" \
+  && no "mutated despite refusing" || ok "no mutating call on either refusal"
 
 echo "── 5. --dry-run mutates nothing ──"
 BIN="$TMP/dry"; mk_gcloud "$BIN" authed ""


### PR DESCRIPTION
Raised on a dry run of what shipped this morning: *"i hope most of this is handled by claude sessions not the user being called to run scripts himself."* Correct, and the dry-run output proved it.

## What the operator actually faced

`AI-126` shipped the tooling and pointed **them** at it:

1. run `bash mcps/google-workspace-mcp/connect.sh`
2. click through the console
3. run `bash …/connect.sh --finish --project-id aios-workspace-260911-4752 --client ~/Downloads/client_secret_*.json` ← a copied id **and** a glob path
4. run the printed `claude mcp add …`
5. restart

Three terminal commands. "One command" was true from the framework's seat, not theirs — and step 3 hands a C-level operator two arguments they can get wrong.

## What changed

**`--finish` takes no arguments.** The project id comes from state the connect run records; the client is the newest `client_secret_*.json` in `~/Downloads`. Guessing that file is safe *because* `--finish` already refuses a Web-type client or one belonging to another project — a wrong guess fails loudly with the fix named, which is what makes the convenience defensible rather than sloppy.

**The connect run prints one stable `AIOS_PROJECT_ID=` line**, so a driving session reads that and never parses prose that exists for a human and is free to be rewritten.

**`/aios:mcps-setup` was the real defect and is rewritten.** It had been telling sessions to *"ask user to run"* a `uvx` command with a hand-typed `--permissions` list — the **seventh** copy of that fact, drifted to six services while the connector requests nine. Following it produced a server that started cleanly and returned `403` on Gmail at the first call. It now drives `connect.sh`, types no list, and carries the division of labour explicitly: Google exposes no API for the consent screen or the client, so a human clicks ~6 times; everything either side of those clicks belongs to the session.

It also encodes a gotcha worth having in writing: **`claude mcp add` writes `~/.claude.json`, which a sandboxed tool call cannot touch — and prints success anyway.** Verify by reading the file back, not by trusting the exit code.

**Operator's total now: one `y`, ~6 clicks, one download, one "done". No terminal commands.**

## AI-150 Half B — the Mac prerequisite truth

macOS ships `git` with the Xcode Command Line Tools (`xcode-select --install`, no Apple ID, not full Xcode), so this guide's GitHub steps work before a package manager exists. Homebrew stays step 1 (it is still the one-liner for `node`/`gh`/`python`/`uv`); SETUP.md just stops implying everything after it is waiting on it.

**Scope correction to the keyed row:** it named `SETUP.md` *and* `START-HERE.md`. `START-HERE.md` has no prerequisites block at all — it delegates the install to `SETUP.md` — so Half B is SETUP.md only. Worth noting that START-HERE was already written session-first (*"Claude reads SETUP.md and does the install"*), which is the model the Google flow should have copied from the start.

## Tests

`tests/google-connect.test.sh` 46 → **52**. New assertions:

- **No doc carries a hand-typed permission list** — defined as ≥3 `service:level` tokens on **one line**, which is the shape someone copies. Two controls: the exact drifted `uvx` line that shipped must be caught, and prose naming a single service (`chat:full` is off by default) must stay silent. The per-line framing matters — the tokens in `connector.json` sit on separate lines, and README prose names services individually; a per-file count would have flagged both.
- **A session can drive it without parsing prose** — exactly one `AIOS_PROJECT_ID=` line, `--dry-run` records no state, and a real run records an id that agrees with the line it printed.

48/48 suites green, bash 3.2 verified.