### PR TITLE
Fix: the MCP registration read-back said 'not registered' on a working install

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1358,6 +1358,25 @@ jobs:
         # -- a suite that cannot detect the defect it was written for measures nothing.
         run: bash tests/daily-note-block-order.test.sh
 
+      - name: the documented MCP registration read-back checks both scopes
+        # `claude mcp add` prints success even when a sandboxed call wrote nothing, so
+        # mcps-setup.md tells sessions to verify by reading ~/.claude.json back. The
+        # first version of that read-back looked only at top-level `mcpServers` -- and
+        # the command DEFAULTS to local (per-directory) scope, so a normal registration
+        # lands under projects["<cwd>"].mcpServers.
+        #
+        # Measured on a live vault: connector running, all nine services present, and
+        # the documented check printed False. A session acting on that re-registers
+        # something that already worked -- and two registrations drift independently
+        # (one grew Gmail, the other did not). So the wrong check pushed toward the
+        # failure it was meant to detect.
+        #
+        # The suite EXTRACTS the snippet from the command file and runs it against
+        # fixtures rather than restating the logic -- a guard that reimplements what it
+        # checks would have passed against the broken original. Its control replays that
+        # original and requires it to still answer False.
+        run: bash tests/mcp-registration-readback.test.sh
+
       - name: the Google connector's API set derives from one manifest
         # The set of Google APIs an operator must enable existed in SIX places before
         # AI-126 -- connector.json's --permissions, SETUP.md's prose, the setup doc's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 >
 > A changelog that only lists *what changed* pushes comprehension-debt onto the operator — they'd have to read a skill's source to know what it does for their day. So every entry leads with a **"What you can now do"** section: the new capabilities in **plain language, with a concrete example**, phrased as things the operator can *do* now — not a component inventory. Keep the full component list too (for the record), but lead with the practical read, and flag the load-bearing behavioral changes worth an actual read. `/aios:update` surfaces this section to the operator after applying an entry, so their own Claude session tells them what the new version unlocks. **The rule:** *translate every shipped change into a capability the operator can use — or it isn't really shipped to them, just to the repo.*
 
