### PR TITLE
feat(star): the ask waits until the operator has actually used AIOS

### DIFF
--- a/hooks/aios-star-check
+++ b/hooks/aios-star-check
@@ -18,6 +18,17 @@
 #   declined   the operator already said no                 → say nothing, ever
 #   unknown    the check could not be completed             → say nothing (FAIL CLOSED)
 #
+# TENURE: the ask waits until the operator has actually used the thing. A star is a
+# public endorsement, and the ask's own copy says the count is what someone checks
+# before trusting an unknown repo — so asking on day one is asking a person to vouch
+# for something they have not used yet. That is the difference between a request and a
+# solicitation, and it is the same argument that already keeps the ask off a no-op sync
+# ("already up to date — by the way, star us" is asking to be paid for nothing).
+# Enforced HERE rather than per-caller, because the idea already existed in exactly one
+# caller: Glass asked after N successful sessions while /aios:update asked at the end of
+# the first applied sync, which on a fresh install is minutes after install. One rule in
+# the shared check is what makes the three callers agree.
+#
 # FAIL CLOSED IS THE LOAD-BEARING RULE. No network, no `gh`, no auth, a rate-limit, a
 # missing tracker — every one of them yields `unknown`, and `unknown` must never produce a
 # prompt. Nagging someone who already starred tells them the software doesn't notice what
@@ -35,6 +46,7 @@ set -u
 
 CONFIG_TRACKER="${AIOS_TRACKER:-$HOME/aios/.aios-update}"
 API_BASE="user/starred"
+MIN_TENURE_DAYS="${AIOS_STAR_MIN_DAYS:-7}"
 
 # ── The repo allowlist is FIXED and every entry is verified public ────────────────────
 # GET /user/starred/{repo} returns 404 for "not starred" AND for "private or nonexistent",
@@ -143,6 +155,35 @@ decline_state() {
   return 1
 }
 
+# ── Tenure: how long has this operator actually had AIOS? ─────────────────────────────
+# Derived from the FIRST COMMIT OF THE TRACKER ITSELF, and the choice matters three ways.
+#
+# (1) No new field, and no write. This function runs on the verdict path, whose documented
+#     contract one line above is "this never prompts and never writes". A `first-seen=`
+#     field would have been simpler to read and would have broken that, and would also
+#     have had nothing to say about every vault that already exists.
+# (2) `.aios-update` is NOT in canonical and is not gitignored, so it cannot carry the
+#     framework's history — it is written by the operator's own first `/aios:update`, and
+#     its first commit is therefore theirs by construction. The repo's first commit would
+#     NOT be safe: a vault started by cloning the framework inherits months of history and
+#     would read as tenured on day one.
+# (3) It travels with the vault, so a second machine inherits the real tenure instead of
+#     restarting the clock — the same reason the decline record lives in this file.
+#
+# %ct (committer date as a unix timestamp) plus `date +%s` avoids date PARSING entirely,
+# which is what makes this portable: GNU `date -d` and BSD `date -j -f` disagree, and this
+# runs on macOS, Linux and Git Bash on Windows.
+tenure_days() {
+  local repo first now
+  command -v git >/dev/null 2>&1 || { echo unknown; return; }
+  repo=$(dirname "$CONFIG_TRACKER")
+  first=$(git -C "$repo" log --reverse --format=%ct -- "$(basename "$CONFIG_TRACKER")" 2>/dev/null | head -1)
+  case "$first" in ''|*[!0-9]*) echo unknown; return ;; esac
+  now=$(date +%s 2>/dev/null)
+  case "$now" in ''|*[!0-9]*) echo unknown; return ;; esac
+  echo $(( (now - first) / 86400 ))
+}
+
 record_decline() {
   if [ ! -f "$CONFIG_TRACKER" ]; then
     echo "aios-star-check: no tracker at $CONFIG_TRACKER — nothing recorded" >&2
@@ -207,6 +248,12 @@ fi
 decline_state; case $? in
   0) finish declined "" "decline on file in .aios-update" ;;
   2) finish unknown  "" "tracker unreadable at $CONFIG_TRACKER — a prior decline would be invisible" ;;
+esac
+TENURE=$(tenure_days)
+case "$TENURE" in
+  unknown) finish unknown "" "cannot date this vault's first sync — tenure unverifiable" ;;
+  *) [ "$TENURE" -lt "$MIN_TENURE_DAYS" ] &&
+       finish unknown "" "vault is ${TENURE}d old — the ask waits for ${MIN_TENURE_DAYS}d of use" ;;
 esac
 command -v gh >/dev/null 2>&1      || finish unknown "" "gh not installed"
 gh auth status >/dev/null 2>&1     || finish unknown "" "gh not authenticated"

--- a/plugins/aios/commands/update.md
+++ b/plugins/aios/commands/update.md
@@ -667,6 +667,8 @@ CRLF-normalize when comparing file *contents* (`tr -d '\r'`) per the § Backup-o
 
 **Runs ONLY when this sync actually applied something.** If zero Tier-1 files changed and the reconcile was clean, skip this step entirely and say nothing. *"Already up to date — by the way, star us"* is asking to be paid for nothing, and it is the difference between a request and a nag.
 
