### PR TITLE
fix(pipeline-executor): retired sources stay off, and read every calendar

### DIFF
--- a/USER.md
+++ b/USER.md
@@ -83,7 +83,12 @@ ssh my-server "osascript -e 'tell application \"Terminal\" to do script \"cd ~/a
 
 *Primary:*
 - *Google email: `you@company.com`*
-- *Google Calendar — via Google Workspace MCP*
+- *Google Calendar — via Google Workspace MCP. Every calendar the account can read is
+  merged, deduplicated by `iCalUID`, and non-primary events are tagged with their source.*
+- *Calendars to skip: `Formula 1, Holidays in Spain`*
+  > Optional. Comma-separated. Matched case-insensitively against a calendar's display name
+  > OR its id. Holiday and birthday feeds are excluded automatically — this is for the rest
+  > (sports, subscriptions, anything that is a feed rather than a commitment).*
 - *Google Tasks — via Google Workspace MCP*
 - *Google Tasks list: `your-list-id`*
 

--- a/hooks/pipeline-executor.py
+++ b/hooks/pipeline-executor.py
@@ -213,6 +213,7 @@ def parse_sources():
         "slack_channels_monitor": [],
         "slack_channels_skip": [],
         "slack_recap_enabled": False,
+        "calendars_skip": [],
     }
     if not SOURCES_PATH.exists():
         # Loud on stderr, not only in the log. Running on defaults means every calendar,
@@ -296,6 +297,13 @@ def parse_sources():
         if "Close-day recap:" in line and "enabled" in line.lower():
             config["slack_recap_enabled"] = True
 
+        # Calendars the operator does not want in the daily plan (entertainment
+        # feeds, subscriptions). Matched case-insensitively against the calendar's
+        # display name OR its id, so either is a valid way to name one.
+        m = re.match(r'- \*\*Calendars to skip:\*\* (.+)', line)
+        if m:
+            config["calendars_skip"] = [c.strip() for c in m.group(1).split(",") if c.strip()]
+
     return config
 
 
@@ -355,35 +363,128 @@ def _save_refreshed_token(creds, creds_path):
             creds_path.write_text(json.dumps(current, indent=2))
 
 
-def google_calendar_events(creds_path, email, time_min, time_max, detailed=False):
-    """Fetch calendar events using Google Calendar API."""
+# Calendars that are feeds, not commitments. Holiday and birthday calendars are
+# auto-subscribed by Google and would pad every daily plan with all-day noise.
+_CALENDAR_FEED_SUFFIXES = (
+    "#holiday@group.v.calendar.google.com",
+    "#contacts@group.v.calendar.google.com",
+)
+
+
+def _calendar_ids(service, skip=()):
+    """Every calendar the account can read, primary first, feeds excluded.
+
+    Reading only `primary` was the original behaviour and it is silently lossy:
+    an account can carry many calendars (venture, role, personal), and work that
+    lives on any of them is invisible to the daily plan. Invisible-but-real is
+    the worst failure mode a planner can have — it does not look like an error,
+    it looks like a free afternoon.
+    """
+    skip_lower = {s.lower() for s in skip}
+    ids, primary = [], None
+    page_token = None
+    while True:
+        resp = service.calendarList().list(pageToken=page_token, maxResults=250).execute()
+        for cal in resp.get("items", []):
+            cal_id = cal.get("id", "")
+            if not cal_id or cal_id.endswith(_CALENDAR_FEED_SUFFIXES):
+                continue
+            name = cal.get("summaryOverride") or cal.get("summary") or cal_id
+            if name.lower() in skip_lower or cal_id.lower() in skip_lower:
+                continue
+            entry = (cal_id, name)
+            if cal.get("primary"):
+                primary = entry
+            else:
+                ids.append(entry)
+        page_token = resp.get("nextPageToken")
+        if not page_token:
+            break
+    return ([primary] if primary else []) + ids
+
+
+def _event_key(event):
+    """Identity of an event ACROSS calendars, for de-duplication.
+
+    `iCalUID` is the cross-calendar identity: the same meeting seen from the
+    organiser's calendar and from an invitee's calendar carries one iCalUID but
+    two different `id`s — so keying on `id` would double-count every shared
+    meeting, which is exactly what merging calendars makes possible. With
+    `singleEvents=True` each recurring instance gets its own iCalUID, so
+    distinct occurrences still stay distinct.
+
+    The start time is folded in as a guard, and the (summary, start) fallback
+    covers events that arrive without an iCalUID at all.
+    """
+    start = event.get("start", {})
+    when = start.get("dateTime") or start.get("date") or ""
+    uid = event.get("iCalUID")
+    return ("uid", uid, when) if uid else ("fallback", event.get("summary", ""), when)
+
+
+def google_calendar_events(creds_path, email, time_min, time_max, detailed=False, skip=()):
+    """Fetch events from EVERY calendar on the account, merged and de-duplicated."""
     from googleapiclient.discovery import build
 
     creds = _load_google_creds(creds_path)
     service = build("calendar", "v3", credentials=creds, cache_discovery=False)