-## 2026-09-11 — Google in one command, a refused login that says so, and Close of Day back at the end
+## 2026-09-11 — Google connects by asking, a refused login that says so, and Close of Day back at the end
 
 `hash: 61e7d9c · 398e526 · 0a2e3db · 236e899` · [#122](https://github.com/The-AIOS/aios/pull/122) · [#123](https://github.com/The-AIOS/aios/pull/123)
 
@@ -76,31 +76,27 @@
 
 **Action required:** none — `/aios:update` lands it. If you added your own `USER.md` override for this, retire it once this lands (check: your `### /today` section names `freshness-probe.sh` from `hooks/custom/`). If a check has said `unreachable` on mornings when your network was fine, run `bash ~/aios/hooks/freshness-probe.sh` — it names the repo that is refusing you.
 
-### Google Workspace connects with one command
+### Google Workspace connects by asking, not by running scripts
 
-**What you can now do.** Run `bash mcps/google-workspace-mcp/connect.sh`. It creates your Google Cloud project and enables every API the connector needs in a single call, then prints the steps Google publishes no API for — as links that land on the exact page for *your* project. Afterwards, `connect.sh --finish --project-id <id> --client <downloaded.json>` installs the credential and prints the `claude mcp add` line with the permission list already filled in. `--verify` re-checks the APIs later; `--dry-run` changes nothing; `--print-apis` shows just the list.
+**What you can now do.** Say *"connect my Google Workspace"*, or run `/aios:mcps-setup` and pick it. Your session creates the Cloud project, enables every API the connector needs, hands you only the two or three console pages Google publishes no API for, and once you say you are done it validates the credential you downloaded and registers the server. **Your part is about six clicks and one download — no terminal commands.**
 
-It also checks the two things that used to fail *much* later: that the client you downloaded is a **Desktop** type (a Web client fails with `redirect_uri_mismatch`) and that it belongs to the project whose APIs were enabled (using one from another project is what `403 org_internal` means). Both now stop the run and name the fix.
+It also catches the two mistakes that used to fail *much* later: a client downloaded as **Web application** instead of Desktop (`redirect_uri_mismatch`) and one belonging to a different project (`403 org_internal`). Both now stop the setup and name the fix.
 
-The API list is **derived** from the `--permissions` list in `mcps/google-workspace-mcp/connector.json` — the same manifest that registers the server. It used to be written out separately in five other places, and those had drifted apart: one sent you to enable a Chat API nothing requests, another omitted Gmail, contacts and forms entirely. That mismatch is the worst failure in this setup because it fails late and blames the wrong thing — consent succeeds, the tool appears, and the first call returns `403 SERVICE_DISABLED`, which reads like an auth problem. It can no longer be expressed.
+**If you do not have `gcloud`, you find out before anything happens.** The preflight runs first and says plainly that nothing was created, so you are never left half-configured. It names the install command for your actual platform — on a Mac with Homebrew, the one-liner — and offers the by-hand console path as a real alternative. Same for not being signed in.
+
+**The API list is derived, not written down.** It comes from the `--permissions` list in `mcps/google-workspace-mcp/connector.json`, the same manifest that registers the server. It had been restated in six other places and they disagreed: one sent you to enable a Chat API nothing requests, another omitted Gmail, contacts and forms entirely. That mismatch is the worst failure here because it fails late and blames the wrong thing — consent succeeds, the tool appears, and the first call returns `403 SERVICE_DISABLED`, which reads like an auth problem. It can no longer be expressed.
 
 **No credential ships in the repo, deliberately.** A shared OAuth client carries a hard cap of **100 grants for the life of the project, unresettable** — it would work for a while and then fail for everyone after that, with nothing in the repo able to explain why. Your own project also avoids your Workspace admin's third-party app gate, since an internal app is trusted by default.
 
-**Action required:** none if Google already works for you — nothing about your existing setup changes. Setting it up for the first time, or redoing it: run `connect.sh` instead of the console walkthrough. It needs `gcloud` for the automated half; without `gcloud` it says so and stops, and `mcps/google-workspace-mcp/personal-account-setup.md` still carries the full manual path plus the one trap no script can remove — on a consumer `@gmail.com` account, an app left in *Testing* expires its refresh token every 7 days.
+**Action required:** none if Google already works for you — nothing about your existing setup changes. Setting it up for the first time, or redoing it: ask your session rather than following the old console walkthrough. `mcps/google-workspace-mcp/personal-account-setup.md` still has the full manual path for anyone who wants it, plus the one trap no script can remove — on a consumer `@gmail.com` account, an app left in *Testing* expires its refresh token every 7 days.
 
-### You should not have been running those Google scripts yourself
+### A check that said your Google connector was not registered, on machines where it was
 
-**What you can now do.** Say *"connect my Google Workspace"*, or run `/aios:mcps-setup` and pick it. Your session creates the Cloud project, enables the APIs, hands you only the two or three console pages Google exposes no API for, and once you say you are done it validates the credential you downloaded and registers the server. **Your part is about six clicks and one download — no terminal commands.**
+**What you can now do.** Trust the answer. `/aios:mcps-setup` verifies a registration by reading `~/.claude.json` back — because `claude mcp add` prints success even when nothing was written — and that read-back looked only at the top-level `mcpServers`. But `claude mcp add` **defaults to local, per-directory scope**, so a normal registration lands under `projects["<your directory>"]`. On a live vault with the connector running and all nine services present, the check answered *not registered*.
 
-This morning's version shipped the tooling and pointed *you* at it: run a script, click through the console, then run a second script with a project id you had to copy and a path into `~/Downloads` you had to get right, then run a third printed command. One command from the framework's point of view; three from yours.
+Acting on that answer is worse than ignoring it: it invites a second registration, and two of them drift independently — which is exactly how one copy grew Gmail and the other did not, with nothing reporting the difference. It now reads both scopes and names where it found each, so being registered twice is surfaced rather than hidden.
 
-Two changes make the session the one holding the tooling. `connect.sh --finish` now needs **no arguments** — it reads the project id the connect run recorded and finds the newest `client_secret_*.json` itself, and because it already refuses a wrong-type or wrong-project client, guessing the file is safe rather than risky. And the connect run prints one stable `AIOS_PROJECT_ID=` line, so a session driving it reads that instead of parsing prose written for a human.
-
-`/aios:mcps-setup` was the worst offender and is rewritten: it had been telling sessions to *"ask user to run"* a `uvx` command with a hand-typed permission list — which had drifted to six services while the connector requested nine, so following it produced a server that started cleanly and then returned `403` on Gmail at the first call. It now drives the tooling and never types a permission list; `connector.json` is the only place that list lives.
-
-**If you don't have `gcloud`, you find out before anything happens** — the preflight runs first, including under `--dry-run`, and says plainly that nothing was created so you are not left half-configured. It names the install command for your actual platform (on a Mac with Homebrew, the one-liner) and offers the by-hand console path as a real alternative. Same for not being logged in.
-
-**Action required:** none, and nothing about a working setup changes. If you have been putting off connecting Google because the instructions read like a build script, this is the version to ask your session about.
+**Action required:** none. If you want to know where yours lives, ask your session to run the check in `/aios:mcps-setup` — and if it reports two, keep one.
 
 ### On macOS, `git` was probably never the thing blocking you
 

--- a/plugins/aios/commands/mcps-setup.md
+++ b/plugins/aios/commands/mcps-setup.md
@@ -215,7 +215,23 @@ Creates a dedicated Slack app. Messages post AS THE BOT, not as the user. Requir
 3. **The operator clicks and downloads.** Irreducible — no API exists for any of it.
 4. **On "done", you run** `bash ~/aios/mcps/google-workspace-mcp/connect.sh --finish`. Both of its arguments default: the project id from the connect run, the client from the newest `client_secret_*.json` in `~/Downloads`. It refuses a Web-type client or one belonging to a different project — so if the operator created the wrong thing you find out **here**, with the fix named, instead of weeks later as `redirect_uri_mismatch` or `403 org_internal`.
 5. **You register it** with the `claude mcp add` line `--finish` prints. It is generated from the manifest, so it carries the current permission list by construction — use it verbatim rather than composing one.
-   - **`claude mcp add` writes `~/.claude.json`, which a sandboxed tool call cannot touch — and it prints success anyway.** Run it un-sandboxed, then **verify by reading the file back**, not by trusting the exit code: `python3 -c "import json,os;print('google-workspace' in json.load(open(os.path.expanduser('~/.claude.json'))).get('mcpServers',{}))"`. A registration that silently did not land looks identical to one that did.
+   - **`claude mcp add` writes `~/.claude.json`, which a sandboxed tool call cannot touch — and it prints success anyway.** Run it un-sandboxed, then **verify by reading the file back**, not by trusting the exit code — a registration that silently did not land looks identical to one that did.
+
+     **Read BOTH scopes, and understand why: `claude mcp add` defaults to *local* (per-directory) scope**, so the entry normally lands under `projects["<cwd>"].mcpServers`, **not** the top-level `mcpServers`. A check that reads only the top level reports `NOT REGISTERED` on a perfectly working install — measured on a live vault whose connector was running at the time — and a session acting on that answer would re-register something that already worked.
+
+     ```bash
+     python3 - <<'PY' google-workspace
+     import json, os, sys
+     cfg = json.load(open(os.path.expanduser("~/.claude.json")))
+     name = sys.argv[1]
+     at = ["user"] if name in cfg.get("mcpServers", {}) else []
+     at += [p for p, v in cfg.get("projects", {}).items()
+            if isinstance(v, dict) and name in v.get("mcpServers", {})]
+     print(f"{name}: {' + '.join(at) if at else 'NOT REGISTERED'}")
+     PY
+     ```
+
+     Registered in more than one place is worth reporting rather than celebrating: two registrations drift independently (this is how one grew Gmail and the other did not), so tell the operator and let them pick which to keep.
 6. **Tell them to restart the session**, and that the first Google tool call opens a browser once for consent. MCP tools register at session start, so it is not callable until then.
 
 **The operator's total: one `y`, about six clicks, one download, one "done". No terminal commands.** If you find yourself about to type a `bash` line into the chat for them to run, you have taken a step that belongs to you.

--- a/tests/mcp-registration-readback.test.sh
+++ b/tests/mcp-registration-readback.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# The documented "did the registration land?" check must read BOTH scopes
+#
+# `claude mcp add` writes ~/.claude.json and prints success even when a
+# sandboxed call wrote nothing, so /aios:mcps-setup tells sessions to verify by
+# reading the file back. The first version of that read-back looked only at the
+# top-level `mcpServers` -- and `claude mcp add` DEFAULTS to local (per-directory)
+# scope, so a normal registration lands under projects["<cwd>"].mcpServers.
+#
+# Measured on a live vault: the connector was running, all nine services
+# present, and the documented check printed False. A session acting on that
+# would re-register something that already worked -- and the repo's own docs
+# warn that two registrations drift independently, which is how one grew Gmail
+# and the other did not. So the wrong check does not merely fail to confirm; it
+# actively pushes toward the failure it was meant to detect.
+#
+# This suite EXTRACTS the snippet from the command file and runs it against
+# fixtures. It does not restate the logic: a guard that reimplements what it
+# checks is only testing its own copy, and would have passed against the
+# broken original.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; return 0; }
+
+DOC="plugins/aios/commands/mcps-setup.md"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+[ -f "$DOC" ] || { printf '  FAIL  %s missing\n' "$DOC"; exit 1; }
+
+echo "── 1. the snippet is extractable from the doc ──"
+# Pull the python heredoc body that follows the read-back instruction.
+python3 - "$DOC" "$TMP/snippet.py" <<'PY'
+import re, sys
+text = open(sys.argv[1], encoding="utf-8").read()
+# the fenced bash block containing a `python3 - <<'PY'` heredoc
+m = re.search(r"```bash\n\s*python3 - <<'PY'[^\n]*\n(.*?)\n\s*PY\n\s*```", text, re.S)
+if not m:
+    sys.exit("could not find the read-back snippet in the doc")
+body = "\n".join(l[5:] if l.startswith("     ") else l for l in m.group(1).split("\n"))
+open(sys.argv[2], "w").write(body)
+PY
+if [ -s "$TMP/snippet.py" ]; then
+  ok "extracted $(grep -c . "$TMP/snippet.py") lines of the documented check"
+else
+  no "could not extract the snippet — this suite cannot test what is shipped"
+  printf '\n%d passed · %d failed\n' "$PASS" "$FAIL"; exit 1
+fi
+
+# Run the extracted snippet against a fixture HOME.
+runsnip(){ HOME="$1" python3 "$TMP/snippet.py" "${2:-google-workspace}" 2>&1; }
+
+mkfix(){ # $1 = dir · stdin = the .claude.json content
+  mkdir -p "$1"; cat > "$1/.claude.json"
+}
+
+echo "── 2. a PROJECT-scoped registration is found (the default scope) ──"
+mkfix "$TMP/proj" <<'J'
+{"mcpServers":{"railway":{}},
+ "projects":{"/Users/someone/aios":{"mcpServers":{"google-workspace":{"args":["--permissions","drive:full"]}}}}}
+J
+OUT="$(runsnip "$TMP/proj")"
+if printf '%s' "$OUT" | grep -q 'NOT REGISTERED'; then
+  no "project-scoped registration reported as NOT REGISTERED" \
+     "this is the live-vault defect: the connector works and the check says it does not
+        got: $OUT"
+elif printf '%s' "$OUT" | grep -q '/Users/someone/aios'; then
+  ok "found it, and named the project it belongs to"
+else
+  no "unexpected output for a project-scoped registration" "$OUT"
+fi
+
+echo "── 3. a USER-scoped registration is still found ──"
+mkfix "$TMP/user" <<'J'
+{"mcpServers":{"google-workspace":{"args":["--permissions","drive:full"]}},"projects":{}}
+J
+OUT="$(runsnip "$TMP/user")"
+printf '%s' "$OUT" | grep -q 'user' \
+  && ok "user scope reported" || no "user-scoped registration missed" "$OUT"
+
+echo "── 4. genuinely absent reads as absent ──"
+mkfix "$TMP/none" <<'J'
+{"mcpServers":{"railway":{}},"projects":{"/Users/someone/aios":{"mcpServers":{"slack":{}}}}}
+J
+OUT="$(runsnip "$TMP/none")"
+printf '%s' "$OUT" | grep -q 'NOT REGISTERED' \
+  && ok "absent → NOT REGISTERED (the check can still say no)" \
+  || no "an absent server was reported as present — the check cannot fail" "$OUT"
+
+echo "── 5. BOTH scopes at once is surfaced, not hidden ──"
+# Two registrations drift independently; the docs already record one growing
+# Gmail while the other did not. Reporting only the first hides that.
+mkfix "$TMP/both" <<'J'
+{"mcpServers":{"google-workspace":{}},
+ "projects":{"/Users/someone/aios":{"mcpServers":{"google-workspace":{}}}}}
+J
+OUT="$(runsnip "$TMP/both")"
+{ printf '%s' "$OUT" | grep -q 'user' && printf '%s' "$OUT" | grep -q '/Users/someone/aios'; } \
+  && ok "both registrations named in one answer" \
+  || no "a duplicate registration was not fully reported" "$OUT
+        two registrations drift independently; the operator must be told there are two"
+
+echo "── 6. CONTROL — the ORIGINAL broken check must fail this suite ──"
+# Without this, a future simplification back to top-level-only would pass
+# whatever the suite happens to assert. Replay the exact shipped one-liner.
+cat > "$TMP/broken.py" <<'PY'
+import json, os, sys
+print('google-workspace' in json.load(open(os.path.expanduser('~/.claude.json'))).get('mcpServers', {}))
+PY
+OUT="$(HOME="$TMP/proj" python3 "$TMP/broken.py" 2>&1)"
+if [ "$OUT" = "False" ]; then
+  ok "control: the original check answers False on a working project-scoped install"
+else
+  no "control: the original broken check did NOT reproduce" \
+     "got '$OUT' — if this stops being wrong, re-derive why this suite exists"
+fi
+
+echo "── 7. the doc states WHY both scopes matter ──"
+# A correct snippet with no explanation gets "simplified" back by the next reader.
+grep -qiE 'defaults to \*?local\*?|per-directory' "$DOC" \
+  && ok "the doc names local/per-directory as the default scope" \
+  || no "the doc does not say why the top level is the wrong place to look" \
+        "without the reason, the next reader shortens it back"
+grep -qiE 'NOT REGISTERED on a perfectly working|reports .*on a perfectly working install' "$DOC" \
+  && ok "the doc records the observed failure" \
+  || no "the doc does not record that this was measured on a live install"
+
+printf '\n%d passed · %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Found by running the action items of the entry merged an hour ago (#124) against a live vault — the honest version of dogfooding, since the check I shipped reported the wrong answer on the first machine it met.

## The defect

`/aios:mcps-setup` tells sessions to verify a registration by reading `~/.claude.json` back, because `claude mcp add` prints success even when a sandboxed call wrote nothing. The snippet was:

```python
print('google-workspace' in json.load(open(os.path.expanduser('~/.claude.json'))).get('mcpServers', {}))
```

It reads only the **top-level** `mcpServers`. But `claude mcp add` **defaults to local, per-directory scope** — which this repo's own `SETUP.md` and the MCP README both already say, in as many words — so a normal registration lands under `projects["<cwd>"].mcpServers`.

Measured on a live vault: connector running, all nine services present, and the documented check printing `False`.

## Why that is worse than a check that merely fails to confirm

Acting on that answer invites a **second** registration — and the same docs record that two registrations drift independently: *"one grew Gmail, the other didn't, and neither surface said so."* So the wrong check pushed a session toward the exact failure it existed to detect.

It now reads both scopes and names where it found each, so registered-twice is surfaced rather than hidden behind a boolean:

```
google-workspace: /Users/someone/aios
google-workspace: user + /Users/someone/aios      ← both, reported, not celebrated
google-workspace: NOT REGISTERED
```

## Tests — `tests/mcp-registration-readback.test.sh` (8)

**It extracts the snippet from the command file and runs it against fixtures.** That framing is the point: a guard that reimplements the logic would have passed against the broken original, since the bug was in the shipped text, not in anyone's understanding of it. Extract-never-restate, applied to a doc.

Its **control replays the original one-liner** and requires it to still answer `False` on a working project-scoped install — so a future "simplification" back to top-level-only fails the build rather than passing whatever the suite happens to assert. It also asserts the doc still *explains* why both scopes matter, because a correct snippet with no reason attached gets shortened back by the next reader.

## Also in here: the day's two Google changelog sections are merged

The budget guard firing at **1552 words** (limit 1500) is what prompted looking, and the right cut was not trimming both. The two sections described **one capability**, the second superseding the first — *"run these scripts"* then *"no, your session does it"* — and nobody syncing now lived through the intermediate state. Merged into the end state: **1193 words**.

The entry title changed with it (`Google in one command` → `Google connects by asking`), since "one command" was the framing that turned out to be wrong from the operator's chair.

49/49 suites green, bash 3.2 verified.