+**Runs ONLY once the operator has actually used AIOS.** The check itself withholds the verdict until the vault is at least 7 days old (`AIOS_STAR_MIN_DAYS`, dated from the tracker's first commit). Nothing to do here — it is enforced inside `hooks/aios-star-check` so all three callers agree — but it is why a fresh install never sees this step. Asking on day one asks someone to vouch publicly for software they have not used, which is the same objection as asking on a no-op sync.
+
 **Runs ONLY when a human is in the loop.** `/aios:update` auto-fires from `/today` and `/close-day`, and those run in scheduled routines with nobody present. A prompt nobody sees cannot be answered, and **silence must never read as yes.** If this run was auto-fired, or you are executing in a routine / cron / bridge context, skip the step and set `AIOS_STAR_ASK=never` so the check itself agrees with you.
 
 ```bash


### PR DESCRIPTION
## What was reported

An operator on a fresh install:

> *"En una nueva instalación me apareció un mensaje para dar estrella al repositorio de GitHub, lo cual me pareció raro que sea en el primer to-do. Lo dejaría correr quizás una semana."*

Setup runs `/aios:update` → the sync applies something → Step 6.9 fires → they're asked to publicly endorse software they've had for ten minutes.

## Why the timing is wrong, in the file's own terms

The ask's copy is the argument against its timing:

> *"The star count is the first thing someone checks before trusting an unknown repo enough to install it."*

Asking on day one asks a person to vouch for something **they have not used yet**. That is the same objection this file already makes about firing on a no-op sync, where *"already up to date — by the way, star us"* is called **"asking to be paid for nothing"**. Day-zero is the same transaction with a different empty hand.

## The idea was already here — in exactly one caller

The header documents three callers:

> *"/aios:update calls it at the end of an APPLIED sync; the App calls it from its what's-new surface; **Glass calls it after N successful sessions**."*

Glass had a tenure condition. The shared check had none. So the three callers did not agree, and the one without a gate is the one a new operator meets first.

This puts the rule **in the check**, which is what the file's own doctrine asks for:

> *"ONE implementation, THREE callers… do not duplicate this one. Shell out to it."*

Default **7 days**, overridable with `AIOS_STAR_MIN_DAYS` — which is also what makes it testable.

## Tenure is derived, not stored

The source is the load-bearing choice: **the first commit of `.aios-update` itself.**

- **No new field, and no write.** This runs on the verdict path, whose contract one line above is *"this never prompts and never writes"*. A `first-seen=` field would have broken that — and would have had nothing to say about any vault that already exists, so every current operator would have restarted a 7-day clock from a field that didn't exist yesterday.
- **`.aios-update` is not in canonical and is not gitignored**, so it cannot carry the framework's history. It's written by the operator's own first `/aios:update`, so its first commit is theirs by construction.
  **The repo's first commit would NOT be safe:** a vault started by cloning the framework inherits months of history and reads as tenured on day one — which is the exact failure being fixed.
- **It travels with the vault**, so a second machine inherits real tenure instead of restarting the clock. Same reasoning the decline record already uses.

`%ct` (committer date as a unix timestamp) plus `date +%s` avoids date *parsing* entirely — GNU `date -d` and BSD `date -j -f` disagree, and this runs on macOS, Linux and Git Bash on Windows.

## Ordering and failure modes

**Tenure is checked after the decline record.** An operator who already said no reads `declined`, not `unknown` — a decline is terminal at any age.

**Unverifiable tenure yields `unknown`**, consistent with the existing fail-closed rule: no `git`, a tracker outside a repo, an unparseable timestamp — all say nothing rather than guess.

## Verification

Run against the real hook, 8 cases:

| case | result |
|---|---|
| syntax | `bash -n` clean |
| real vault (87d, min 7) | passes the gate → reaches the API → `starred` |
| **control** (min 999) | withheld: *"vault is 87d old — the ask waits for 999d of use"* |
| **fresh install (0d, min 7)** | **withheld — the reported case** |
| tracker outside git | `unknown`, fail closed |
| `eval "$(...)"` contract | intact; the apostrophe in *"vault's"* still correctly shell-quoted |
| prior decline at 0d tenure | `declined`, not `unknown` — order preserved |
| `--json` | still valid JSON |

The control (a threshold nothing can satisfy) is there because a gate that silently never fires and a gate that silently always fires produce the same green output. Without it, "no ask appeared" isn't evidence of anything.

Nothing was starred or declined during testing — the verdict path doesn't write, and `--star` / `--decline` were never invoked.

## Notes

- No `CHANGELOG.md` entry — the convention is one consolidated dated entry per day keyed to a merge hash, which I can't know pre-merge. Happy to add one if you'd like it in the PR.
- The 7-day default is a guess at the right number, not a measured one. It came from the operator's *"quizás una semana"*. If you'd rather it were 14, or session-count rather than days, the knob is already there and I'll change the default to whatever you name.