-    result = service.events().list(
-        calendarId="primary",
-        timeMin=time_min,
-        timeMax=time_max,
-        singleEvents=True,
-        orderBy="startTime",
-        maxResults=50,
-    ).execute()
 
-    events = result.get("items", [])
+    seen = {}
+    order = []
+    for cal_id, cal_name in _calendar_ids(service, skip):
+        try:
+            result = service.events().list(
+                calendarId=cal_id,
+                timeMin=time_min,
+                timeMax=time_max,
+                singleEvents=True,
+                orderBy="startTime",
+                maxResults=50,
+            ).execute()
+        except Exception as exc:
+            # One unreadable calendar must not take the whole day's plan with it.
+            order.append((("~error", cal_id), f"- ⚠️ calendar '{cal_name}' could not be read: {exc}"))
+            continue
+
+        for event in result.get("items", []):
+            key = _event_key(event)
+            if key in seen:
+                continue
+            seen[key] = True
+            order.append((key, (cal_id, cal_name, event)))
+
     lines = []
-    for e in events:
+    rendered = []
+    for key, payload in order:
+        if key[0] == "~error":
+            lines.append(payload)
+            continue
+        rendered.append(payload)
+
+    # Chronological across all calendars. All-day events sort ahead of timed ones
+    # because they are the day's context ("Home", travel), not appointments in it.
+    def _sort_key(item):
+        start = item[2].get("start", {})
+        if "date" in start:
+            return (start["date"], 0, "")
+        when = start.get("dateTime", "")
+        return (when[:10], 1, when)
+
+    for cal_id, cal_name, e in sorted(rendered, key=_sort_key):
         start = e.get("start", {})
         end = e.get("end", {})
         summary = e.get("summary", "(no title)")
+        # Name the calendar for anything off the primary, so a Bloom commitment
+        # is not mistaken for a personal block (and vice versa).
+        origin = "" if cal_id == email or cal_id == "primary" else f"  _[{cal_name}]_"
         if "date" in start:
-            lines.append(f"- All day — {summary}")
+            lines.append(f"- All day — {summary}{origin}")
         else:
             s = start.get("dateTime", "")[:16].split("T")
             en = end.get("dateTime", "")[:16].split("T")
             s_time = s[1] if len(s) > 1 else ""
             e_time = en[1] if len(en) > 1 else ""
-            lines.append(f"- {s_time} – {e_time} — {summary}")
+            lines.append(f"- {s_time} – {e_time} — {summary}{origin}")
 
         if detailed:
             desc = e.get("description", "")
@@ -629,18 +730,20 @@ def run_pipeline(command_name):
             futures["calendar_primary"] = pool.submit(
                 google_calendar_events, creds_primary,
                 sources["google_email_primary"], time_min, time_max,
-                detailed=is_close_day
+                detailed=is_close_day, skip=sources["calendars_skip"]
             )
             # close-day also needs next 7 days for calendar cross-check
             if is_close_day:
                 futures["calendar_next_week"] = pool.submit(
                     google_calendar_events, creds_primary,
-                    sources["google_email_primary"], time_min, time_max_week
+                    sources["google_email_primary"], time_min, time_max_week,
+                    skip=sources["calendars_skip"]
                 )
         if "calendar-personal" in sources["configured"] and creds_personal and creds_personal.exists():
             futures["calendar_personal"] = pool.submit(
                 google_calendar_events, creds_personal,
-                sources["google_email_personal"], time_min, time_max
+                sources["google_email_personal"], time_min, time_max,
+                skip=sources["calendars_skip"]
             )
         if "tasks" in sources["configured"] and sources["google_tasks_list"] and creds_primary and creds_primary.exists():
             futures["tasks"] = pool.submit(

--- a/hooks/pipeline-executor.py
+++ b/hooks/pipeline-executor.py
@@ -112,6 +112,11 @@ _NEGATION_MARKERS = (
     "no conectada", "no conectado", "not connected",
     "desactivado", "desactivada", "disabled", "deshabilitado",
     "a propósito", "por decisión", "on purpose", "deliberately", "by choice",
+    # Retired-state wording. A source that was REMOVED reads differently from one
+    # that was never set up, and none of the words above appear in that phrasing --
+    # so "Google Tasks - removed (operator decision)" scanned as an ENABLED source.
+    "eliminado", "eliminada", "removed", "retirado", "retirada", "dado de baja",
+    "fuera del sistema", "no lo uso", "no lo utilizo", "ya no",
 )
 
 

--- a/tests/source-detector.test.sh
+++ b/tests/source-detector.test.sh
@@ -31,7 +31,7 @@ printf 'USER.md source detector\n'
 probe(){ # $1 = USER.md content, $2 = keyword  →  prints ON | off
 python3 - "$EXEC" "$1" "$2" <<'PY'
 import re, sys
-src = open(sys.argv[1]).read()
+src = open(sys.argv[1], encoding='utf-8').read()   # explicit: the executor is UTF-8; the Windows default codec is not
 ns = {}
 exec(re.search(r'_NEGATION_MARKERS = \((?:.|\n)*?\)\n', src).group(0), ns)
 import re as _re
@@ -123,6 +123,30 @@ if [ -f "$ROOT/USER.md" ]; then
 else
   ok "8. skipped — no USER.md at repo root"
 fi
+
+# ---------------------------------------------------------------------------
+# TEST 9 - a source described as REMOVED stays off.
+#          Distinct from tests 3/4: those negate "never set up" ("no se usa",
+#          "not used, on purpose"). This is the OTHER half - a source that WAS
+#          set up and was later retired. An operator writes that in the past
+#          tense, and none of the never-set-up markers appear in that sentence,
+#          so the line read as naming an ACTIVE source and switched it back on.
+#          Writing the removal down is what re-enabled it.
+# ---------------------------------------------------------------------------
+have "$(probe '- Google Tasks - removed (operator decision: no lo utilizo)' 'Google Tasks')"  "off" "9. retired source stays off (removed)"
+have "$(probe '- Google Tasks - eliminado, fuera del sistema' 'Google Tasks')"                "off" "9. retired source stays off (eliminado)"
+have "$(probe '- Google Tasks - retirado el 2026-08-28, ya no se sincroniza' 'Google Tasks')" "off" "9. retired source stays off (retirado)"
+
+# ---------------------------------------------------------------------------
+# TEST 10 - counterpart guard: a retirement on one line must not silence an
+#           unrelated LIVE source on another. Test 7's no-over-correction
+#           rule, applied to the new markers.
+# ---------------------------------------------------------------------------
+REMOVED_MIX="- Google Tasks - removed, no lo utilizo
+- Slack - daily recap at 09:00
+"
+have "$(probe "$REMOVED_MIX" 'Google Tasks')" "off" "10. retired source off ..."
+have "$(probe "$REMOVED_MIX" 'Slack')"        "ON"  "10. ... while a live source beside it stays on"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Two independent defects in `hooks/pipeline-executor.py`, both found on a live vault. Both fail **silently** — neither raises, logs, or renders an empty state — which is why they survived months.

Three commits, reviewable separately.

---

### 1. A retired source switches itself back on

`_NEGATION_MARKERS` covers "never set up yet" (`no configurada`, `disabled`, `on purpose`). It has no word for a source that **was** set up and was later **removed** — and that is how an operator writes it down:

> `- Google Tasks — removed (operator decision: "no lo utilizo")`

None of the existing markers appear in that sentence, so the line scanned as naming an **active** source. The failure is self-inflicting: *documenting the removal is what re-enables it.* It surfaces later as a spurious `credentials missing` for a source nobody wanted, inside a ritual nobody suspects.

### 2. Only `primary` was ever read

`google_calendar_events` requested `calendarId="primary"` and stopped there. An account routinely carries several calendars — a venture, a role, a shared family one — and work on any of them was invisible to the daily plan.

**A missing calendar does not look like an error. It looks like a free afternoon.** Measured on one live account: **eight of nine calendars unread for months**, with daily plans describing mornings as open that were not.

Now: enumerate `calendarList`, merge by start time, deduplicate by `iCalUID` so one meeting seen from two calendars counts once, and tag non-primary events with their source. Holiday and contact feeds are excluded by suffix (auto-subscribed by Google, all-day noise). Anything else goes in `USER.md` as `Calendars to skip`, matched case-insensitively against display name **or** id — documented in the same commit. A calendar that cannot be read gets its own line rather than being dropped, so a permissions problem stays visible.

---

### Tests

`tests/source-detector.test.sh` gains cases 9 and 10. They are canaries in this file's own sense — **all four fail against the code as it stands on `main`** and pass after the fix, so they measure the change rather than decorate it. Case 10 is the counterpart guard: a retirement on one line must not silence a live source on another (test 7's no-over-correction rule, applied to the new markers).

**One unrelated fix was required to get there.** `probe()` read the executor with the platform default codec. On Windows that is cp1252, so the suite raised `UnicodeDecodeError` on the executor's own accented comments — **0 passed, 11 failed, before any change**. It reads as broken tests rather than an unrunnable harness, and it means a Windows contributor cannot verify their own work in this file. Same class the repo already guards with `tests/lint-windows-stdout.py`.

```
before this PR, on Windows:   0 passed, 11 failed
after the encoding fix:      12 passed,  4 failed   <- the 4 new cases, correctly failing
after the executor fix:      16 passed,  0 failed
```

`tests/pipeline-executor-config.test.sh` and `tests/pipeline-executor-status.test.sh` also pass.

---

### Notes for review

- Built from a **clean clone of upstream**, not from a downstream vault — the branch carries exactly these 3 commits and touches no `vault/` path.
- The two defects are independent; commit 1 and commit 3 can be taken separately if you would rather split them. Commit 2 carries the tests for the first plus the harness fix both need.
- No behaviour change for a single-calendar account beyond the extra `calendarList` call.